### PR TITLE
feat: UZF state-tier foundation — makeStore(extra), ThunkExtra, Result/Exception, typed hooks

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@kro/app",
   "version": "0.1.0",
   "private": true,
-  "description": "Shared feature + design tier (UI that is not app-shell specific). Skeleton — populated by the design-system and feature children of #1.",
+  "description": "Shared UZF state + feature tier: makeStore(extra), the ThunkExtra service manifest, typed hooks, Services and feature slices. May import react; never next.",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
@@ -13,12 +13,27 @@
     "src"
   ],
   "scripts": {
+    "lint": "node ./scripts/check-uzf-boundaries.mjs",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kro/core": "workspace:*"
+    "@kro/core": "workspace:*",
+    "@reduxjs/toolkit": "^2.12.0",
+    "react-redux": "^9.3.0"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5"
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "jsdom": "^30.0.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -30,7 +30,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "jsdom": "^30.0.1",
+    "jsdom": "^26.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5",

--- a/packages/app/scripts/check-uzf-boundaries.mjs
+++ b/packages/app/scripts/check-uzf-boundaries.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * UZF boundary check for `packages/app` — wired as `@kro/app`'s `lint` task.
+ *
+ * The react-uzf-v1 rules that matter most are the ones a component can break by
+ * accident: importing a Service, building a second store, or calling
+ * `useSelector` straight from `react-redux`. Review catches those inconsistently,
+ * so they are checked here instead — this is what turns "components cannot fetch"
+ * from a convention into a structural fact (issue #5, acceptance criterion 2).
+ *
+ * Checked:
+ *   RC-22  `configureStore(` appears only in `src/library/store.ts`.
+ *   RC-10  `react-redux` is imported only by `src/library/hooks.ts` and
+ *          `src/library/StoreProvider.tsx`.
+ *   RC-6   a Service module is imported only by `src/library/store.ts` (which
+ *          assembles `ThunkExtra`) and by test/mock files.
+ *   RC-3   `fetch(` is called only inside `src/services/**`.
+ *   RC-1   `createSlice(` appears only in a `…Feature.ts` file.
+ *   RC-3   `createAsyncThunk(` appears only in a `…Producer.ts` file.
+ *   RC-5   `createSelector(` appears only in a `…Selectors.ts` file.
+ *   RC-50  nothing in this package imports `next/*` — the shell owns Next.js.
+ *
+ * Run: `node packages/app/scripts/check-uzf-boundaries.mjs` (cwd may be anywhere).
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const sourceRoot = join(packageRoot, 'src')
+
+const STORE_FILE = 'src/library/store.ts'
+const REACT_REDUX_FILES = ['src/library/hooks.ts', 'src/library/StoreProvider.tsx']
+
+const IMPORT_RE = /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]/g
+const BARE_IMPORT_RE = /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g
+
+function collectFiles(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...collectFiles(full))
+    else if (/\.(ts|tsx)$/.test(full)) out.push(full)
+  }
+  return out
+}
+
+/** Strips line and block comments so commented-out code is not flagged. */
+function stripComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+}
+
+function importsOf(source) {
+  const found = []
+  for (const re of [IMPORT_RE, BARE_IMPORT_RE]) {
+    re.lastIndex = 0
+    let match
+    while ((match = re.exec(source)) !== null) found.push(match[1])
+  }
+  return found
+}
+
+const isTestFile = (where) =>
+  /(\.test\.tsx?|\.stories\.tsx?|\.mocks\.ts)$/.test(where) || where.includes('/__tests__/')
+const isServiceFile = (where) => where.startsWith('src/services/')
+const isServiceSpecifier = (specifier) =>
+  /(^|\/)services\//.test(specifier) || /Service(\.js)?$/.test(specifier)
+
+const violations = []
+
+for (const file of collectFiles(sourceRoot)) {
+  const where = relative(packageRoot, file).split('\\').join('/')
+  const source = stripComments(readFileSync(file, 'utf8'))
+
+  if (where !== STORE_FILE && /\bconfigureStore\s*\(/.test(source)) {
+    violations.push(`${where}: calls configureStore() — the only store path is makeStore() (RC-22)`)
+  }
+
+  if (!isServiceFile(where) && /(?<![.\w$])fetch\s*\(/.test(source)) {
+    violations.push(`${where}: calls fetch() outside services/ — go through a Service (RC-3)`)
+  }
+
+  if (/\bcreateSlice\s*\(/.test(source) && !where.endsWith('Feature.ts')) {
+    violations.push(`${where}: calls createSlice() outside a …Feature.ts file (RC-1)`)
+  }
+
+  if (/\bcreateAsyncThunk\s*\(/.test(source) && !where.endsWith('Producer.ts')) {
+    violations.push(`${where}: calls createAsyncThunk() outside a …Producer.ts file (RC-3)`)
+  }
+
+  if (/\bcreateSelector\s*\(/.test(source) && !where.endsWith('Selectors.ts')) {
+    violations.push(`${where}: calls createSelector() outside a …Selectors.ts file (RC-5)`)
+  }
+
+  for (const specifier of importsOf(source)) {
+    if (specifier === 'next' || specifier.startsWith('next/')) {
+      violations.push(`${where}: imports '${specifier}' — Next.js belongs to apps/web (RC-50)`)
+    }
+
+    if (specifier === 'react-redux' && !REACT_REDUX_FILES.includes(where)) {
+      violations.push(
+        `${where}: imports 'react-redux' — use useAppSelector/useAppDispatch from library/hooks (RC-10)`,
+      )
+    }
+
+    if (
+      isServiceSpecifier(specifier) &&
+      where !== STORE_FILE &&
+      !isServiceFile(where) &&
+      !isTestFile(where)
+    ) {
+      violations.push(
+        `${where}: imports the Service module '${specifier}' — Services reach a Producer only through ThunkExtra (RC-6, RC-21)`,
+      )
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('@kro/app breaks a UZF boundary:\n')
+  for (const violation of violations) console.error(`  - ${violation}`)
+  console.error(
+    '\nSee the react-uzf-v1 handbook rules cited above; every one of these has a sanctioned route.',
+  )
+  process.exit(1)
+}
+
+console.log('@kro/app holds its UZF boundaries: one store, one hooks surface, services behind DI.')

--- a/packages/app/src/features/greeting/GreetingFeature.ts
+++ b/packages/app/src/features/greeting/GreetingFeature.ts
@@ -1,0 +1,104 @@
+/**
+ * SCAFFOLDING — the demo feature slice (`RC-1`, `RC-2`, `RC-20`, `RC-24`, `RC-36`).
+ *
+ * One `createSlice` per feature, its `State` co-located, its name registered
+ * exactly once in `library/store.ts`'s reducer map. This file is the reference a
+ * feature child (#16+) copies; delete it once real slices exist.
+ *
+ * Two shapes carry the whole convention:
+ *
+ * **State (`RC-24`).** The lifecycle is ONE discriminated field, `load`, not a
+ * pair of `isLoading` + `exception` fields — the pair can represent "loaded and
+ * failed at once", which `UZF-9` forbids by construction.
+ *
+ * **Events (`RC-2`).** Reducer keys name intent or source, never mechanism:
+ * `onViewLoaded`, `userDidTapRetry`, `childDetailDelegatedClose`. There is no
+ * `fetchGreeting` action — the effect is a Producer thunk whose type string is
+ * itself an event name, and whose three lifecycle phases are the one completion
+ * event (`UZF-3`), never a hand-minted succeeded/failed pair.
+ */
+import { type Greeting, type GreetingException, unknownException } from '@kro/core'
+import { type PayloadAction, createSlice } from '@reduxjs/toolkit'
+import { fetchGreetingThunk } from './GreetingProducer'
+import {
+  withException,
+  withGreetingLoaded,
+  withLoadingStarted,
+  withRecipientStamped,
+} from './GreetingShifters'
+
+export type GreetingLoadState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'loaded'; readonly greeting: Greeting }
+  | { readonly kind: 'failed'; readonly exception: GreetingException }
+
+export interface GreetingState {
+  readonly recipient: string | null
+  readonly load: GreetingLoadState
+  readonly detailOpen: boolean
+}
+
+export const initialGreetingState: GreetingState = {
+  recipient: null,
+  load: { kind: 'idle' },
+  detailOpen: false,
+}
+
+export const greetingSlice = createSlice({
+  name: 'greeting',
+  initialState: initialGreetingState,
+  reducers: {
+    /** Lifecycle signal: the surface mounted and knows who it is greeting. */
+    onViewLoaded(state, action: PayloadAction<{ recipient: string }>) {
+      Object.assign(state, withRecipientStamped(state, action.payload.recipient))
+    },
+
+    /** User intent: the retry affordance a recoverable exception offered. */
+    userDidTapRetry(state) {
+      Object.assign(state, withLoadingStarted(state))
+    },
+
+    /** User intent, single primitive field — the one mutation allowed to skip a Shifter. */
+    userDidTapGreeting(state) {
+      state.detailOpen = true
+    },
+
+    /** A child fragment talking back rather than reaching into this slice itself. */
+    childDetailDelegatedClose(state) {
+      state.detailOpen = false
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchGreetingThunk.pending, (state) => {
+        Object.assign(state, withLoadingStarted(state))
+      })
+      .addCase(fetchGreetingThunk.fulfilled, (state, action) => {
+        // The payload is a `Result`, never a bare success value (`RC-26`).
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(state, withGreetingLoaded(state, result.value))
+        } else {
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      // Defensive only: the payload creator catches everything, so a domain
+      // failure never reaches here. It routes into the same exception Shifter as
+      // the `.fulfilled` false branch — never a second state shape (`RC-26`).
+      .addCase(fetchGreetingThunk.rejected, (state, action) => {
+        // Cancellation is the only silent exit (`UZF-14`): an aborted dispatch —
+        // the surface unmounted, or a newer recipient superseded this one — is
+        // not a failure and must never paint an exception.
+        if (action.meta.aborted) return
+
+        Object.assign(
+          state,
+          withException(state, unknownException(action.error.message ?? 'Unknown error')),
+        )
+      })
+  },
+})
+
+export const { childDetailDelegatedClose, onViewLoaded, userDidTapGreeting, userDidTapRetry } =
+  greetingSlice.actions

--- a/packages/app/src/features/greeting/GreetingMocks.ts
+++ b/packages/app/src/features/greeting/GreetingMocks.ts
@@ -1,0 +1,57 @@
+/**
+ * SCAFFOLDING — canned `GreetingState` variants (`UZF-18`).
+ *
+ * Stories, render tests and selector tests all read from here; a feature's
+ * `State` is never constructed inline in a test or a story, so the set of states
+ * the product claims to support is enumerable in one file.
+ */
+import { GreetingExceptions } from '@kro/core'
+import { greetingMocks } from '@kro/core/mocks'
+import { type GreetingState, initialGreetingState } from './GreetingFeature'
+
+export const greetingStateMocks = {
+  /** Nothing has been asked for yet — first paint before the surface mounts. */
+  idle: initialGreetingState,
+
+  /** A request is in flight for a named recipient. */
+  loading: {
+    recipient: 'ada',
+    load: { kind: 'loading' },
+    detailOpen: false,
+  } satisfies GreetingState,
+
+  /** The ordinary success state. */
+  loaded: {
+    recipient: 'ada',
+    load: { kind: 'loaded', greeting: greetingMocks.typical },
+    detailOpen: false,
+  } satisfies GreetingState,
+
+  /** Loaded, with the detail surface open on top of it. */
+  loadedWithDetailOpen: {
+    recipient: 'ada',
+    load: { kind: 'loaded', greeting: greetingMocks.typical },
+    detailOpen: true,
+  } satisfies GreetingState,
+
+  /** Loaded, but the greeting has no body — the empty-copy fallback path. */
+  loadedEmptyMessage: {
+    recipient: 'nobody',
+    load: { kind: 'loaded', greeting: greetingMocks.emptyMessage },
+    detailOpen: false,
+  } satisfies GreetingState,
+
+  /** Recoverable failure — the surface offers a retry. */
+  failedOffline: {
+    recipient: 'ada',
+    load: { kind: 'failed', exception: GreetingExceptions.offline() },
+    detailOpen: false,
+  } satisfies GreetingState,
+
+  /** Unrecoverable failure — retrying the same request cannot help. */
+  failedNotFound: {
+    recipient: 'nobody-at-all',
+    load: { kind: 'failed', exception: GreetingExceptions.notFound() },
+    detailOpen: false,
+  } satisfies GreetingState,
+}

--- a/packages/app/src/features/greeting/GreetingProducer.ts
+++ b/packages/app/src/features/greeting/GreetingProducer.ts
@@ -1,0 +1,33 @@
+/**
+ * SCAFFOLDING — the demo feature's Producer (`RC-3`, `RC-6`, `RC-7`, `RC-25`).
+ *
+ * Everything a feature child needs to copy is in the twelve lines below:
+ *   - the thunk type string is an **event name**, `"<feature>/on<Thing>Completed"`,
+ *     never a mechanism like `"greeting/fetchGreeting"` (`RC-2`);
+ *   - the Service arrives through `extra`, never a module-level import (`RC-6`);
+ *   - `thunkAPI.signal` is passed into the Service so an aborted dispatch exits
+ *     silently instead of surfacing as an exception (`RC-3` rule 4);
+ *   - the payload creator **never throws** — every failure is caught, translated
+ *     by the Mapper, and resolved as `err(...)` (`RC-7`), which is what makes the
+ *     slice's `.rejected` arm a defensive fallback rather than the error path.
+ */
+import { GreetingExceptions, GreetingMapper, err, ok } from '@kro/core'
+import type { Greeting, GreetingException, Result } from '@kro/core'
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import type { ThunkExtra } from '../../library/store'
+
+export const fetchGreetingThunk = createAsyncThunk<
+  Result<Greeting, GreetingException>,
+  { recipient: string },
+  { extra: ThunkExtra }
+>('greeting/onGreetingFetchCompleted', async ({ recipient }, { extra, signal }) => {
+  try {
+    const response = await extra.greetingService.fetchGreeting(recipient, { signal })
+    const greeting = GreetingMapper.toDomain(response)
+    return greeting
+      ? ok(greeting)
+      : err(GreetingExceptions.malformed(`greeting for "${recipient}" failed to map`))
+  } catch (error) {
+    return err(GreetingMapper.toException(error))
+  }
+})

--- a/packages/app/src/features/greeting/GreetingSelectors.ts
+++ b/packages/app/src/features/greeting/GreetingSelectors.ts
@@ -1,0 +1,48 @@
+/**
+ * SCAFFOLDING — the demo feature's Selectors (`RC-5`).
+ *
+ * Every derived read lives here, built with `createSelector` and taking
+ * `RootState` as its only input. A `useAppSelector((s) => …)` callback may do a
+ * plain O(1) field read and nothing more: the moment it combines two fields,
+ * formats a string, or filters a list, that logic is a Selector that escaped its
+ * file. Cross-slice reads compose here from other Selectors — never by importing
+ * another slice's state shape (`RC-20`).
+ */
+import { greetingExceptionCopy } from '@kro/core'
+import { createSelector } from '@reduxjs/toolkit'
+import type { RootState } from '../../library/store'
+
+const selectGreetingSlice = (state: RootState) => state.greeting
+
+export const selectGreeting = createSelector([selectGreetingSlice], (slice) =>
+  slice.load.kind === 'loaded' ? slice.load.greeting : null,
+)
+
+export const selectIsGreetingLoading = createSelector(
+  [selectGreetingSlice],
+  (slice) => slice.load.kind === 'loading',
+)
+
+export const selectGreetingException = createSelector([selectGreetingSlice], (slice) =>
+  slice.load.kind === 'failed' ? slice.load.exception : null,
+)
+
+export const selectIsGreetingDetailOpen = createSelector(
+  [selectGreetingSlice],
+  (slice) => slice.detailOpen,
+)
+
+/**
+ * The one line the surface renders, whatever the lifecycle is doing. Failure copy
+ * comes from the platform-free `greetingExceptionCopy` switch, so the sentence a
+ * user reads is decided once, in the domain tier, and never assembled in a view.
+ */
+export const selectGreetingHeadline = createSelector(
+  [selectGreeting, selectGreetingException, selectIsGreetingLoading],
+  (greeting, exception, isLoading) => {
+    if (exception !== null) return greetingExceptionCopy(exception)
+    if (isLoading) return 'Fetching your greeting…'
+    if (greeting === null) return ''
+    return greeting.message.length > 0 ? greeting.message : `Hello, ${greeting.recipient}.`
+  },
+)

--- a/packages/app/src/features/greeting/GreetingShifters.ts
+++ b/packages/app/src/features/greeting/GreetingShifters.ts
@@ -1,0 +1,31 @@
+/**
+ * SCAFFOLDING — the demo feature's Shifters (`RC-4`, `RC-19`).
+ *
+ * A Shifter is a pure `with…(state, args)` function returning a brand-new plain
+ * object. No I/O, no `Date.now()`, no `Math.random()`, no Service — if a shift
+ * needs the clock or an id, the reducer arm passes it in as an argument. Reducer
+ * arms apply them as `Object.assign(state, withThing(state, args))`, the only
+ * sanctioned multi-field mutation; a single primitive assignment may be written
+ * inline, and nothing else may.
+ */
+import type { Greeting, GreetingException } from '@kro/core'
+import type { GreetingState } from './GreetingFeature'
+
+/** One concern: a recipient was named, so the previous outcome is now stale. */
+export function withRecipientStamped(state: GreetingState, recipient: string): GreetingState {
+  return { ...state, recipient, load: { kind: 'loading' }, detailOpen: false }
+}
+
+/** One concern: a request is in flight, so any prior exception is cleared. */
+export function withLoadingStarted(state: GreetingState): GreetingState {
+  return { ...state, load: { kind: 'loading' } }
+}
+
+export function withGreetingLoaded(state: GreetingState, greeting: Greeting): GreetingState {
+  return { ...state, load: { kind: 'loaded', greeting } }
+}
+
+/** One concern: the load failed, so nothing can be showing its detail. */
+export function withException(state: GreetingState, exception: GreetingException): GreetingState {
+  return { ...state, load: { kind: 'failed', exception }, detailOpen: false }
+}

--- a/packages/app/src/features/greeting/__tests__/GreetingFeature.test.ts
+++ b/packages/app/src/features/greeting/__tests__/GreetingFeature.test.ts
@@ -1,0 +1,179 @@
+import type { GreetingResponse } from '@kro/core'
+import { greetingMocks } from '@kro/core/mocks'
+import { describe, expect, it, vi } from 'vitest'
+import { type ThunkExtra, makeStore, stubbedThunkExtra } from '../../../library/store'
+import type { GreetingService } from '../../../services/greeting/GreetingService'
+import {
+  childDetailDelegatedClose,
+  greetingSlice,
+  initialGreetingState,
+  onViewLoaded,
+  userDidTapGreeting,
+  userDidTapRetry,
+} from '../GreetingFeature'
+import { greetingStateMocks } from '../GreetingMocks'
+import { fetchGreetingThunk } from '../GreetingProducer'
+
+const reduce = greetingSlice.reducer
+
+/** A store wired to a service that behaves however the scenario needs (`RC-22`). */
+const storeWith = (fetchGreeting: GreetingService['fetchGreeting']) =>
+  makeStore({ greetingService: { fetchGreeting } } satisfies ThunkExtra)
+
+describe('onViewLoaded', () => {
+  it('stamps the recipient and starts loading on first mount', () => {
+    const next = reduce(initialGreetingState, onViewLoaded({ recipient: 'ada' }))
+
+    expect(next.recipient).toBe('ada')
+    expect(next.load.kind).toBe('loading')
+  })
+
+  it('replaces the previous recipient when the surface remounts for someone else', () => {
+    const next = reduce(greetingStateMocks.loaded, onViewLoaded({ recipient: 'grace' }))
+
+    expect(next.recipient).toBe('grace')
+    expect(next.load.kind).toBe('loading')
+  })
+
+  it('clears an error left over from the last recipient', () => {
+    const next = reduce(greetingStateMocks.failedOffline, onViewLoaded({ recipient: 'grace' }))
+
+    expect(next.load.kind).toBe('loading')
+  })
+})
+
+describe('userDidTapRetry', () => {
+  it('puts a failed surface back into loading — the user taps "try again"', () => {
+    expect(reduce(greetingStateMocks.failedOffline, userDidTapRetry()).load.kind).toBe('loading')
+  })
+
+  it('keeps the recipient so the retry asks for the same greeting', () => {
+    expect(reduce(greetingStateMocks.failedOffline, userDidTapRetry()).recipient).toBe('ada')
+  })
+
+  it('is harmless when a request is already in flight — a double tap changes nothing', () => {
+    expect(reduce(greetingStateMocks.loading, userDidTapRetry())).toEqual(
+      greetingStateMocks.loading,
+    )
+  })
+})
+
+describe('userDidTapGreeting', () => {
+  it('opens the detail on a loaded greeting', () => {
+    expect(reduce(greetingStateMocks.loaded, userDidTapGreeting()).detailOpen).toBe(true)
+  })
+
+  it('leaves the loaded greeting itself untouched — opening a detail loads nothing', () => {
+    const next = reduce(greetingStateMocks.loaded, userDidTapGreeting())
+
+    expect(next.load).toEqual(greetingStateMocks.loaded.load)
+  })
+
+  it('is idempotent — tapping an already-open detail keeps it open', () => {
+    expect(reduce(greetingStateMocks.loadedWithDetailOpen, userDidTapGreeting()).detailOpen).toBe(
+      true,
+    )
+  })
+})
+
+describe('childDetailDelegatedClose', () => {
+  it('closes the detail when the child asks to be dismissed', () => {
+    expect(
+      reduce(greetingStateMocks.loadedWithDetailOpen, childDetailDelegatedClose()).detailOpen,
+    ).toBe(false)
+  })
+
+  it('leaves the greeting loaded behind it', () => {
+    const next = reduce(greetingStateMocks.loadedWithDetailOpen, childDetailDelegatedClose())
+
+    expect(next.load.kind).toBe('loaded')
+  })
+
+  it('is a no-op when nothing was open — a stray delegate cannot corrupt state', () => {
+    expect(reduce(greetingStateMocks.loaded, childDetailDelegatedClose())).toEqual(
+      greetingStateMocks.loaded,
+    )
+  })
+})
+
+describe('the fetch lifecycle', () => {
+  it('shows loading while the request is in flight — the user waits', async () => {
+    let release: (value: GreetingResponse) => void = () => {}
+    const pending = new Promise<GreetingResponse>((resolve) => {
+      release = resolve
+    })
+    const store = storeWith(() => pending)
+
+    const effect = store.dispatch(fetchGreetingThunk({ recipient: 'ada' }))
+    expect(store.getState().greeting.load.kind).toBe('loading')
+
+    release({
+      id: 'greeting-1',
+      recipient: 'ada',
+      message: 'Good morning, Ada.',
+      signature: '— Kro',
+      issued_at: '2026-01-15T08:00:00.000Z',
+    })
+    await effect
+  })
+
+  it('lands the mapped greeting in state — the fixture-backed happy path', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    await store.dispatch(fetchGreetingThunk({ recipient: 'ada' }))
+
+    const { load } = store.getState().greeting
+    expect(load.kind).toBe('loaded')
+    if (load.kind === 'loaded') expect(load.greeting).toEqual(greetingMocks.typical)
+  })
+
+  it('surfaces an offline exception when the request never left the device (user on the subway)', async () => {
+    const store = storeWith(vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+
+    await store.dispatch(fetchGreetingThunk({ recipient: 'ada' }))
+
+    const { load } = store.getState().greeting
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') expect(load.exception.kind).toBe('offline')
+  })
+
+  it('surfaces a malformed exception when the payload cannot be mapped', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    await store.dispatch(fetchGreetingThunk({ recipient: 'malformed' }))
+
+    const { load } = store.getState().greeting
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') expect(load.exception.kind).toBe('malformed')
+  })
+
+  it('ignores an aborted request — cancellation is the only silent exit', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    const effect = store.dispatch(fetchGreetingThunk({ recipient: 'ada' }))
+    effect.abort('superseded by a newer recipient')
+    await effect
+
+    expect(store.getState().greeting.load.kind).toBe('loading')
+  })
+
+  it('degrades to a generic exception if the payload creator itself throws (defensive .rejected)', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    // The Producer never throws, so `.rejected` is reached here only by
+    // dispatching the lifecycle action directly — which is exactly the shape a
+    // serialization bug or a dispatch-level failure would take.
+    store.dispatch({
+      type: fetchGreetingThunk.rejected.type,
+      error: { message: 'dispatch exploded' },
+      meta: { aborted: false, condition: false, arg: { recipient: 'ada' }, requestId: 'r1' },
+    })
+
+    const { load } = store.getState().greeting
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') {
+      expect(load.exception.kind).toBe('unknown')
+      expect(load.exception.message).toBe('dispatch exploded')
+    }
+  })
+})

--- a/packages/app/src/features/greeting/__tests__/GreetingProducer.test.ts
+++ b/packages/app/src/features/greeting/__tests__/GreetingProducer.test.ts
@@ -1,0 +1,77 @@
+import { greetingMocks } from '@kro/core/mocks'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { type ThunkExtra, makeStore, stubbedThunkExtra } from '../../../library/store'
+import type { GreetingService } from '../../../services/greeting/GreetingService'
+import { fetchGreetingThunk } from '../GreetingProducer'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const storeWith = (fetchGreeting: GreetingService['fetchGreeting']) =>
+  makeStore({ greetingService: { fetchGreeting } } satisfies ThunkExtra)
+
+describe('fetchGreetingThunk', () => {
+  it('resolves ok with the mapped domain greeting — the fixture-backed happy path', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    const action = await store.dispatch(fetchGreetingThunk({ recipient: 'ada' }))
+
+    expect(action.payload).toEqual({ ok: true, value: greetingMocks.typical })
+  })
+
+  it('resolves err(notFound) rather than rejecting when the service 404s', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    const action = await store.dispatch(fetchGreetingThunk({ recipient: 'nobody-at-all' }))
+
+    expect(action.type).toBe('greeting/onGreetingFetchCompleted/fulfilled')
+    expect(action.payload).toEqual({ ok: false, error: expect.objectContaining({ kind: 'notFound' }) })
+  })
+
+  it('resolves err(offline) when the request never left the device', async () => {
+    const store = storeWith(vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+
+    const action = await store.dispatch(fetchGreetingThunk({ recipient: 'ada' }))
+
+    expect(action.payload).toEqual({ ok: false, error: expect.objectContaining({ kind: 'offline' }) })
+  })
+
+  it('resolves err(malformed) when the payload cannot become a domain greeting', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    const action = await store.dispatch(fetchGreetingThunk({ recipient: 'malformed' }))
+
+    expect(action.payload).toEqual({
+      ok: false,
+      error: expect.objectContaining({ kind: 'malformed' }),
+    })
+  })
+
+  it('hands the abort signal to the Service so an aborted dispatch cancels the request', async () => {
+    const fetchGreeting = vi.fn(async (_recipient: string, options?: { signal?: AbortSignal }) => {
+      expect(options?.signal).toBeInstanceOf(AbortSignal)
+      return {
+        id: 'greeting-1',
+        recipient: 'ada',
+        message: 'Good morning, Ada.',
+        signature: '— Kro',
+        issued_at: '2026-01-15T08:00:00.000Z',
+      }
+    })
+
+    await storeWith(fetchGreeting).dispatch(fetchGreetingThunk({ recipient: 'ada' }))
+
+    expect(fetchGreeting).toHaveBeenCalledTimes(1)
+  })
+
+  it('never reaches the network — every failure mode is a stubbed Service, not a mocked fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const store = makeStore(stubbedThunkExtra)
+
+    await store.dispatch(fetchGreetingThunk({ recipient: 'ada' }))
+    await store.dispatch(fetchGreetingThunk({ recipient: 'nobody-at-all' }))
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
+++ b/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
@@ -1,0 +1,99 @@
+import { greetingMocks } from '@kro/core/mocks'
+import { describe, expect, it } from 'vitest'
+import type { RootState } from '../../../library/store'
+import type { GreetingState } from '../GreetingFeature'
+import { greetingStateMocks } from '../GreetingMocks'
+import {
+  selectGreeting,
+  selectGreetingException,
+  selectGreetingHeadline,
+  selectIsGreetingDetailOpen,
+  selectIsGreetingLoading,
+} from '../GreetingSelectors'
+
+/** Selectors are exercised against a hand-built root state, never a live store. */
+const rootWith = (greeting: GreetingState): RootState => ({ greeting })
+
+describe('selectGreeting', () => {
+  it('returns the greeting once it has loaded', () => {
+    expect(selectGreeting(rootWith(greetingStateMocks.loaded))).toEqual(greetingMocks.typical)
+  })
+
+  it('returns null while the request is still in flight', () => {
+    expect(selectGreeting(rootWith(greetingStateMocks.loading))).toBeNull()
+  })
+
+  it('returns null on failure — a failed load never yields a half-built greeting', () => {
+    expect(selectGreeting(rootWith(greetingStateMocks.failedNotFound))).toBeNull()
+  })
+})
+
+describe('selectIsGreetingLoading', () => {
+  it('is true while the request is in flight — the spinner condition', () => {
+    expect(selectIsGreetingLoading(rootWith(greetingStateMocks.loading))).toBe(true)
+  })
+
+  it('is false before anything was asked for', () => {
+    expect(selectIsGreetingLoading(rootWith(greetingStateMocks.idle))).toBe(false)
+  })
+
+  it('is false once the load failed, so a spinner never sits on top of an error', () => {
+    expect(selectIsGreetingLoading(rootWith(greetingStateMocks.failedOffline))).toBe(false)
+  })
+})
+
+describe('selectGreetingException', () => {
+  it('surfaces the typed exception on failure — the user is offline', () => {
+    expect(selectGreetingException(rootWith(greetingStateMocks.failedOffline))?.kind).toBe('offline')
+  })
+
+  it('is null on the happy path', () => {
+    expect(selectGreetingException(rootWith(greetingStateMocks.loaded))).toBeNull()
+  })
+
+  it('is null while loading, so a retry affordance cannot flash mid-request', () => {
+    expect(selectGreetingException(rootWith(greetingStateMocks.loading))).toBeNull()
+  })
+})
+
+describe('selectIsGreetingDetailOpen', () => {
+  it('is true after the user opened the detail', () => {
+    expect(selectIsGreetingDetailOpen(rootWith(greetingStateMocks.loadedWithDetailOpen))).toBe(true)
+  })
+
+  it('is false on a freshly loaded greeting', () => {
+    expect(selectIsGreetingDetailOpen(rootWith(greetingStateMocks.loaded))).toBe(false)
+  })
+
+  it('is false before anything has loaded at all', () => {
+    expect(selectIsGreetingDetailOpen(rootWith(greetingStateMocks.idle))).toBe(false)
+  })
+})
+
+describe('selectGreetingHeadline', () => {
+  it('reads the greeting body once it has loaded', () => {
+    expect(selectGreetingHeadline(rootWith(greetingStateMocks.loaded))).toBe('Good morning, Ada.')
+  })
+
+  it('falls back to the recipient when the greeting arrived with an empty body', () => {
+    expect(selectGreetingHeadline(rootWith(greetingStateMocks.loadedEmptyMessage))).toBe(
+      'Hello, nobody.',
+    )
+  })
+
+  it('shows exception copy instead of the body when the load failed', () => {
+    expect(selectGreetingHeadline(rootWith(greetingStateMocks.failedNotFound))).toMatch(
+      /could not find/i,
+    )
+  })
+
+  it('announces the in-flight request rather than an empty line', () => {
+    expect(selectGreetingHeadline(rootWith(greetingStateMocks.loading))).toBe(
+      'Fetching your greeting…',
+    )
+  })
+
+  it('is empty before anything has been asked for', () => {
+    expect(selectGreetingHeadline(rootWith(greetingStateMocks.idle))).toBe('')
+  })
+})

--- a/packages/app/src/features/greeting/__tests__/GreetingShifters.test.ts
+++ b/packages/app/src/features/greeting/__tests__/GreetingShifters.test.ts
@@ -1,0 +1,105 @@
+import { GreetingExceptions } from '@kro/core'
+import { greetingMocks } from '@kro/core/mocks'
+import { describe, expect, it } from 'vitest'
+import { greetingStateMocks } from '../GreetingMocks'
+import {
+  withException,
+  withGreetingLoaded,
+  withLoadingStarted,
+  withRecipientStamped,
+} from '../GreetingShifters'
+
+describe('withRecipientStamped', () => {
+  it('names the recipient and starts loading — the surface just mounted', () => {
+    const next = withRecipientStamped(greetingStateMocks.idle, 'ada')
+
+    expect(next.recipient).toBe('ada')
+    expect(next.load.kind).toBe('loading')
+  })
+
+  it('drops a stale exception when a new recipient is named — the user typed a different name', () => {
+    const next = withRecipientStamped(greetingStateMocks.failedOffline, 'grace')
+
+    expect(next.load.kind).toBe('loading')
+    expect(next.recipient).toBe('grace')
+  })
+
+  it('closes a detail left open by the previous recipient rather than showing it over new data', () => {
+    const next = withRecipientStamped(greetingStateMocks.loadedWithDetailOpen, 'grace')
+
+    expect(next.detailOpen).toBe(false)
+  })
+
+  it('never mutates the state it was given — Shifters are pure', () => {
+    const before = greetingStateMocks.idle
+
+    withRecipientStamped(before, 'ada')
+
+    expect(before).toEqual(greetingStateMocks.idle)
+  })
+})
+
+describe('withLoadingStarted', () => {
+  it('moves an idle surface into loading — the first request goes out', () => {
+    expect(withLoadingStarted(greetingStateMocks.idle).load.kind).toBe('loading')
+  })
+
+  it('clears the exception when the user retries after an error', () => {
+    const next = withLoadingStarted(greetingStateMocks.failedOffline)
+
+    expect(next.load.kind).toBe('loading')
+  })
+
+  it('leaves the recipient and the detail flag alone — one concern per Shifter', () => {
+    const next = withLoadingStarted(greetingStateMocks.loadedWithDetailOpen)
+
+    expect(next.recipient).toBe('ada')
+    expect(next.detailOpen).toBe(true)
+  })
+
+  it('is a no-op in effect when a request is already in flight', () => {
+    expect(withLoadingStarted(greetingStateMocks.loading)).toEqual(greetingStateMocks.loading)
+  })
+})
+
+describe('withGreetingLoaded', () => {
+  it('carries the greeting into the loaded arm — the ordinary success', () => {
+    const next = withGreetingLoaded(greetingStateMocks.loading, greetingMocks.typical)
+
+    expect(next.load).toEqual({ kind: 'loaded', greeting: greetingMocks.typical })
+  })
+
+  it('replaces a previous greeting when a second load lands', () => {
+    const next = withGreetingLoaded(greetingStateMocks.loaded, greetingMocks.unicode)
+
+    if (next.load.kind !== 'loaded') throw new Error('expected the loaded arm')
+    expect(next.load.greeting.recipient).toBe('山田')
+  })
+
+  it('recovers from a failed state without a separate "clear the error" step', () => {
+    const next = withGreetingLoaded(greetingStateMocks.failedOffline, greetingMocks.typical)
+
+    expect(next.load.kind).toBe('loaded')
+  })
+})
+
+describe('withException', () => {
+  it('parks the typed exception in the failed arm — the request came back 404', () => {
+    const next = withException(greetingStateMocks.loading, GreetingExceptions.notFound())
+
+    if (next.load.kind !== 'failed') throw new Error('expected the failed arm')
+    expect(next.load.exception.kind).toBe('notFound')
+  })
+
+  it('closes an open detail — nothing can be shown on top of a failed load', () => {
+    const next = withException(greetingStateMocks.loadedWithDetailOpen, GreetingExceptions.offline())
+
+    expect(next.detailOpen).toBe(false)
+  })
+
+  it('keeps the recipient so a retry knows what to ask for again', () => {
+    const next = withException(greetingStateMocks.loading, GreetingExceptions.offline())
+
+    expect(next.recipient).toBe('ada')
+  })
+})

--- a/packages/app/src/features/greeting/__tests__/useGreeting.test.tsx
+++ b/packages/app/src/features/greeting/__tests__/useGreeting.test.tsx
@@ -1,0 +1,91 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { StoreProvider } from '../../../library/StoreProvider'
+import { type AppStore, type ThunkExtra, makeStore, stubbedThunkExtra } from '../../../library/store'
+import type { GreetingService } from '../../../services/greeting/GreetingService'
+import { useGreeting } from '../useGreeting'
+
+afterEach(cleanup)
+
+function wrapperFor(store: AppStore) {
+  return ({ children }: { children: ReactNode }) => (
+    <StoreProvider store={store}>{children}</StoreProvider>
+  )
+}
+
+const storeWith = (fetchGreeting: GreetingService['fetchGreeting']) =>
+  makeStore({ greetingService: { fetchGreeting } } satisfies ThunkExtra)
+
+describe('useGreeting', () => {
+  it('runs the whole loop on mount and exposes the greeting — a returning user opens the page', async () => {
+    const { result } = renderHook(() => useGreeting('ada'), {
+      wrapper: wrapperFor(makeStore(stubbedThunkExtra)),
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.headline).toBe('Good morning, Ada.')
+    expect(result.current.greeting?.recipient).toBe('ada')
+    expect(result.current.exception).toBeNull()
+  })
+
+  it('announces the request while it is in flight rather than rendering an empty surface', () => {
+    const { result } = renderHook(() => useGreeting('ada'), {
+      wrapper: wrapperFor(makeStore(stubbedThunkExtra)),
+    })
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.headline).toBe('Fetching your greeting…')
+  })
+
+  it('shows exception copy and offers a retry when the device is offline', async () => {
+    const store = storeWith(vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+
+    const { result } = renderHook(() => useGreeting('ada'), { wrapper: wrapperFor(store) })
+
+    await waitFor(() => expect(result.current.exception).not.toBeNull())
+    expect(result.current.headline).toMatch(/offline/i)
+    expect(result.current.canRetry).toBe(true)
+  })
+
+  it('withholds the retry affordance when retrying cannot help — the greeting does not exist', async () => {
+    const { result } = renderHook(() => useGreeting('nobody-at-all'), {
+      wrapper: wrapperFor(makeStore(stubbedThunkExtra)),
+    })
+
+    await waitFor(() => expect(result.current.exception?.kind).toBe('notFound'))
+    expect(result.current.canRetry).toBe(false)
+  })
+
+  it('asks the Service again when the user retries', async () => {
+    const fetchGreeting = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    const { result } = renderHook(() => useGreeting('ada'), { wrapper: wrapperFor(storeWith(fetchGreeting)) })
+
+    await waitFor(() => expect(result.current.canRetry).toBe(true))
+    await act(async () => {
+      result.current.onRetry()
+    })
+
+    expect(fetchGreeting).toHaveBeenCalledTimes(2)
+  })
+
+  it('opens and closes the detail through intent callbacks, never local component state', async () => {
+    const { result } = renderHook(() => useGreeting('ada'), {
+      wrapper: wrapperFor(makeStore(stubbedThunkExtra)),
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.detailOpen).toBe(false)
+
+    act(() => {
+      result.current.onTapGreeting()
+    })
+    expect(result.current.detailOpen).toBe(true)
+
+    act(() => {
+      result.current.onCloseDetail()
+    })
+    expect(result.current.detailOpen).toBe(false)
+  })
+})

--- a/packages/app/src/features/greeting/useGreeting.ts
+++ b/packages/app/src/features/greeting/useGreeting.ts
@@ -1,0 +1,83 @@
+/**
+ * SCAFFOLDING — the headless half of the demo feature's stateful wrapper
+ * (`UZF-4`, `RC-10`, `RC-15`).
+ *
+ * This is where the loop closes: the hook dispatches intent through the typed
+ * hooks, reads everything it renders through named Selectors, and hands the
+ * surface a plain view model plus callbacks. It holds **no** `useState` — the
+ * feature's state lives in the slice — and it never touches a Service: the mount
+ * effect dispatches a Producer thunk, which is the only sanctioned way an effect
+ * starts (`RC-3`).
+ *
+ * The Page / Fragment that renders this arrives with the design-system and shell
+ * children (#6, #13); until then the hook *is* the render contract, and its test
+ * is what proves the loop runs end to end.
+ */
+import type { Greeting, GreetingException } from '@kro/core'
+import { useCallback, useEffect } from 'react'
+import { useAppDispatch, useAppSelector } from '../../library/hooks'
+import { childDetailDelegatedClose, onViewLoaded, userDidTapGreeting, userDidTapRetry } from './GreetingFeature'
+import { fetchGreetingThunk } from './GreetingProducer'
+import {
+  selectGreeting,
+  selectGreetingException,
+  selectGreetingHeadline,
+  selectIsGreetingDetailOpen,
+  selectIsGreetingLoading,
+} from './GreetingSelectors'
+
+export interface GreetingViewModel {
+  readonly headline: string
+  readonly greeting: Greeting | null
+  readonly isLoading: boolean
+  readonly exception: GreetingException | null
+  readonly canRetry: boolean
+  readonly detailOpen: boolean
+  readonly onTapGreeting: () => void
+  readonly onCloseDetail: () => void
+  readonly onRetry: () => void
+}
+
+export function useGreeting(recipient: string): GreetingViewModel {
+  const dispatch = useAppDispatch()
+
+  const headline = useAppSelector(selectGreetingHeadline)
+  const greeting = useAppSelector(selectGreeting)
+  const isLoading = useAppSelector(selectIsGreetingLoading)
+  const exception = useAppSelector(selectGreetingException)
+  const detailOpen = useAppSelector(selectIsGreetingDetailOpen)
+
+  useEffect(() => {
+    dispatch(onViewLoaded({ recipient }))
+    const effect = dispatch(fetchGreetingThunk({ recipient }))
+
+    // Abort supersedes: a new recipient, or an unmount, cancels the in-flight
+    // request instead of letting a stale completion land in state.
+    return () => effect.abort()
+  }, [dispatch, recipient])
+
+  const onRetry = useCallback(() => {
+    dispatch(userDidTapRetry())
+    void dispatch(fetchGreetingThunk({ recipient }))
+  }, [dispatch, recipient])
+
+  const onTapGreeting = useCallback(() => {
+    dispatch(userDidTapGreeting())
+  }, [dispatch])
+
+  const onCloseDetail = useCallback(() => {
+    dispatch(childDetailDelegatedClose())
+  }, [dispatch])
+
+  return {
+    headline,
+    greeting,
+    isLoading,
+    exception,
+    canRetry: exception?.recoverable ?? false,
+    detailOpen,
+    onTapGreeting,
+    onCloseDetail,
+    onRetry,
+  }
+}

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -1,14 +1,51 @@
 /**
- * `@kro/app` — the shared feature + design tier.
+ * `@kro/app` — the shared UZF state + feature tier.
  *
- * Everything that is Kro UI but not Next.js app-shell plumbing lives here:
- * design system (tokens, glass), the component kit, and feature slices with
- * their Screens / Pages / Fragments.
+ * Layout:
+ *   `library/`   the store (`makeStore`, `ThunkExtra`), the typed hooks and the
+ *                `StoreProvider` — the whole Redux ↔ React seam (`RC-10`, `RC-21`,
+ *                `RC-22`).
+ *   `services/`  Service interfaces with their `live…` / `stubbed…` pair. NOT
+ *                exported from this barrel on purpose: a Service reaches a
+ *                Producer only through `ThunkExtra`, so no component can import
+ *                one (`RC-6`).
+ *   `features/`  one folder per feature — slice, Shifters, Selectors, Producer,
+ *                mocks and the headless hook (`RC-1`).
  *
- * This package is a deliberate skeleton at this point in the epic. It is
- * populated by the design-system foundation and the feature children of #1;
- * this restructure only establishes the workspace member, its `workspace:*`
- * edge to `@kro/core`, and its place in the Turborepo task graph.
+ * `apps/web` is a thin shell over this package: it builds the store once at its
+ * composition root, wraps the tree in `StoreProvider`, and renders. It owns no
+ * slice, no selector and no producer (`RC-62`).
  */
 
-export {}
+export { StoreProvider, type StoreProviderProps } from './library/StoreProvider'
+export { useAppDispatch, useAppSelector } from './library/hooks'
+export {
+  type AppDispatch,
+  type AppStore,
+  type RootState,
+  type ThunkExtra,
+  liveThunkExtra,
+  makeStore,
+  stubbedThunkExtra,
+} from './library/store'
+
+// SCAFFOLDING — the demo feature proving the loop. Feature children replace it.
+export {
+  type GreetingLoadState,
+  type GreetingState,
+  childDetailDelegatedClose,
+  greetingSlice,
+  initialGreetingState,
+  onViewLoaded,
+  userDidTapGreeting,
+  userDidTapRetry,
+} from './features/greeting/GreetingFeature'
+export { fetchGreetingThunk } from './features/greeting/GreetingProducer'
+export {
+  selectGreeting,
+  selectGreetingException,
+  selectGreetingHeadline,
+  selectIsGreetingDetailOpen,
+  selectIsGreetingLoading,
+} from './features/greeting/GreetingSelectors'
+export { type GreetingViewModel, useGreeting } from './features/greeting/useGreeting'

--- a/packages/app/src/library/StoreProvider.tsx
+++ b/packages/app/src/library/StoreProvider.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+/**
+ * The minimal store binding for a React tree.
+ *
+ * It takes an **instance**, it never builds one: the host decides when to call
+ * `makeStore(...)` and with which `ThunkExtra` (`RC-22`). `apps/web`'s root
+ * layout builds the live store once per browser session and hands it here; a
+ * test hands in `makeStore(stubbedThunkExtra)`; a story hands in a preview store.
+ *
+ * The `'use client'` directive is what lets a Next.js Server Component render
+ * this without the package importing anything from `next/*` (`RC-50`'s
+ * framework-blind boundary, held even though this package is app-tier).
+ */
+import type { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import type { AppStore } from './store'
+
+export interface StoreProviderProps {
+  readonly store: AppStore
+  readonly children: ReactNode
+}
+
+export function StoreProvider({ store, children }: StoreProviderProps) {
+  return <Provider store={store}>{children}</Provider>
+}

--- a/packages/app/src/library/__tests__/StoreProvider.test.tsx
+++ b/packages/app/src/library/__tests__/StoreProvider.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { onViewLoaded } from '../../features/greeting/GreetingFeature'
+import { StoreProvider } from '../StoreProvider'
+import { useAppSelector } from '../hooks'
+import { makeStore, stubbedThunkExtra } from '../store'
+
+afterEach(cleanup)
+
+function RecipientProbe() {
+  const recipient = useAppSelector((state) => state.greeting.recipient)
+  return <span data-testid="recipient">{recipient ?? 'nobody'}</span>
+}
+
+describe('StoreProvider', () => {
+  it('binds the tree to the store instance it was handed', () => {
+    const store = makeStore(stubbedThunkExtra)
+    store.dispatch(onViewLoaded({ recipient: 'ada' }))
+
+    render(
+      <StoreProvider store={store}>
+        <RecipientProbe />
+      </StoreProvider>,
+    )
+
+    expect(screen.getByTestId('recipient').textContent).toBe('ada')
+  })
+
+  it('never builds a store of its own — two trees, two stores, no shared state', () => {
+    const first = makeStore(stubbedThunkExtra)
+    const second = makeStore(stubbedThunkExtra)
+    first.dispatch(onViewLoaded({ recipient: 'ada' }))
+
+    render(
+      <div>
+        <StoreProvider store={first}>
+          <span data-testid="first">
+            <RecipientProbe />
+          </span>
+        </StoreProvider>
+        <StoreProvider store={second}>
+          <span data-testid="second">
+            <RecipientProbe />
+          </span>
+        </StoreProvider>
+      </div>,
+    )
+
+    expect(screen.getByTestId('first').textContent).toBe('ada')
+    expect(screen.getByTestId('second').textContent).toBe('nobody')
+  })
+
+  it('renders its children untouched — it is a binding, not a layout', () => {
+    render(
+      <StoreProvider store={makeStore(stubbedThunkExtra)}>
+        <h1>Kro</h1>
+        <p>Focus.</p>
+      </StoreProvider>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Kro' })).toBeDefined()
+    expect(screen.getByText('Focus.')).toBeDefined()
+  })
+})

--- a/packages/app/src/library/__tests__/hooks.test.tsx
+++ b/packages/app/src/library/__tests__/hooks.test.tsx
@@ -1,0 +1,93 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { onViewLoaded, userDidTapGreeting } from '../../features/greeting/GreetingFeature'
+import { fetchGreetingThunk } from '../../features/greeting/GreetingProducer'
+import {
+  selectGreetingHeadline,
+  selectIsGreetingDetailOpen,
+} from '../../features/greeting/GreetingSelectors'
+import { StoreProvider } from '../StoreProvider'
+import { useAppDispatch, useAppSelector } from '../hooks'
+import { type AppStore, makeStore, stubbedThunkExtra } from '../store'
+
+afterEach(cleanup)
+
+function wrapperFor(store: AppStore) {
+  return ({ children }: { children: ReactNode }) => (
+    <StoreProvider store={store}>{children}</StoreProvider>
+  )
+}
+
+describe('useAppSelector', () => {
+  it('reads through a named Selector — the only way a surface sees state', () => {
+    const store = makeStore(stubbedThunkExtra)
+    store.dispatch(onViewLoaded({ recipient: 'ada' }))
+
+    const { result } = renderHook(() => useAppSelector(selectGreetingHeadline), {
+      wrapper: wrapperFor(store),
+    })
+
+    expect(result.current).toBe('Fetching your greeting…')
+  })
+
+  it('re-renders the caller when the slice it reads changes — user opens the detail', () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    const { result } = renderHook(() => useAppSelector(selectIsGreetingDetailOpen), {
+      wrapper: wrapperFor(store),
+    })
+    expect(result.current).toBe(false)
+
+    act(() => {
+      store.dispatch(userDidTapGreeting())
+    })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('is bound to RootState, so a plain field read needs no annotation at the call site', () => {
+    const store = makeStore(stubbedThunkExtra)
+    store.dispatch(onViewLoaded({ recipient: 'grace' }))
+
+    const { result } = renderHook(() => useAppSelector((state) => state.greeting.recipient), {
+      wrapper: wrapperFor(store),
+    })
+
+    expect(result.current).toBe('grace')
+  })
+})
+
+describe('useAppDispatch', () => {
+  it('dispatches a synchronous event and the store reflects it immediately', () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    const { result } = renderHook(() => useAppDispatch(), { wrapper: wrapperFor(store) })
+    act(() => {
+      result.current(onViewLoaded({ recipient: 'ada' }))
+    })
+
+    expect(store.getState().greeting.recipient).toBe('ada')
+  })
+
+  it('dispatches a Producer thunk and awaits its completion — the typed thunk overload', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    const { result } = renderHook(() => useAppDispatch(), { wrapper: wrapperFor(store) })
+    await result.current(fetchGreetingThunk({ recipient: 'ada' }))
+
+    await waitFor(() => expect(store.getState().greeting.load.kind).toBe('loaded'))
+  })
+
+  it('returns an abortable effect handle for the in-flight request', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    const { result } = renderHook(() => useAppDispatch(), { wrapper: wrapperFor(store) })
+    const effect = result.current(fetchGreetingThunk({ recipient: 'ada' }))
+    effect.abort('superseded')
+    await effect
+
+    // Cancellation is the only silent exit: an aborted request paints nothing.
+    expect(store.getState().greeting.load.kind).not.toBe('failed')
+  })
+})

--- a/packages/app/src/library/__tests__/store.test.ts
+++ b/packages/app/src/library/__tests__/store.test.ts
@@ -1,0 +1,66 @@
+import { greetingMocks } from '@kro/core/mocks'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { greetingSlice, initialGreetingState } from '../../features/greeting/GreetingFeature'
+import { fetchGreetingThunk } from '../../features/greeting/GreetingProducer'
+import type { GreetingService } from '../../services/greeting/GreetingService'
+import { type ThunkExtra, makeStore, stubbedThunkExtra } from '../store'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('makeStore', () => {
+  it('builds a store from the stubbed manifest with every slice at its registered key', () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    expect(store.getState().greeting).toEqual(initialGreetingState)
+  })
+
+  it('hands the injected services to a Producer — the substitution seam tests depend on', async () => {
+    const fetchGreeting = vi.fn(async (_recipient: string, _options?: { signal?: AbortSignal }) => ({
+      id: 'greeting-1',
+      recipient: 'ada',
+      message: 'Good morning, Ada.',
+      signature: '— Kro',
+      issued_at: '2026-01-15T08:00:00.000Z',
+    }))
+    const extra: ThunkExtra = { greetingService: { fetchGreeting } satisfies GreetingService }
+
+    await makeStore(extra).dispatch(fetchGreetingThunk({ recipient: 'ada' }))
+
+    expect(fetchGreeting).toHaveBeenCalledTimes(1)
+    expect(fetchGreeting.mock.calls[0]?.[0]).toBe('ada')
+  })
+
+  it('returns an isolated store per call, so one suite cannot leak state into the next', () => {
+    const first = makeStore(stubbedThunkExtra)
+    const second = makeStore(stubbedThunkExtra)
+
+    first.dispatch(greetingSlice.actions.onViewLoaded({ recipient: 'ada' }))
+
+    expect(first.getState().greeting.recipient).toBe('ada')
+    expect(second.getState().greeting.recipient).toBeNull()
+  })
+
+  it('defaults to the live manifest when called with no argument — the shape apps/web uses', () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    const store = makeStore()
+
+    // Construction alone must never reach a Service: nothing is dispatched yet.
+    expect(store.getState().greeting).toEqual(initialGreetingState)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts a Date in state without a serializability complaint — domain models carry real dates', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = makeStore(stubbedThunkExtra)
+
+    await store.dispatch(fetchGreetingThunk({ recipient: 'ada' }))
+
+    const { load } = store.getState().greeting
+    expect(load.kind).toBe('loaded')
+    if (load.kind === 'loaded') expect(load.greeting.issuedAt).toEqual(greetingMocks.typical.issuedAt)
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/library/hooks.ts
+++ b/packages/app/src/library/hooks.ts
@@ -1,0 +1,16 @@
+/**
+ * The only Redux ↔ React binding surface in the app (`RC-10`).
+ *
+ * Every Page, Fragment, Adapter and headless hook imports these two. A raw
+ * `useSelector` / `useDispatch` from `react-redux` anywhere outside this file is
+ * a finding — `scripts/check-uzf-boundaries.mjs` fails the lint task on it.
+ *
+ * `react-redux@9`'s `.withTypes<…>()` replaces the older `TypedUseSelectorHook`
+ * annotation; it types the dispatch overloads for thunks as well, which the
+ * annotation form could not.
+ */
+import { useDispatch, useSelector } from 'react-redux'
+import type { AppDispatch, RootState } from './store'
+
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>()
+export const useAppSelector = useSelector.withTypes<RootState>()

--- a/packages/app/src/library/store.ts
+++ b/packages/app/src/library/store.ts
@@ -1,0 +1,66 @@
+/**
+ * The single store-construction path (`RC-22`) and the closed service manifest
+ * (`RC-21`).
+ *
+ * `configureStore` is called here and nowhere else — not in a test, not in a
+ * story, not in a route file. Production code calls `makeStore()` and gets the
+ * live bindings; a test calls `makeStore(stubbedThunkExtra)` and gets
+ * deterministic doubles through the exact same reducer map and middleware chain.
+ * That is why the factory exists instead of a module-level `export const store`:
+ * a singleton could only ever be wired to the live services, so every suite in
+ * CI would talk to the network.
+ *
+ * Registering a feature is one line in the `reducer` map below (`RC-23`) plus one
+ * field in `ThunkExtra` per new Service (`RC-21`). There is no second injection
+ * mechanism — no service locator, no ambient singleton import.
+ */
+import { configureStore, isPlain } from '@reduxjs/toolkit'
+import { greetingSlice } from '../features/greeting/GreetingFeature'
+import {
+  type GreetingService,
+  liveGreetingService,
+  stubbedGreetingService,
+} from '../services/greeting/GreetingService'
+
+/**
+ * Every injectable Service in the app, in one closed manifest. A Producer reads
+ * `extra.<service>`; a reducer never sees `extra` at all.
+ */
+export interface ThunkExtra {
+  readonly greetingService: GreetingService
+}
+
+/** The production bindings — the default `makeStore()` argument. */
+export const liveThunkExtra: ThunkExtra = {
+  greetingService: liveGreetingService,
+}
+
+/**
+ * The fixture-backed bindings every test and story uses. Exported here, beside
+ * the manifest, so a suite never has to reach into `services/` itself.
+ */
+export const stubbedThunkExtra: ThunkExtra = {
+  greetingService: stubbedGreetingService,
+}
+
+export const makeStore = (extra: ThunkExtra = liveThunkExtra) =>
+  configureStore({
+    reducer: {
+      greeting: greetingSlice.reducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        thunk: { extraArgument: extra },
+        // Domain models carry real domain types, so a `Date` in state is correct
+        // (`RC-24`/`UZF-8`) — a wire string there would be the bug. The check is
+        // widened to accept `Date` and nothing else; class instances, functions
+        // and promises still fail it.
+        serializableCheck: {
+          isSerializable: (value: unknown) => value instanceof Date || isPlain(value),
+        },
+      }),
+  })
+
+export type AppStore = ReturnType<typeof makeStore>
+export type RootState = ReturnType<AppStore['getState']>
+export type AppDispatch = AppStore['dispatch']

--- a/packages/app/src/services/greeting/GreetingService.ts
+++ b/packages/app/src/services/greeting/GreetingService.ts
@@ -1,0 +1,47 @@
+/**
+ * SCAFFOLDING — the demo feature's Service (`RC-6`, `RC-33`, `RC-59`).
+ *
+ * A Service is a stateless wrapper around one external system. It returns the
+ * **wire** shape and is allowed to throw: the `Result` boundary belongs to the
+ * Producer, not here (`RC-7`). It ships in a pair — `liveGreetingService` for
+ * production and `stubbedGreetingService` reading `greeting.fixtures.json` for
+ * every test and story. A live-only Service is incomplete.
+ *
+ * Nothing outside `library/store.ts` (which assembles `ThunkExtra`) and test
+ * setup may import this module — `scripts/check-uzf-boundaries.mjs` fails the
+ * lint task if it does, which is what makes "components cannot fetch" a
+ * structural fact rather than a convention.
+ */
+import type { GreetingResponse } from '@kro/core'
+import fixtures from './greeting.fixtures.json'
+
+export interface GreetingService {
+  fetchGreeting(recipient: string, options?: { signal?: AbortSignal }): Promise<GreetingResponse>
+}
+
+const GREETINGS_ENDPOINT = 'https://greetings.kro.invalid/greetings'
+
+const fixtureGreetings = fixtures.greetings as Record<string, GreetingResponse | undefined>
+
+/** Shapes a transport failure the way `GreetingMapper.toException` reads it. */
+function httpError(status: number, message: string): Error {
+  return Object.assign(new Error(message), { status })
+}
+
+export const liveGreetingService: GreetingService = {
+  async fetchGreeting(recipient, options = {}) {
+    const response = await fetch(`${GREETINGS_ENDPOINT}/${encodeURIComponent(recipient)}`, {
+      signal: options.signal,
+    })
+    if (!response.ok) throw httpError(response.status, `HTTP ${response.status}`)
+    return (await response.json()) as GreetingResponse
+  },
+}
+
+export const stubbedGreetingService: GreetingService = {
+  async fetchGreeting(recipient, _options = {}) {
+    const found = fixtureGreetings[recipient]
+    if (found === undefined) throw httpError(404, `no greeting fixture for "${recipient}"`)
+    return found
+  },
+}

--- a/packages/app/src/services/greeting/greeting.fixtures.json
+++ b/packages/app/src/services/greeting/greeting.fixtures.json
@@ -1,0 +1,39 @@
+{
+  "greetings": {
+    "ada": {
+      "id": "greeting-1",
+      "recipient": "ada",
+      "message": "Good morning, Ada.",
+      "signature": "— Kro",
+      "issued_at": "2026-01-15T08:00:00.000Z"
+    },
+    "grace": {
+      "id": "greeting-2",
+      "recipient": "grace",
+      "message": "Welcome back, Grace.",
+      "signature": "— Kro",
+      "issued_at": "2026-01-15T08:59:59.000Z"
+    },
+    "linus": {
+      "id": "greeting-4",
+      "recipient": "linus",
+      "message": "Hey Linus.",
+      "signature": null,
+      "issued_at": "2026-01-14T19:45:00.000Z"
+    },
+    "山田": {
+      "id": "greeting-7",
+      "recipient": "山田",
+      "message": "おはよう、山田さん 🌸 — مرحبا",
+      "signature": "— クロ",
+      "issued_at": "2026-01-13T22:05:00.000Z"
+    },
+    "malformed": {
+      "id": "greeting-8",
+      "recipient": "malformed",
+      "message": "This payload never survives the Mapper.",
+      "signature": null,
+      "issued_at": "the day before yesterday"
+    }
+  }
+}

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * `@kro/app` holds the store, the typed hooks and the feature slices, so its
+ * suite runs under jsdom: a headless hook still needs a React renderer.
+ *
+ * `globals: false` keeps `describe`/`it`/`expect` explicit imports, so the
+ * package needs no ambient `types` entry and stays compilable with `types: []`.
+ *
+ * No network transport is configured anywhere in this project on purpose — every
+ * suite reaches a Service only through a stubbed binding injected into
+ * `makeStore(extra)` (`RC-35`).
+ */
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: false,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "typescript": "^5",
+    "jsdom": "^26.1.0",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,11 +2,12 @@
   "name": "@kro/core",
   "version": "0.1.0",
   "private": true,
-  "description": "Platform-free Kro domain tier. No react / next / DOM — enforced by tsconfig lib and by scripts/check-platform-free.mjs.",
+  "description": "Platform-free Kro domain tier: UZF library primitives (Result, Exception, assertNever), domain models, mappers and mocks. No react / next / DOM — enforced by tsconfig lib and by scripts/check-platform-free.mjs.",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./mocks": "./src/mocks.ts",
     "./package.json": "./package.json"
   },
   "files": [
@@ -14,9 +15,11 @@
   ],
   "scripts": {
     "lint": "node ../../scripts/check-platform-free.mjs",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,9 +4,27 @@
  * Nothing exported from here may reach for `react`, `next`, `react-dom` or a DOM
  * global: this package is compiled with `lib: ["ES2022"]` and `types: []`, and
  * `scripts/check-platform-free.mjs` fails `pnpm lint` if a platform import appears.
+ *
+ * Layout:
+ *   `library/`  the UZF runtime primitives every feature sits on — `Result`,
+ *               `Exception`, `assertNever` (`RC-7`, `RC-8`, `RC-9`).
+ *   `models/`   domain models, their `…Exception` unions and Mappers, plus the
+ *               `__mocks__` spread each model ships (`RC-13`, exported under the
+ *               `@kro/core/mocks` subpath so production bundles never pull them).
+ *
+ * The store, the typed hooks and the feature slices live in `@kro/app`: they need
+ * `react-redux`, which would breach this package's platform-free contract. See
+ * the PR for #5 for that interpretation of `RC-50`.
  */
 
+export * from './library/assertNever'
+export * from './library/exception'
+export * from './library/result'
 export * from './model/Session/SessionConfig'
 export * from './model/Session/SessionFragment'
 export * from './model/Session/SessionTypes'
+export * from './models/Greeting'
+export * from './models/GreetingException'
+export * from './models/GreetingMapper'
+export * from './models/GreetingResponse'
 export * from './utils/durations'

--- a/packages/core/src/library/__tests__/assertNever.test.ts
+++ b/packages/core/src/library/__tests__/assertNever.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { assertNever } from '../assertNever'
+
+type Signal = { kind: 'start' } | { kind: 'stop' }
+
+/** Stand-in for a real `switch` over a sealed union, closed by `assertNever`. */
+function describeSignal(signal: Signal): string {
+  switch (signal.kind) {
+    case 'start':
+      return 'started'
+    case 'stop':
+      return 'stopped'
+    default:
+      return assertNever(signal)
+  }
+}
+
+describe('assertNever', () => {
+  it('never runs while every union member is handled — the normal path', () => {
+    expect(describeSignal({ kind: 'start' })).toBe('started')
+    expect(describeSignal({ kind: 'stop' })).toBe('stopped')
+  })
+
+  it('throws when a value outside the union reaches the default arm — a stale payload from an older build', () => {
+    const rogue = { kind: 'pause' } as unknown as Signal
+
+    expect(() => describeSignal(rogue)).toThrow(/Unhandled discriminated-union case/)
+  })
+
+  it('names the offending value so the log says which member was missed', () => {
+    const rogue = { kind: 'pause' } as unknown as Signal
+
+    expect(() => describeSignal(rogue)).toThrow(/"kind":"pause"/)
+  })
+})

--- a/packages/core/src/library/__tests__/exception.test.ts
+++ b/packages/core/src/library/__tests__/exception.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { exception, toUnknownException, unknownException } from '../exception'
+
+describe('exception', () => {
+  it('builds a union member with its discriminant, detail and retry affordance', () => {
+    const built = exception('offline', 'The greeting service is unreachable.', true)
+
+    expect(built).toEqual({
+      kind: 'offline',
+      message: 'The greeting service is unreachable.',
+      recoverable: true,
+    })
+  })
+
+  it('marks a member unrecoverable when the caller says so — a 403 no retry can fix', () => {
+    expect(exception('unauthorized', 'refused', false).recoverable).toBe(false)
+  })
+
+  it('defaults to recoverable, so a forgotten flag offers a retry rather than a dead end', () => {
+    expect(exception('unknown', 'something happened').recoverable).toBe(true)
+  })
+})
+
+describe('unknownException', () => {
+  it('keeps the developer-facing detail for the log — a serialization bug in the payload creator', () => {
+    expect(unknownException('cannot serialize payload').message).toBe('cannot serialize payload')
+  })
+
+  it('always discriminates as `unknown`, so the defensive `.rejected` arm has one shape to shift into', () => {
+    expect(unknownException('anything').kind).toBe('unknown')
+  })
+
+  it('is recoverable — an unexplained failure still lets the user try again', () => {
+    expect(unknownException('anything').recoverable).toBe(true)
+  })
+})
+
+describe('toUnknownException', () => {
+  it('reads the message off a thrown Error — the usual shape a Service rejects with', () => {
+    expect(toUnknownException(new Error('HTTP 500')).message).toBe('HTTP 500')
+  })
+
+  it('passes a thrown string straight through — a hand-rolled `throw "boom"` somewhere', () => {
+    expect(toUnknownException('boom').message).toBe('boom')
+  })
+
+  it('degrades a non-Error object into a printable detail rather than crashing the catch block', () => {
+    expect(toUnknownException({ status: 500 }).message).toBe('[object Object]')
+  })
+
+  it('survives a thrown `undefined` — the shape a rejected promise with no reason produces', () => {
+    expect(toUnknownException(undefined).kind).toBe('unknown')
+    expect(toUnknownException(undefined).message).toBe('undefined')
+  })
+})

--- a/packages/core/src/library/__tests__/result.test.ts
+++ b/packages/core/src/library/__tests__/result.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { err, isErr, isOk, ok, type Result } from '../result'
+import { GreetingExceptions, type GreetingException } from '../../models/GreetingException'
+
+type GreetingResult = Result<string, GreetingException>
+
+describe('ok', () => {
+  it('carries the value a Producer resolved — greeting loaded from the service', () => {
+    const result: GreetingResult = ok('Good morning, Ada.')
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toBe('Good morning, Ada.')
+  })
+
+  it('accepts a falsy value without collapsing it into a failure — an empty greeting body', () => {
+    const result: GreetingResult = ok('')
+
+    expect(result.ok).toBe(true)
+    expect(isErr(result)).toBe(false)
+  })
+
+  it('produces a fresh container per call so two completions never alias', () => {
+    const first = ok('a')
+    const second = ok('a')
+
+    expect(first).not.toBe(second)
+    expect(first).toEqual(second)
+  })
+})
+
+describe('err', () => {
+  it('carries the typed exception a Producer caught — the phone went offline mid-request', () => {
+    const result: GreetingResult = err(GreetingExceptions.offline())
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('offline')
+  })
+
+  it('keeps the recoverable flag intact so the surface can offer a retry', () => {
+    const result: GreetingResult = err(GreetingExceptions.unauthorized())
+
+    if (!result.ok) expect(result.error.recoverable).toBe(false)
+  })
+
+  it('never exposes a `value` field, so a careless read cannot pass for success', () => {
+    const result: GreetingResult = err(GreetingExceptions.notFound())
+
+    expect('value' in result).toBe(false)
+  })
+})
+
+describe('isOk', () => {
+  it('is true for a resolved success — the reducer takes the loaded arm', () => {
+    expect(isOk(ok('Hello.'))).toBe(true)
+  })
+
+  it('is false for a resolved failure — the reducer takes the exception arm', () => {
+    expect(isOk(err(GreetingExceptions.offline()))).toBe(false)
+  })
+
+  it('narrows the union so `value` is reachable without a cast', () => {
+    const result: GreetingResult = ok('Welcome back, Grace.')
+
+    if (isOk(result)) {
+      expect(result.value.startsWith('Welcome')).toBe(true)
+    } else {
+      throw new Error('expected the success arm')
+    }
+  })
+})
+
+describe('isErr', () => {
+  it('is true for a resolved failure — the service refused the request', () => {
+    expect(isErr(err(GreetingExceptions.unauthorized()))).toBe(true)
+  })
+
+  it('is false for a resolved success — nothing to surface to the user', () => {
+    expect(isErr(ok('Hi.'))).toBe(false)
+  })
+
+  it('narrows the union so `error.kind` is reachable without a cast', () => {
+    const result: GreetingResult = err(GreetingExceptions.malformed('missing id'))
+
+    if (isErr(result)) {
+      expect(result.error.kind).toBe('malformed')
+    } else {
+      throw new Error('expected the failure arm')
+    }
+  })
+})

--- a/packages/core/src/library/assertNever.ts
+++ b/packages/core/src/library/assertNever.ts
@@ -1,0 +1,23 @@
+/**
+ * Compile-time exhaustiveness check for discriminated unions (`RC-9`).
+ *
+ * Call it from the `default` branch of every hand-written `switch` over a
+ * `…Exception["kind"]`, a `Result` branch, or any other sealed `kind` union:
+ * TypeScript then fails the build the day a new member is added, instead of the
+ * code silently falling through at runtime.
+ *
+ * ```ts
+ * switch (exception.kind) {
+ *   case 'offline': return 'You are offline.'
+ *   // …
+ *   default: return assertNever(exception)
+ * }
+ * ```
+ *
+ * `createSlice`'s own `reducers` / `extraReducers` maps are exempt — TypeScript's
+ * case-key checking on the action map is already the equivalent guarantee, so an
+ * unreachable `default` is never bolted onto a reducer arm.
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled discriminated-union case: ${JSON.stringify(value)}`)
+}

--- a/packages/core/src/library/exception.ts
+++ b/packages/core/src/library/exception.ts
@@ -1,0 +1,54 @@
+/**
+ * The shape every UZF `…Exception` union member shares (`RC-8`).
+ *
+ * State and completion events never carry a raw `string` or `Error` to describe
+ * a user-facing problem — they carry a discriminated `…Exception`. Each feature
+ * declares its own closed union in `models/…Exception.ts`, built from this shape
+ * plus a factory object, e.g.
+ *
+ * ```ts
+ * export type GreetingException =
+ *   | Exception<'offline'>
+ *   | Exception<'notFound'>
+ *
+ * export const GreetingExceptions = {
+ *   offline: () => exception('offline', 'You are offline.', true),
+ *   notFound: () => exception('notFound', 'No greeting for that name.', false),
+ * }
+ * ```
+ *
+ * `kind` is the discriminant a `switch` narrows on (always closed by
+ * `assertNever`, `RC-9`), `message` is developer-facing detail for logs, and
+ * `recoverable` says whether the surface should offer a retry affordance.
+ * User-facing copy is derived per `kind`, never read from `message`.
+ */
+export interface Exception<Kind extends string = string> {
+  readonly kind: Kind
+  readonly message: string
+  readonly recoverable: boolean
+}
+
+/** Builds one member of a feature's `…Exception` union. */
+export const exception = <Kind extends string>(
+  kind: Kind,
+  message: string,
+  recoverable = true,
+): Exception<Kind> => ({ kind, message, recoverable })
+
+/**
+ * The shared `unknown` fallback every feature union is expected to include, so a
+ * defensive `.rejected` reducer arm has a typed value to shift into (`RC-26`).
+ */
+export const unknownException = (message: string): Exception<'unknown'> =>
+  exception('unknown', message, true)
+
+/**
+ * Normalizes an arbitrary caught value into the `unknown` exception. Mappers call
+ * this as the last arm of `toException`; it is never a substitute for mapping a
+ * recognized failure to its own `kind`.
+ */
+export const toUnknownException = (error: unknown): Exception<'unknown'> => {
+  if (error instanceof Error) return unknownException(error.message)
+  if (typeof error === 'string') return unknownException(error)
+  return unknownException(String(error))
+}

--- a/packages/core/src/library/result.ts
+++ b/packages/core/src/library/result.ts
@@ -1,0 +1,27 @@
+/**
+ * The canonical UZF `Result<T, E>` container (`RC-7`).
+ *
+ * `Result` is the *only* contract between a Producer and a Reducer: a
+ * `createAsyncThunk` payload creator resolves `Promise<Result<Success, …Exception>>`,
+ * never throws, and its `.rejected` arm exists purely as a defensive fallback.
+ * Every action payload that carries the outcome of an Effect is a `Result`.
+ *
+ * This module is deliberately dependency-free — it compiles against a bare
+ * TypeScript install with no DOM, no Node and no React in scope.
+ */
+
+export type Result<T, E> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: E }
+
+/** Wraps a success value. `ok(v)` widens to any `Result<T, E>`. */
+export const ok = <T>(value: T): Result<T, never> => ({ ok: true, value })
+
+/** Wraps a failure value — always a typed `…Exception`, never a raw `Error` (`RC-8`). */
+export const err = <E>(error: E): Result<never, E> => ({ ok: false, error })
+
+/** Narrowing guard for the success arm. */
+export const isOk = <T, E>(result: Result<T, E>): result is { ok: true; value: T } => result.ok
+
+/** Narrowing guard for the failure arm. */
+export const isErr = <T, E>(result: Result<T, E>): result is { ok: false; error: E } => !result.ok

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -1,0 +1,9 @@
+/**
+ * `@kro/core/mocks` — domain-model mock fixtures (`RC-13`).
+ *
+ * Kept off the main `@kro/core` barrel deliberately: mocks are test/story data,
+ * so importing them must be an explicit, greppable act (`@kro/core/mocks`) that
+ * never rides along into a production bundle.
+ */
+
+export * from './models/__mocks__/Greeting.mocks'

--- a/packages/core/src/models/Greeting.ts
+++ b/packages/core/src/models/Greeting.ts
@@ -1,0 +1,19 @@
+/**
+ * SCAFFOLDING — demo domain model for the UZF reference loop.
+ *
+ * `Greeting` exists only so the state tier landed by #5 has a real domain type to
+ * carry end to end (Service → Mapper → Producer → Reducer → Selector → hook).
+ * Feature children (#7+) replace it with the actual Kro domain; nothing outside
+ * the `greeting` demo feature may depend on it.
+ *
+ * Domain model rules it demonstrates: `readonly` throughout, real domain types
+ * (`Date`, not a wire string), no serialization annotations, no UI concern.
+ */
+export interface Greeting {
+  readonly id: string
+  readonly recipient: string
+  readonly message: string
+  /** Optional flourish — present on some greetings, absent on others. */
+  readonly signature: string | null
+  readonly issuedAt: Date
+}

--- a/packages/core/src/models/GreetingException.ts
+++ b/packages/core/src/models/GreetingException.ts
@@ -1,0 +1,59 @@
+/**
+ * SCAFFOLDING — the demo feature's `…Exception` union (`RC-8`) and the worked
+ * example of the shape every real feature union copies.
+ *
+ * Three things are load-bearing here for feature children:
+ *   1. the union is **closed** — every failure the feature can surface is a
+ *      member, so state never holds a raw `Error` or a bare `string`;
+ *   2. members are built by **factories**, never by literals scattered across
+ *      Producers, so the copy and the `recoverable` flag live in one place; and
+ *   3. user-facing copy is derived by a `switch` closed with `assertNever`
+ *      (`RC-9`) — adding a member is a compile error until the copy is written.
+ */
+import { assertNever } from '../library/assertNever'
+import { type Exception, exception } from '../library/exception'
+
+export type GreetingException =
+  | Exception<'offline'>
+  | Exception<'notFound'>
+  | Exception<'unauthorized'>
+  | Exception<'malformed'>
+  | Exception<'unknown'>
+
+export const GreetingExceptions = {
+  offline: (): GreetingException =>
+    exception('offline', 'The greeting service is unreachable.', true),
+
+  notFound: (): GreetingException =>
+    exception('notFound', 'The greeting service has no greeting for that recipient.', false),
+
+  unauthorized: (): GreetingException =>
+    exception('unauthorized', 'The greeting service refused the request.', false),
+
+  malformed: (detail: string): GreetingException => exception('malformed', detail, false),
+
+  unknown: (message: string): GreetingException => exception('unknown', message, true),
+}
+
+/**
+ * User-facing copy per exception kind. Lives in the platform-free tier so both a
+ * DOM surface and a headless test read the same sentence, and is the reference
+ * for `RC-9`: the `default` arm is `assertNever`, so a new union member fails
+ * `tsc` here before it can reach a screen untranslated.
+ */
+export function greetingExceptionCopy(value: GreetingException): string {
+  switch (value.kind) {
+    case 'offline':
+      return 'You are offline — the greeting will load when you reconnect.'
+    case 'notFound':
+      return 'We could not find a greeting for that name.'
+    case 'unauthorized':
+      return 'You are not allowed to read that greeting.'
+    case 'malformed':
+      return 'That greeting arrived in a shape we do not understand.'
+    case 'unknown':
+      return 'Something went wrong loading the greeting.'
+    default:
+      return assertNever(value)
+  }
+}

--- a/packages/core/src/models/GreetingMapper.ts
+++ b/packages/core/src/models/GreetingMapper.ts
@@ -1,0 +1,59 @@
+/**
+ * SCAFFOLDING — the demo feature's Mapper (`RC-30`, `UZF-17`).
+ *
+ * The single place wire ↔ domain translation happens, and the single place a
+ * caught `unknown` becomes a typed `GreetingException`. A Producer's `catch`
+ * block calls `toException` — it never re-implements the mapping inline.
+ */
+import { type Exception, toUnknownException } from '../library/exception'
+import type { Greeting } from './Greeting'
+import { type GreetingException, GreetingExceptions } from './GreetingException'
+import type { GreetingResponse } from './GreetingResponse'
+
+/** Reads an HTTP-ish `status` off an arbitrary caught value without throwing. */
+function statusOf(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const status = (error as { status?: unknown }).status
+  return typeof status === 'number' ? status : undefined
+}
+
+export const GreetingMapper = {
+  /**
+   * Returns `null` on malformed input rather than a partial domain object, so the
+   * caller surfaces a typed exception instead of storing something half-built.
+   */
+  toDomain(response: GreetingResponse): Greeting | null {
+    const issuedAt = new Date(response.issued_at)
+    if (response.id.length === 0 || response.recipient.length === 0) return null
+    if (Number.isNaN(issuedAt.getTime())) return null
+
+    return {
+      id: response.id,
+      recipient: response.recipient,
+      message: response.message,
+      signature: response.signature ?? null,
+      issuedAt,
+    }
+  },
+
+  fromDomain(greeting: Greeting): GreetingResponse {
+    return {
+      id: greeting.id,
+      recipient: greeting.recipient,
+      message: greeting.message,
+      signature: greeting.signature,
+      issued_at: greeting.issuedAt.toISOString(),
+    }
+  },
+
+  toException(error: unknown): GreetingException {
+    if (error instanceof TypeError) return GreetingExceptions.offline()
+
+    const status = statusOf(error)
+    if (status === 401 || status === 403) return GreetingExceptions.unauthorized()
+    if (status === 404) return GreetingExceptions.notFound()
+
+    const unknown: Exception<'unknown'> = toUnknownException(error)
+    return unknown
+  },
+}

--- a/packages/core/src/models/GreetingResponse.ts
+++ b/packages/core/src/models/GreetingResponse.ts
@@ -1,0 +1,14 @@
+/**
+ * SCAFFOLDING — the wire shape of a greeting, as a Service returns it.
+ *
+ * Wire types never leak past the Producer boundary: `GreetingMapper.toDomain`
+ * translates this into the `Greeting` domain model, and slice state only ever
+ * holds the domain side (`UZF-8`, `UZF-17`, `RC-30`).
+ */
+export interface GreetingResponse {
+  readonly id: string
+  readonly recipient: string
+  readonly message: string
+  readonly signature?: string | null
+  readonly issued_at: string
+}

--- a/packages/core/src/models/__mocks__/Greeting.mocks.ts
+++ b/packages/core/src/models/__mocks__/Greeting.mocks.ts
@@ -1,0 +1,74 @@
+/**
+ * SCAFFOLDING — ≥7 mock variations of the demo domain model (`RC-13`).
+ *
+ * The spread is the canonical one: convenient (typical, freshlyIssued,
+ * withSignature), neutral (emptyMessage, noSignature) and inconvenient
+ * (longMessage, unicode, stale). Stories, render tests and Service fixtures all
+ * consume these — a domain value is never written inline in a test.
+ */
+import type { Greeting } from '../Greeting'
+
+export const greetingMocks = {
+  /** The happy path: a short greeting issued this morning. */
+  typical: {
+    id: 'greeting-1',
+    recipient: 'ada',
+    message: 'Good morning, Ada.',
+    signature: '— Kro',
+    issuedAt: new Date('2026-01-15T08:00:00.000Z'),
+  } satisfies Greeting,
+
+  /** Just written — exercises "issued seconds ago" formatting. */
+  freshlyIssued: {
+    id: 'greeting-2',
+    recipient: 'grace',
+    message: 'Welcome back, Grace.',
+    signature: '— Kro',
+    issuedAt: new Date('2026-01-15T08:59:59.000Z'),
+  } satisfies Greeting,
+
+  /** Months old — exercises stale-timestamp presentation. */
+  stale: {
+    id: 'greeting-3',
+    recipient: 'alan',
+    message: 'Long time no see, Alan.',
+    signature: '— Kro',
+    issuedAt: new Date('2025-03-02T11:30:00.000Z'),
+  } satisfies Greeting,
+
+  /** The optional field is absent — the layout must not reserve space for it. */
+  noSignature: {
+    id: 'greeting-4',
+    recipient: 'linus',
+    message: 'Hey Linus.',
+    signature: null,
+    issuedAt: new Date('2026-01-14T19:45:00.000Z'),
+  } satisfies Greeting,
+
+  /** Neutral / empty: a greeting whose body never arrived. */
+  emptyMessage: {
+    id: 'greeting-5',
+    recipient: 'nobody',
+    message: '',
+    signature: null,
+    issuedAt: new Date('2026-01-10T06:00:00.000Z'),
+  } satisfies Greeting,
+
+  /** Inconvenient: a body far longer than any line box. */
+  longMessage: {
+    id: 'greeting-6',
+    recipient: 'verbose',
+    message: 'A very warm and thoroughly unnecessary welcome to you. '.repeat(8).trim(),
+    signature: '— Kro, at length',
+    issuedAt: new Date('2026-01-12T13:20:00.000Z'),
+  } satisfies Greeting,
+
+  /** Inconvenient: non-ASCII names, emoji, and right-to-left text. */
+  unicode: {
+    id: 'greeting-7',
+    recipient: '山田',
+    message: 'おはよう、山田さん 🌸 — مرحبا',
+    signature: '— クロ',
+    issuedAt: new Date('2026-01-13T22:05:00.000Z'),
+  } satisfies Greeting,
+}

--- a/packages/core/src/models/__tests__/GreetingException.test.ts
+++ b/packages/core/src/models/__tests__/GreetingException.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { GreetingExceptions, greetingExceptionCopy } from '../GreetingException'
+
+describe('GreetingExceptions factories', () => {
+  it('offline is recoverable — reconnecting is all the user has to do', () => {
+    const built = GreetingExceptions.offline()
+
+    expect(built.kind).toBe('offline')
+    expect(built.recoverable).toBe(true)
+  })
+
+  it('unauthorized is not recoverable — retrying the same request changes nothing', () => {
+    expect(GreetingExceptions.unauthorized().recoverable).toBe(false)
+  })
+
+  it('malformed keeps the parse detail for the log while the user sees generic copy', () => {
+    const built = GreetingExceptions.malformed('issued_at was not a date')
+
+    expect(built.kind).toBe('malformed')
+    expect(built.message).toBe('issued_at was not a date')
+  })
+})
+
+describe('greetingExceptionCopy', () => {
+  it('offers reconnect guidance when the request never left the device', () => {
+    expect(greetingExceptionCopy(GreetingExceptions.offline())).toMatch(/offline/i)
+  })
+
+  it('says the greeting is missing, not that something broke, on a 404', () => {
+    expect(greetingExceptionCopy(GreetingExceptions.notFound())).toMatch(/could not find/i)
+  })
+
+  it('never leaks the developer-facing message into user copy — a malformed payload', () => {
+    const copy = greetingExceptionCopy(GreetingExceptions.malformed('issued_at was not a date'))
+
+    expect(copy).not.toContain('issued_at')
+  })
+
+  it('has a sentence for every member of the union — the exhaustiveness contract in practice', () => {
+    const everyMember = [
+      GreetingExceptions.offline(),
+      GreetingExceptions.notFound(),
+      GreetingExceptions.unauthorized(),
+      GreetingExceptions.malformed('detail'),
+      GreetingExceptions.unknown('detail'),
+    ]
+
+    for (const member of everyMember) {
+      expect(greetingExceptionCopy(member).length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/core/src/models/__tests__/GreetingMapper.test.ts
+++ b/packages/core/src/models/__tests__/GreetingMapper.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { greetingMocks } from '../__mocks__/Greeting.mocks'
+import { GreetingMapper } from '../GreetingMapper'
+import type { GreetingResponse } from '../GreetingResponse'
+
+const wire: GreetingResponse = {
+  id: 'greeting-1',
+  recipient: 'ada',
+  message: 'Good morning, Ada.',
+  signature: '— Kro',
+  issued_at: '2026-01-15T08:00:00.000Z',
+}
+
+describe('GreetingMapper.toDomain', () => {
+  it('turns a well-formed payload into the domain model — the ordinary success path', () => {
+    expect(GreetingMapper.toDomain(wire)).toEqual(greetingMocks.typical)
+  })
+
+  it('defaults an absent signature to null rather than leaving it undefined', () => {
+    const { signature: _omitted, ...withoutSignature } = wire
+
+    expect(GreetingMapper.toDomain(withoutSignature)?.signature).toBeNull()
+  })
+
+  it('returns null when the timestamp is unparseable — a backend that shipped a bad format', () => {
+    expect(GreetingMapper.toDomain({ ...wire, issued_at: 'yesterday' })).toBeNull()
+  })
+
+  it('returns null when the identity fields are empty, so no half-built greeting is stored', () => {
+    expect(GreetingMapper.toDomain({ ...wire, id: '' })).toBeNull()
+    expect(GreetingMapper.toDomain({ ...wire, recipient: '' })).toBeNull()
+  })
+})
+
+describe('GreetingMapper.fromDomain', () => {
+  it('serializes the timestamp back to ISO-8601 for the wire', () => {
+    expect(GreetingMapper.fromDomain(greetingMocks.typical).issued_at).toBe(
+      '2026-01-15T08:00:00.000Z',
+    )
+  })
+
+  it('round-trips a greeting unchanged — write, read back, same domain value', () => {
+    const roundTripped = GreetingMapper.toDomain(GreetingMapper.fromDomain(greetingMocks.unicode))
+
+    expect(roundTripped).toEqual(greetingMocks.unicode)
+  })
+
+  it('keeps a null signature null instead of dropping the key', () => {
+    expect(GreetingMapper.fromDomain(greetingMocks.noSignature).signature).toBeNull()
+  })
+})
+
+describe('GreetingMapper.toException', () => {
+  it('reads a TypeError as offline — the shape `fetch` throws with no connection', () => {
+    expect(GreetingMapper.toException(new TypeError('Failed to fetch')).kind).toBe('offline')
+  })
+
+  it('reads 401 and 403 as unauthorized — the session expired while the tab was open', () => {
+    expect(GreetingMapper.toException({ status: 401 }).kind).toBe('unauthorized')
+    expect(GreetingMapper.toException({ status: 403 }).kind).toBe('unauthorized')
+  })
+
+  it('reads 404 as notFound — the recipient has no greeting registered', () => {
+    expect(GreetingMapper.toException({ status: 404 }).kind).toBe('notFound')
+  })
+
+  it('falls back to unknown for an unrecognized failure, keeping the detail for the log', () => {
+    const mapped = GreetingMapper.toException(new Error('HTTP 500'))
+
+    expect(mapped.kind).toBe('unknown')
+    expect(mapped.message).toBe('HTTP 500')
+  })
+
+  it('survives a thrown null without throwing out of the catch block', () => {
+    expect(GreetingMapper.toException(null).kind).toBe('unknown')
+  })
+})

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * `@kro/core` is the platform-free tier, so its suite runs on the plain Node
+ * environment — no jsdom, no DOM globals. A test in this package that needs a
+ * browser API is testing the wrong thing: that logic belongs in `@kro/app`.
+ *
+ * `globals: false` keeps `describe`/`it`/`expect` explicit imports, so the
+ * package needs no ambient `types` entry and stays compilable with `types: []`.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,16 +129,49 @@ importers:
       '@kro/core':
         specifier: workspace:*
         version: link:../core
+      '@reduxjs/toolkit':
+        specifier: ^2.12.0
+        version: 2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)
+      react-redux:
+        specifier: ^9.3.0
+        version: 9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1)
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@types/react':
+        specifier: ^19
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.5(@types/react@19.2.18)
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
+      react:
+        specifier: ^19.0.0
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.8(react@19.2.8)
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@20.19.43)(jsdom@30.0.1)
 
   packages/core:
     devDependencies:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@20.19.43)(jsdom@30.0.1)
 
 packages:
 
@@ -150,6 +183,14 @@ packages:
     peerDependencies:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -320,6 +361,10 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@chakra-ui/react@3.37.0':
     resolution: {integrity: sha512-TaFju5LTT7GEZ8brcyZOhM7fNN54tJ/rMaMFvUAD7UE8tsUJb/j3zCUYPjchkoVXD1vinXtN9S31cp2QcOTUPg==}
     peerDependencies:
@@ -330,6 +375,42 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.2':
+    resolution: {integrity: sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.10':
+    resolution: {integrity: sha512-xBja6gaAaH2R2c7eNyl0TY4dhnnZ2uhj+KXpLdEQ6M/wuk9bYFZM8wY0ykw3VO4TgEJ56KGlerXS/9KBKVR/Cg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -391,6 +472,162 @@ packages:
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -428,6 +665,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
@@ -694,6 +940,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
@@ -784,6 +1036,142 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    resolution: {integrity: sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    resolution: {integrity: sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    resolution: {integrity: sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    resolution: {integrity: sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    resolution: {integrity: sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    resolution: {integrity: sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    resolution: {integrity: sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    resolution: {integrity: sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    resolution: {integrity: sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    resolution: {integrity: sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    resolution: {integrity: sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    resolution: {integrity: sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    resolution: {integrity: sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    resolution: {integrity: sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    resolution: {integrity: sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    resolution: {integrity: sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    resolution: {integrity: sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    resolution: {integrity: sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    resolution: {integrity: sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    resolution: {integrity: sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    resolution: {integrity: sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    resolution: {integrity: sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    resolution: {integrity: sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -798,6 +1186,12 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -904,6 +1298,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -950,6 +1350,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/web-push@3.6.4':
     resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
@@ -1128,6 +1531,35 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@zag-js/accordion@1.43.3':
     resolution: {integrity: sha512-J6rGbMPXhYDa2dLgp66DPpwC3OcNAJH71kuGakz7SfCvQWiR9lIyB26G/QdSjJjf0rVARM8rN90e5PxZjYdWjA==}
@@ -1472,6 +1904,10 @@ packages:
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1538,6 +1974,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -1577,6 +2016,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1604,6 +2047,10 @@ packages:
   caniuse-lite@1.0.30001810:
     resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1611,6 +2058,10 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -1677,6 +2128,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -1699,6 +2154,10 @@ packages:
   data-urls@3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1746,6 +2205,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1828,6 +2291,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -1851,6 +2318,9 @@ packages:
     resolution: {integrity: sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -1866,6 +2336,11 @@ packages:
   es-to-primitive@1.3.4:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2006,6 +2481,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2017,6 +2495,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -2245,6 +2727,10 @@ packages:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -2283,6 +2769,9 @@ packages:
   ignore@7.0.7:
     resolution: {integrity: sha512-dML0wP6oak21rsNYCJpJB6O1BJIEwNpGrTw0URPfAk4hm0e3pRfCtzkfB6olBcXcVlU2rouCyz7lCyRB0OMVCA==}
     engines: {node: '>= 4'}
+
+  immer@11.1.18:
+    resolution: {integrity: sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -2619,6 +3108,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.15.2:
     resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
@@ -2632,6 +3124,15 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -2718,6 +3219,13 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2728,6 +3236,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -2742,6 +3253,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2975,6 +3489,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2993,6 +3510,13 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   perfect-freehand@1.2.3:
     resolution: {integrity: sha512-bHZSfqDHGNlPpgH2yxXgPHlQSPpEbo+qg7li0M78J9vNAi2yjwLeA4x79BEQhX44lEWpCLSFCeRZwpw0niiXPA==}
@@ -3022,6 +3546,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact-render-to-string@5.2.6:
@@ -3108,6 +3636,18 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
@@ -3115,6 +3655,14 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3128,8 +3676,15 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.3.0:
+    resolution: {integrity: sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -3163,6 +3718,11 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup@4.63.1:
+    resolution: {integrity: sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3244,6 +3804,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3286,6 +3849,12 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3350,6 +3919,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -3385,9 +3957,34 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.11:
+    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+
+  tldts@7.4.11:
+    resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
+    hasBin: true
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -3404,12 +4001,20 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -3517,6 +4122,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
+
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
@@ -3542,6 +4151,11 @@ packages:
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
@@ -3558,9 +4172,86 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
     engines: {node: '>=14'}
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -3577,6 +4268,10 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   webpack-bundle-analyzer@4.10.1:
     resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
     engines: {node: '>= 10.13.0'}
@@ -3591,9 +4286,21 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
   whatwg-url@11.0.0:
     resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
     engines: {node: '>=12'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3617,6 +4324,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3664,6 +4376,10 @@ packages:
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -3775,6 +4491,21 @@ snapshots:
       '@zag-js/utils': 1.43.3
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -3967,6 +4698,10 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@chakra-ui/react@3.37.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@ark-ui/react': 5.39.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3983,6 +4718,30 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.10(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -4075,6 +4834,84 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
   '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5)':
     dependencies:
       eslint: 9.39.5
@@ -4120,6 +4957,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.8.0':
     dependencies:
@@ -4449,6 +5288,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.6.0
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -4513,6 +5355,93 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.18
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.3.0
+    optionalDependencies:
+      react: 19.2.8
+      react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1)
+
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
@@ -4526,6 +5455,10 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -4628,6 +5561,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/graceful-fs@4.1.9':
@@ -4676,6 +5616,8 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/web-push@3.6.4':
     dependencies:
@@ -4847,6 +5789,48 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@20.19.43))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@20.19.43)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@zag-js/accordion@1.43.3':
     dependencies:
@@ -5562,6 +6546,8 @@ snapshots:
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -5645,6 +6631,10 @@ snapshots:
 
   baseline-browser-mapping@2.11.20: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   bignumber.js@9.3.1: {}
 
   bn.js@4.12.5: {}
@@ -5686,6 +6676,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -5711,12 +6703,22 @@ snapshots:
 
   caniuse-lite@1.0.30001810: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   char-regex@1.0.2: {}
+
+  check-error@2.1.3: {}
 
   ci-info@3.9.0: {}
 
@@ -5785,6 +6787,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css.escape@1.5.1: {}
 
   cssom@0.3.8: {}
@@ -5804,6 +6811,13 @@ snapshots:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -5840,6 +6854,8 @@ snapshots:
   dedent@1.7.2(babel-plugin-macros@3.1.0):
     optionalDependencies:
       babel-plugin-macros: 3.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -5903,6 +6919,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -5995,6 +7013,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -6018,6 +7038,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -6229,6 +7278,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   execa@5.1.1:
@@ -6244,6 +7297,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   exit@0.1.2: {}
+
+  expect-type@1.4.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -6516,6 +7571,12 @@ snapshots:
     dependencies:
       whatwg-encoding: 2.0.0
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   http-proxy-agent@5.0.0:
@@ -6555,6 +7616,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.7: {}
+
+  immer@11.1.18: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -7093,6 +8156,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
@@ -7134,6 +8199,32 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.10(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -7210,6 +8301,10 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -7219,6 +8314,10 @@ snapshots:
       yallist: 4.0.0
 
   lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   make-dir@4.0.0:
     dependencies:
@@ -7231,6 +8330,8 @@ snapshots:
       tmpl: 1.0.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   merge-stream@2.0.0: {}
 
@@ -7457,6 +8558,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -7466,6 +8571,10 @@ snapshots:
   path-parse@1.0.7: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   perfect-freehand@1.2.3: {}
 
@@ -7484,6 +8593,12 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.26:
     dependencies:
       nanoid: 3.3.18
       picocolors: 1.1.1
@@ -7569,12 +8684,27 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      redux: 5.0.1
+
   react@19.2.8: {}
 
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -7598,7 +8728,11 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   requires-port@1.0.0: {}
+
+  reselect@5.3.0: {}
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -7629,6 +8763,38 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rollup@4.63.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.63.1
+      '@rollup/rollup-android-arm64': 4.63.1
+      '@rollup/rollup-darwin-arm64': 4.63.1
+      '@rollup/rollup-darwin-x64': 4.63.1
+      '@rollup/rollup-freebsd-arm64': 4.63.1
+      '@rollup/rollup-freebsd-x64': 4.63.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.63.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.63.1
+      '@rollup/rollup-linux-arm64-gnu': 4.63.1
+      '@rollup/rollup-linux-arm64-musl': 4.63.1
+      '@rollup/rollup-linux-loong64-gnu': 4.63.1
+      '@rollup/rollup-linux-loong64-musl': 4.63.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.63.1
+      '@rollup/rollup-linux-ppc64-musl': 4.63.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.63.1
+      '@rollup/rollup-linux-riscv64-musl': 4.63.1
+      '@rollup/rollup-linux-s390x-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-musl': 4.63.1
+      '@rollup/rollup-openbsd-x64': 4.63.1
+      '@rollup/rollup-openharmony-arm64': 4.63.1
+      '@rollup/rollup-win32-arm64-msvc': 4.63.1
+      '@rollup/rollup-win32-ia32-msvc': 4.63.1
+      '@rollup/rollup-win32-x64-gnu': 4.63.1
+      '@rollup/rollup-win32-x64-msvc': 4.63.1
+      fsevents: 2.3.3
 
   run-parallel@1.2.0:
     dependencies:
@@ -7759,6 +8925,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   sirv@2.0.4:
@@ -7791,6 +8959,10 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7877,6 +9049,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   styled-jsx@5.1.6(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react@19.2.8):
     dependencies:
       client-only: 0.0.1
@@ -7905,10 +9081,26 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.7)
       picomatch: 4.0.7
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@7.4.11: {}
+
+  tldts@7.4.11:
+    dependencies:
+      tldts-core: 7.4.11
 
   tmpl@1.0.5: {}
 
@@ -7925,9 +9117,17 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.11
+
   tr46@0.0.3: {}
 
   tr46@3.0.0:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
 
@@ -8048,6 +9248,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@8.10.0: {}
+
   universalify@0.2.0: {}
 
   unrs-resolver@1.12.2:
@@ -8096,6 +9298,10 @@ snapshots:
 
   url-template@2.0.8: {}
 
+  use-sync-external-store@1.6.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
   uuid@11.1.1: {}
 
   uuid@9.0.1: {}
@@ -8108,9 +9314,88 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  vite-node@3.2.4(@types/node@20.19.43):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@20.19.43)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@20.19.43):
+    dependencies:
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+      postcss: 8.5.26
+      rollup: 4.63.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.43
+      fsevents: 2.3.3
+
+  vitest@3.2.7(@types/node@20.19.43)(jsdom@30.0.1):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@20.19.43))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@20.19.43)
+      vite-node: 3.2.4(@types/node@20.19.43)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.43
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   w3c-xmlserializer@4.0.0:
     dependencies:
       xml-name-validator: 4.0.0
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   walker@1.0.8:
     dependencies:
@@ -8129,6 +9414,8 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
+
+  webidl-conversions@8.0.1: {}
 
   webpack-bundle-analyzer@4.10.1:
     dependencies:
@@ -8155,10 +9442,28 @@ snapshots:
 
   whatwg-mimetype@3.0.0: {}
 
+  whatwg-mimetype@5.0.0: {}
+
   whatwg-url@11.0.0:
     dependencies:
       tr46: 3.0.0
       webidl-conversions: 7.0.0
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -8210,6 +9515,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wordwrap@1.0.0: {}
@@ -8232,6 +9542,8 @@ snapshots:
   ws@8.21.3: {}
 
   xml-name-validator@4.0.0: {}
+
+  xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ importers:
         specifier: ^19
         version: 19.2.5(@types/react@19.2.18)
       jsdom:
-        specifier: ^30.0.1
-        version: 30.0.1
+        specifier: ^26.1.0
+        version: 26.1.0
       react:
         specifier: ^19.0.0
         version: 19.2.8
@@ -162,16 +162,19 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@20.19.43)(jsdom@30.0.1)
+        version: 3.2.7(@types/node@20.19.43)(jsdom@26.1.0)
 
   packages/core:
     devDependencies:
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       typescript:
         specifier: ^5
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@20.19.43)(jsdom@30.0.1)
+        version: 3.2.7(@types/node@20.19.43)(jsdom@26.1.0)
 
 packages:
 
@@ -184,13 +187,8 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  '@asamuzakjp/css-color@6.0.7':
-    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
-    engines: {node: ^22.13.0 || >=24.0.0}
-
-  '@asamuzakjp/dom-selector@8.3.2':
-    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
-    engines: {node: ^22.13.0 || >=24.0.0}
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -361,10 +359,6 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@bramus/specificity@2.4.2':
-    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
-    hasBin: true
-
   '@chakra-ui/react@3.37.0':
     resolution: {integrity: sha512-TaFju5LTT7GEZ8brcyZOhM7fNN54tJ/rMaMFvUAD7UE8tsUJb/j3zCUYPjchkoVXD1vinXtN9S31cp2QcOTUPg==}
     peerDependencies:
@@ -376,41 +370,33 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@csstools/color-helpers@6.1.1':
-    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
-    engines: {node: '>=20.19.0'}
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
 
-  '@csstools/css-calc@3.3.0':
-    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
-    engines: {node: '>=20.19.0'}
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^4.0.0
-      '@csstools/css-tokenizer': ^4.0.0
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
 
-  '@csstools/css-color-parser@4.2.2':
-    resolution: {integrity: sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==}
-    engines: {node: '>=20.19.0'}
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^4.0.0
-      '@csstools/css-tokenizer': ^4.0.0
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
 
-  '@csstools/css-parser-algorithms@4.0.0':
-    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
-    engines: {node: '>=20.19.0'}
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@csstools/css-tokenizer': ^4.0.0
+      '@csstools/css-tokenizer': ^3.0.4
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.10':
-    resolution: {integrity: sha512-xBja6gaAaH2R2c7eNyl0TY4dhnnZ2uhj+KXpLdEQ6M/wuk9bYFZM8wY0ykw3VO4TgEJ56KGlerXS/9KBKVR/Cg==}
-    peerDependencies:
-      css-tree: ^3.2.1
-    peerDependenciesMeta:
-      css-tree:
-        optional: true
-
-  '@csstools/css-tokenizer@4.0.0':
-    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
-    engines: {node: '>=20.19.0'}
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -665,15 +651,6 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@exodus/bytes@1.15.1':
-    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@noble/hashes': ^1.8.0 || ^2.0.0
-    peerDependenciesMeta:
-      '@noble/hashes':
-        optional: true
 
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
@@ -1974,9 +1951,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  bidi-js@1.0.3:
-    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
-
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -2128,10 +2102,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-tree@3.2.1:
-    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
-    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
-
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -2145,6 +2115,10 @@ packages:
     resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
     engines: {node: '>=8'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2155,9 +2129,9 @@ packages:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
 
-  data-urls@7.0.0:
-    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2290,10 +2264,6 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
-
-  entities@8.0.0:
-    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
-    engines: {node: '>=20.19.0'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -2727,9 +2697,9 @@ packages:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
 
-  html-encoding-sniffer@6.0.0:
-    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2737,6 +2707,10 @@ packages:
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   http_ece@1.2.0:
     resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
@@ -3128,11 +3102,11 @@ packages:
       canvas:
         optional: true
 
-  jsdom@30.0.1:
-    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
-    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
     peerDependencies:
-      canvas: ^3.2.3
+      canvas: ^3.0.0
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -3222,9 +3196,8 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
-  lru-cache@11.5.2:
-    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
-    engines: {node: 20 || >=22}
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -3253,9 +3226,6 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-
-  mdn-data@2.27.1:
-    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3489,9 +3459,6 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
-  parse5@8.0.1:
-    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
-
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3676,10 +3643,6 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
-
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -3723,6 +3686,9 @@ packages:
     resolution: {integrity: sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3979,11 +3945,11 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.4.11:
-    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
-  tldts@7.4.11:
-    resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
   tmpl@1.0.5:
@@ -4001,8 +3967,8 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
-  tough-cookie@6.0.2:
-    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
 
   tr46@0.0.3:
@@ -4012,9 +3978,9 @@ packages:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
 
-  tr46@6.0.0:
-    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
-    engines: {node: '>=20'}
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -4121,10 +4087,6 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
-    engines: {node: '>=22.19.0'}
 
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
@@ -4268,10 +4230,6 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  webidl-conversions@8.0.1:
-    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
-    engines: {node: '>=20'}
-
   webpack-bundle-analyzer@4.10.1:
     resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
     engines: {node: '>= 10.13.0'}
@@ -4282,25 +4240,26 @@ packages:
     engines: {node: '>=12'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
-  whatwg-mimetype@5.0.0:
-    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
-    engines: {node: '>=20'}
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@11.0.0:
     resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
     engines: {node: '>=12'}
 
-  whatwg-url@16.0.1:
-    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  whatwg-url@17.1.0:
-    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
-    engines: {node: ^22.14.0 || >=24.0.0}
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4492,20 +4451,13 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@asamuzakjp/css-color@6.0.7':
+  '@asamuzakjp/css-color@3.2.0':
     dependencies:
-      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.2.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-tokenizer': 4.0.0
-      lru-cache: 11.5.2
-
-  '@asamuzakjp/dom-selector@8.3.2':
-    dependencies:
-      bidi-js: 1.0.3
-      css-tree: 3.2.1
-      is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.5.2
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -4698,10 +4650,6 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@bramus/specificity@2.4.2':
-    dependencies:
-      css-tree: 3.2.1
-
   '@chakra-ui/react@3.37.0(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@ark-ui/react': 5.39.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -4719,29 +4667,25 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@csstools/color-helpers@6.1.1': {}
+  '@csstools/color-helpers@5.1.0': {}
 
-  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
-      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/css-color-parser@4.2.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
-      '@csstools/color-helpers': 6.1.1
-      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
-      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.10(css-tree@3.2.1)':
-    optionalDependencies:
-      css-tree: 3.2.1
-
-  '@csstools/css-tokenizer@4.0.0': {}
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -4957,8 +4901,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
-
-  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.8.0':
     dependencies:
@@ -6631,10 +6573,6 @@ snapshots:
 
   baseline-browser-mapping@2.11.20: {}
 
-  bidi-js@1.0.3:
-    dependencies:
-      require-from-string: 2.0.2
-
   bignumber.js@9.3.1: {}
 
   bn.js@4.12.5: {}
@@ -6787,11 +6725,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-tree@3.2.1:
-    dependencies:
-      mdn-data: 2.27.1
-      source-map-js: 1.2.1
-
   css.escape@1.5.1: {}
 
   cssom@0.3.8: {}
@@ -6801,6 +6734,11 @@ snapshots:
   cssstyle@2.3.0:
     dependencies:
       cssom: 0.3.8
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -6812,12 +6750,10 @@ snapshots:
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
 
-  data-urls@7.0.0:
+  data-urls@5.0.0:
     dependencies:
-      whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
-    transitivePeerDependencies:
-      - '@noble/hashes'
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -6919,8 +6855,6 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   entities@6.0.1: {}
-
-  entities@8.0.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -7571,11 +7505,9 @@ snapshots:
     dependencies:
       whatwg-encoding: 2.0.0
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@4.0.0:
     dependencies:
-      '@exodus/bytes': 1.15.1
-    transitivePeerDependencies:
-      - '@noble/hashes'
+      whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
 
@@ -7583,6 +7515,13 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.1
       agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -8200,31 +8139,32 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@30.0.1:
+  jsdom@26.1.0:
     dependencies:
-      '@asamuzakjp/css-color': 6.0.7
-      '@asamuzakjp/dom-selector': 8.3.2
-      '@bramus/specificity': 2.4.2
-      '@csstools/css-syntax-patches-for-csstree': 1.1.10(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.1
-      css-tree: 3.2.1
-      data-urls: 7.0.0
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.5.2
-      parse5: 8.0.1
+      nwsapi: 2.2.27
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 6.0.2
-      undici: 8.10.0
+      tough-cookie: 5.1.2
       w3c-xmlserializer: 5.0.0
-      webidl-conversions: 8.0.1
-      whatwg-mimetype: 5.0.0
-      whatwg-url: 17.1.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.3
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
-      - '@noble/hashes'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -8303,7 +8243,7 @@ snapshots:
 
   loupe@3.2.1: {}
 
-  lru-cache@11.5.2: {}
+  lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -8330,8 +8270,6 @@ snapshots:
       tmpl: 1.0.5
 
   math-intrinsics@1.1.0: {}
-
-  mdn-data@2.27.1: {}
 
   merge-stream@2.0.0: {}
 
@@ -8558,10 +8496,6 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
-  parse5@8.0.1:
-    dependencies:
-      entities: 8.0.0
-
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -8728,8 +8662,6 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2: {}
-
   requires-port@1.0.0: {}
 
   reselect@5.3.0: {}
@@ -8795,6 +8727,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.63.1
       '@rollup/rollup-win32-x64-msvc': 4.63.1
       fsevents: 2.3.3
+
+  rrweb-cssom@0.8.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -9096,11 +9030,11 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tldts-core@7.4.11: {}
+  tldts-core@6.1.86: {}
 
-  tldts@7.4.11:
+  tldts@6.1.86:
     dependencies:
-      tldts-core: 7.4.11
+      tldts-core: 6.1.86
 
   tmpl@1.0.5: {}
 
@@ -9117,9 +9051,9 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
-  tough-cookie@6.0.2:
+  tough-cookie@5.1.2:
     dependencies:
-      tldts: 7.4.11
+      tldts: 6.1.86
 
   tr46@0.0.3: {}
 
@@ -9127,7 +9061,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tr46@6.0.0:
+  tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
 
@@ -9248,8 +9182,6 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@8.10.0: {}
-
   universalify@0.2.0: {}
 
   unrs-resolver@1.12.2:
@@ -9347,7 +9279,7 @@ snapshots:
       '@types/node': 20.19.43
       fsevents: 2.3.3
 
-  vitest@3.2.7(@types/node@20.19.43)(jsdom@30.0.1):
+  vitest@3.2.7(@types/node@20.19.43)(jsdom@26.1.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
@@ -9374,7 +9306,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.43
-      jsdom: 30.0.1
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -9415,8 +9347,6 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webidl-conversions@8.0.1: {}
-
   webpack-bundle-analyzer@4.10.1:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
@@ -9440,30 +9370,23 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-mimetype@3.0.0: {}
 
-  whatwg-mimetype@5.0.0: {}
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@11.0.0:
     dependencies:
       tr46: 3.0.0
       webidl-conversions: 7.0.0
 
-  whatwg-url@16.0.1:
+  whatwg-url@14.2.0:
     dependencies:
-      '@exodus/bytes': 1.15.1
-      tr46: 6.0.0
-      webidl-conversions: 8.0.1
-    transitivePeerDependencies:
-      - '@noble/hashes'
-
-  whatwg-url@17.1.0:
-    dependencies:
-      '@exodus/bytes': 1.15.1
-      tr46: 6.0.0
-      webidl-conversions: 8.0.1
-    transitivePeerDependencies:
-      - '@noble/hashes'
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:


### PR DESCRIPTION
> 🟥 **Ichigo · Substitute** — the local plane, entire · *local, on your creds · I open PRs for **you** to merge (I never merge `main`, never review my own work)*
> Authored locally in a Claude Code session on behalf of @zheref — no CI run. Canon read at `zheref/bankai-core@eb4ac93` (`handbooks/stacks/react-uzf-v1`, rules `00`–`11`).

Closes #5

# What this changes for you

Every feature you build from here on has one place to put each thing, and the wrong place stops compiling.

State lives in a slice. Effects live in a Producer. Failures are a typed `Exception`, never a raw `Error`. Services arrive through one injected manifest, so a component *cannot* fetch — not "shouldn't", *cannot*: `pnpm --filter @kro/app lint` fails the build on a `react-redux` import outside `library/hooks.ts`, a second `configureStore`, a `fetch` outside `services/`, or a Service imported anywhere but the manifest. Tests get a real store with stubbed services in one line — `makeStore(stubbedThunkExtra)` — and nothing in the suite can reach the network.

Nothing user-visible ships here. This is the floor the Endeavor domain (#7), the session tier (#8) and every feature child (#16+) stand on, and it is the first realization of bankai-core's `react-uzf-v1` canon in any repo, so the shapes below are the precedent.

## What changed

**`packages/core` — the platform-free half** (no `react`, no DOM, no Node; `lib: ["ES2022"]`, `types: []`)

| Artifact | Realizes |
|---|---|
| `src/library/result.ts` — `Result<T, E>`, `ok`, `err`, `isOk`, `isErr` | `RC-7` — the sole Producer→Reducer contract |
| `src/library/exception.ts` — `Exception<Kind>`, `exception()`, `unknownException()`, `toUnknownException()` | `RC-8`, `RC-26` |
| `src/library/assertNever.ts` | `RC-9` |
| `src/models/Greeting.ts`, `GreetingResponse.ts` | `UZF-8`, `UZF-17` — domain and wire types never mix |
| `src/models/GreetingException.ts` — closed union + factories + per-kind copy closed by `assertNever` | `RC-8`, `RC-9` |
| `src/models/GreetingMapper.ts` — `toDomain` / `fromDomain` / `toException` | `RC-30` |
| `src/models/__mocks__/Greeting.mocks.ts` — 7 variants, exported as `@kro/core/mocks` | `RC-13` |
| `vitest.config.ts` + `test` script — node environment, `globals: false` | `RC-53` |

**`packages/app` — the wired half**

| Artifact | Realizes |
|---|---|
| `src/library/store.ts` — `makeStore(extra)`, the only `configureStore` call in the repo | `RC-22` |
| …its `ThunkExtra` interface + `liveThunkExtra` / `stubbedThunkExtra` | `RC-21`, `RC-6` |
| …its `reducer` map — one line per feature | `RC-23`, `RC-1`, `RC-20` |
| `src/library/hooks.ts` — `useAppSelector` / `useAppDispatch` | `RC-10` |
| `src/library/StoreProvider.tsx` — takes a store instance, never builds one | `RC-22`, `RC-63` |
| `src/services/greeting/GreetingService.ts` + `greeting.fixtures.json` — interface, `live…`, `stubbed…` | `RC-6`, `RC-33`, `RC-59` |
| `src/features/greeting/GreetingFeature.ts` — one slice, `load` as a single discriminated lifecycle field, `userDid…` / `on…` / `child…Delegated…` events | `RC-1`, `RC-2`, `RC-24`, `RC-36` |
| `src/features/greeting/GreetingShifters.ts` — pure `with…(state, args)` | `RC-4`, `RC-19` |
| `src/features/greeting/GreetingSelectors.ts` — `createSelector`, `RootState` in | `RC-5` |
| `src/features/greeting/GreetingProducer.ts` — `createAsyncThunk` resolving `Result`, never throwing | `RC-3`, `RC-7`, `RC-25`, `RC-26` |
| `src/features/greeting/GreetingMocks.ts` — canned `State` variants | `UZF-18` |
| `src/features/greeting/useGreeting.ts` — the headless stateful wrapper closing the loop | `UZF-4`, `RC-10` |
| `scripts/check-uzf-boundaries.mjs`, wired as the `lint` task | `RC-1`, `RC-3`, `RC-5`, `RC-6`, `RC-10`, `RC-21`, `RC-22`, `RC-50` |
| `vitest.config.ts` + `test` script — jsdom, `globals: false` | `RC-53` |

**Dependencies** — `@reduxjs/toolkit` + `react-redux` (runtime) and `vitest`, `jsdom`, `@testing-library/react`, `react`/`react-dom` + types (dev) added to `packages/app/package.json`; `vitest` added to `packages/core/package.json`. Root `package.json`, `turbo.json`, the `Makefile` and `apps/web/**` are untouched — only `pnpm-lock.yaml` changed outside `packages/`.

**Tests** — 119 new tests, all passing: 44 in `@kro/core`, 75 in `@kro/app`. ≥3 per exported primitive, per reducer arm, per Shifter, per Selector and for the Producer, each named as a real-world scenario (`UZF-20`). Every store in every test is built by `makeStore(stubbedExtra)`; no test mocks `fetch` or an interceptor, and two tests assert `globalThis.fetch` was never called.

## How to verify

```bash
git fetch origin && git checkout ichigo/5-uzf-state-foundation
corepack enable && pnpm install
```

| Command | Expected |
|---|---|
| `pnpm --filter @kro/core test` | `Test Files 5 passed (5)` · `Tests 44 passed (44)` |
| `pnpm --filter @kro/app test` | `Test Files 8 passed (8)` · `Tests 75 passed (75)` |
| `pnpm --filter @kro/core lint` | `@kro/core is platform-free: no react/next/DOM/Node imports or globals.` (exit 0) |
| `pnpm --filter @kro/app lint` | `@kro/app holds its UZF boundaries: one store, one hooks surface, services behind DI.` (exit 0) |
| `pnpm -r exec tsc --noEmit` | no output, exit 0 — all four workspace members, `strict` + `noUncheckedIndexedAccess` |
| `pnpm turbo run test` | `Tasks: 3 successful, 3 total` (core, app, and `apps/web`'s untouched 41 Jest tests) |
| `pnpm turbo run build` | `Tasks: 1 successful, 1 total` — `apps/web` still builds |

**Prove the boundary check actually bites** (this is acceptance criterion 2 — "no service importable outside `ThunkExtra`"):

```bash
cat > packages/app/src/features/greeting/Probe.ts <<'EOF'
import { configureStore } from '@reduxjs/toolkit'
import { useSelector } from 'react-redux'
import { stubbedGreetingService } from '../../services/greeting/GreetingService'
export const probe = [configureStore, useSelector, stubbedGreetingService, fetch('/x')]
EOF
pnpm --filter @kro/app lint    # exits 1, naming RC-22, RC-10, RC-6/RC-21 and RC-3
rm packages/app/src/features/greeting/Probe.ts
```

**Read the loop in one pass** — `GreetingProducer.ts` → `GreetingFeature.ts`'s `extraReducers` → `GreetingShifters.ts` → `GreetingSelectors.ts` → `useGreeting.ts` is the whole architecture in five short files; `__tests__/useGreeting.test.tsx` drives it end to end against the stub.

`pnpm turbo run lint` is still red overall — `apps/web`'s pre-existing ESLint `semi` backlog, documented in `TOOLCHAIN.md` and cleared by #3's Biome swap. Both packages I own are green.

## Notes

**The demo `greeting` feature is scaffolding.** Every file in it carries a `SCAFFOLDING —` header. It exists to prove the loop runs and to give feature children a worked reference in this repo's own idiom; #7/#16+ delete it as real slices land. It ships no Kro business behaviour, which is also why no KroApple canon was consulted for this child — there is nothing here to be in parity with.

**RC rules I had to interpret.** This repo binds the precedent, so each one is stated plainly:

1. **`library/` is split across two packages** (`RC-50`, `02-store-setup` §1 put all four files in `{{CORE_PACKAGE}}`). `packages/core` compiles with `lib: ["ES2022"]`, `types: []` and a name-based platform check landed by #2 — `store.ts` is fine there, but `hooks.ts` imports `react-redux`, which is not. Rather than fork the runtime across a boundary mid-module, `Result`/`Exception`/`assertNever` stayed in core and `store.ts`/`hooks.ts`/`StoreProvider.tsx` went to `packages/app`. There is still exactly one `makeStore` and exactly one hooks module, so `RC-22` and `RC-10` hold in substance; only the address moved.
2. **The state quartet lives in `packages/app/src/features/<feature>/`**, not core (`RC-49`, `RC-50` say core owns every slice/Shifter/Selector/Producer). It follows from (1) — a Selector takes `RootState`, which is defined beside the store — and it matches the file lane epic #1 already declared for feature children (`packages/app/src/features/<feature>/**`).
3. **Services live in `packages/app/src/services/`**, not core. A `live…Service` needs `fetch` and `AbortSignal`; neither has typings in core. `RC-48` splits only the `live…` half by platform, but this is Scenario 5 — one platform — so the whole pair sits in app and the stub stays single-sourced. Related open question: zheref/bankai-core#900 (`RC-49` fixes a four-member topology including `apps/mobile`; this repo has three).
4. **`Exception<Kind>` as a shared base.** Canon shows per-feature unions but never names the member shape; `{ kind, message, recoverable }` is lifted from canon's own `.rejected` example. It is generic and product-free, so it stays `library`-legal.
5. **`.rejected` returns early on `action.meta.aborted`.** `RC-26` says the arm routes into the exception Shifter; `RC-3` rule 4 says cancellation is the only silent exit. Read literally, the first would paint an exception every time a surface unmounts mid-request. Resolved in favour of `RC-3` — the abort case is not a failure. This is the one place I would most like a second opinion.
6. **`useDispatch.withTypes<AppDispatch>()`** rather than canon's `TypedUseSelectorHook` annotation — the react-redux 9 replacement, and the only form that types the thunk dispatch overload.
7. **The serializable check accepts `Date`, and nothing else.** `RC-24`/`UZF-8` want real domain types in state, and RTK's default check rejects `Date`. Widened by predicate in `makeStore`; class instances, functions and promises still fail it. #7's Endeavor model will lean on this.
8. **Mocks reach consumers as `@kro/core/mocks`.** `RC-13` says "build-excluded", but workspace packages here are consumed as TypeScript source with no build step, so a subpath export is the equivalent: importing test data is explicit and greppable, and the main barrel never carries it.
9. **The headless hook is `use<Feature>.ts`**, a suffix `RC-49`'s table does not list. It is the logic half of the `UZF-4` stateful wrapper, standing in until the Page/Fragment arrive with #6/#13.
10. **No Storybook stories (`RC-11`)** — there is no Page/Fragment yet and no Storybook in the repo; #6 owns both. **No coverage floor wired (`UZF-19`)** — the repo-wide harness belongs to #3, which is in flight.
11. **New domain went to `models/`** (canon) while the legacy `packages/core/src/model/Session/**` predates the handbook; reconciling the two folders belongs to #7/#8, not here.

**Lane discipline.** Only `packages/core/**`, `packages/app/**` and `pnpm-lock.yaml` are touched. `apps/web/**` is untouched, so the parallel Jest→Vitest migration on it will not conflict; `TOOLCHAIN.md`'s "what is green today" table now understates the test count, and updating it belongs to whoever owns root.

Bankai-Agent: ichigo
