### PR TITLE
feat(do): lane partition, featured scoring, rings and clear-expired

### DIFF
--- a/packages/app/src/features/do/DoException.ts
+++ b/packages/app/src/features/do/DoException.ts
@@ -1,0 +1,67 @@
+/**
+ * The Do surface's typed failure union (`RC-8`, `UZF-8`).
+ *
+ * Canon declares three separate enums at the head of `Kro/Application/Do/
+ * DoProducer.swift` — `DoTuningException`, `DoClearExpiredException` and
+ * `DoEndeavorsFetchException`. They are folded into **one** union here for the
+ * reason `RC-24` gives: the slice carries a single `load` lifecycle field, and
+ * a field typed as a union of three unions would let a reader believe a
+ * clear-expired failure and a fetch failure can coexist. One union, one
+ * `kind` discriminant, one exhaustive `switch` (`RC-9`).
+ *
+ * Every member keeps canon's own copy verbatim, and `recoverable` says whether
+ * the surface should offer a retry — the two mutation failures are recoverable
+ * (the user can try again), a malformed persisted row is not (retrying reads
+ * the same bad row).
+ */
+import { type Exception, exception } from '@kro/core'
+
+export type DoException =
+  /** Reading the Do preferences failed. Canon `DoTuningException.loadFailed`. */
+  | Exception<'preferencesLoadFailed'>
+  /** The whole-day read failed. Canon `DoEndeavorsFetchException.loadFailed`. */
+  | Exception<'fetchFailed'>
+  /** Clear Expired could not close every target. Canon `.mutationFailed`. */
+  | Exception<'clearExpiredMutationFailed'>
+  /** Targets closed, but the follow-up refetch failed. Canon `.refreshFailed`. */
+  | Exception<'clearExpiredRefreshFailed'>
+  /** Persisting one completion failed. */
+  | Exception<'markCompleteFailed'>
+  /** The completed endeavor is not in the pool — a stale card key. */
+  | Exception<'endeavorNotFound'>
+  /** The defensive `.rejected` fallback's landing shape (`RC-26`). */
+  | Exception<'unknown'>
+
+export const DoExceptions = {
+  preferencesLoadFailed: (reason: string): DoException =>
+    exception(
+      'preferencesLoadFailed',
+      `Couldn't load your Do preferences: ${reason}`,
+      true,
+    ),
+
+  fetchFailed: (reason: string): DoException =>
+    exception('fetchFailed', `Couldn't refresh the Do screen: ${reason}`, true),
+
+  clearExpiredMutationFailed: (): DoException =>
+    exception(
+      'clearExpiredMutationFailed',
+      "Couldn't clear every expired endeavor.",
+      true,
+    ),
+
+  clearExpiredRefreshFailed: (): DoException =>
+    exception(
+      'clearExpiredRefreshFailed',
+      "Expired endeavors were cleared, but today's occurrences couldn't be refreshed.",
+      true,
+    ),
+
+  markCompleteFailed: (reason: string): DoException =>
+    exception('markCompleteFailed', `Couldn't save that completion: ${reason}`, true),
+
+  endeavorNotFound: (id: string): DoException =>
+    exception('endeavorNotFound', `No endeavor with id '${id}' is on the Do surface.`, false),
+
+  unknown: (message: string): DoException => exception('unknown', message, true),
+} as const

--- a/packages/app/src/features/do/DoFeature.ts
+++ b/packages/app/src/features/do/DoFeature.ts
@@ -216,6 +216,7 @@ export const doSlice = createSlice({
       state,
       action: PayloadAction<{ capacity: FeaturedNowCapacity }>,
     ) {
+      if (state.featuredCapacity === action.payload.capacity) return
       state.featuredCapacity = action.payload.capacity
     },
 

--- a/packages/app/src/features/do/DoFeature.ts
+++ b/packages/app/src/features/do/DoFeature.ts
@@ -1,0 +1,478 @@
+/**
+ * The Do surface's slice — the daily execution surface's business rules
+ * (`RC-1`, `RC-2`, `RC-24`, `RC-36`), ported from `DoFeature`
+ * (`Kro/Application/Do/DoFeature.swift`).
+ *
+ * Do is **one vista** (`EndeavorsVistas.doTab`), fetched once, reconciled once
+ * and partitioned in memory: there is no per-lane query. Every lane, the
+ * featured hero, the rings and the counts fall out of that single snapshot.
+ *
+ * ## The clock never comes from here
+ *
+ * No reducer, Shifter or Selector in this feature reads `Date.now()` or
+ * constructs a `Date`. Every event that needs the current instant carries
+ * `now` in its payload, and every Producer takes it as an argument (`RC-4`:
+ * *"if a Shifter genuinely needs the current time or an id, pass it in"*).
+ * That is what makes a midnight-boundary case a plain unit test rather than a
+ * mocked global, and it is why `clockAnchor` exists: the reducer parks the
+ * instant it last partitioned against so the pure ring Selectors can answer
+ * without consulting a clock themselves. Canon does exactly this, for exactly
+ * this reason.
+ *
+ * ## Why `load` is one field and the pool is not inside it
+ *
+ * `RC-24` requires one discriminated lifecycle field, never `isLoading` +
+ * `exception` in parallel — so `load` is that field. The day's endeavors sit
+ * **beside** it rather than inside its `loaded` case, because canon keeps the
+ * retained day usable through a failed refresh (*"existing data is kept; only
+ * the loading flag clears"*). A `loaded`-carries-the-data union could not
+ * represent "showing yesterday's good snapshot, and the refresh just failed"
+ * without throwing the snapshot away.
+ */
+import type { Endeavor } from '@kro/core'
+import { type PayloadAction, createSlice } from '@reduxjs/toolkit'
+import type { DoException } from './DoException'
+import { DoExceptions } from './DoException'
+import type { FeaturedNowCapacity } from './DoFeaturedNow'
+import {
+  clearExpiredThunk,
+  fetchDoEndeavorsThunk,
+  loadDoPreferencesThunk,
+  markEndeavorCompleteThunk,
+} from './DoProducer'
+import {
+  type DoLane,
+  type DoLanes,
+  type DoVisibility,
+  emptyDoLanes,
+  initialDoVisibility,
+} from './DoRules'
+import {
+  withAutoAdvanced,
+  withBackdatingCancelled,
+  withBackdatingRequested,
+  withCardSelected,
+  withEndeavorsInstalled,
+  withException,
+  withFetchStarted,
+  withLoadedAt,
+  withMarkCompleteModeToggled,
+  withOptimisticallyCompleted,
+  withPreferencesApplied,
+  withScrollRequestHandled,
+  withSuggestionDismissed,
+  withSuggestionsRefreshed,
+  withVisibilityApplied,
+} from './DoShifters'
+import type { DoSuggestion, DoSuggestionSource } from './DoSuggestions'
+
+/** The one lifecycle field (`RC-24`, `UZF-9`). */
+export type DoLoadState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'loaded' }
+  | { readonly kind: 'failed'; readonly exception: DoException }
+
+/**
+ * The Do preferences and kill-switch flags, resolved together.
+ *
+ * Canon reads the three `do.*` options through `SettingsProvider` and the two
+ * flags through `featureFlags`, then AND's them at the point of use
+ * (`showSuggestions` with the preference, the Google nudge with the
+ * `googleCalendar` flag, the rings with `doActivityRings`). They travel as one
+ * value here because they are read in one pass and are meaningless apart.
+ */
+export interface DoPreferences {
+  /** `do.showSuggestions` — gates the Suggestions lane. Default on. */
+  readonly showSuggestions: boolean
+  /** `do.nowThresholdHours` — the Due Soon window. Default 2. */
+  readonly nowThresholdHours: number
+  /** `do.autoAdvanceAfterComplete` — default **off**; the preference is the gate. */
+  readonly autoAdvanceAfterComplete: boolean
+  /** The `doActivityRings` kill switch. */
+  readonly activityRingsEnabled: boolean
+  /** The `googleCalendar` flag — whether the connect nudge is offerable at all. */
+  readonly googleCalendarEnabled: boolean
+}
+
+/**
+ * The option defaults, so the first paint is already correct before the
+ * preference read lands — canon's own reasoning for seeding these.
+ *
+ * The two flags seed `false` rather than their baseline: canon starts
+ * `isActivityRingsEnabled = false` *"so the pre-flag-read first render never
+ * flashes them"*, and the same argument applies to a suggestion card.
+ */
+export const defaultDoPreferences: DoPreferences = {
+  showSuggestions: true,
+  nowThresholdHours: 2,
+  autoAdvanceAfterComplete: false,
+  activityRingsEnabled: false,
+  googleCalendarEnabled: false,
+}
+
+/**
+ * The pending completion the compact date/time popover is editing.
+ *
+ * State only — the popover itself is #17's. Canon carries the chosen instant
+ * as an argument on `userDidMarkCardComplete(_:completionDate:)`; holding it
+ * here is what lets the surface open the popover, let the user step the date,
+ * and confirm, without the view owning feature state (`UZF-4`).
+ */
+export interface DoBackdatedCompletion {
+  readonly endeavorId: string
+  readonly completionDate: Date
+}
+
+export interface DoState {
+  readonly load: DoLoadState
+
+  // --- the reconciled channels, as the last successful install left them ---
+  /** Canon's `allTasks`: the resolved task channel **plus** habits. */
+  readonly tasks: readonly Endeavor[]
+  /** Canon's `allHabits` — the rings' gold denominator. */
+  readonly habits: readonly Endeavor[]
+  /** Canon's `allReminders`. Only Completed Today and the tasks ring read it. */
+  readonly reminders: readonly Endeavor[]
+  /**
+   * Today's calendar events. Installed so the single fetch is not thrown away,
+   * but **not** grouped into a lane here: the all-day / timed carousel and its
+   * session-skip state are the events lane's own work and are not among this
+   * issue's deliverables.
+   */
+  readonly events: readonly Endeavor[]
+
+  // --- the regroup's output ---
+  readonly lanes: DoLanes
+
+  // --- user and environment state ---
+  readonly visibility: DoVisibility
+  readonly preferences: DoPreferences
+  /** Whether the user has linked their Google account. */
+  readonly isGoogleCalendarConnected: boolean
+  readonly suggestions: readonly DoSuggestion[]
+  readonly dismissedSuggestionSources: readonly DoSuggestionSource[]
+
+  /**
+   * The instant the lanes were last partitioned against, so the pure ring
+   * Selectors can answer without a clock. `null` until the first regroup, at
+   * which point every ring is absent — nothing has been classified yet.
+   */
+  readonly clockAnchor: Date | null
+
+  /** How many featured cards the current width can show: 3, 5, 7 or 9. */
+  readonly featuredCapacity: FeaturedNowCapacity
+
+  /** `"lane:endeavorId"` — the card in preparation mode, at most one. */
+  readonly selectedCardKey: string | null
+  /**
+   * One-shot: the renderer should bring the auto-advanced card into view.
+   * Set only alongside a fresh `selectedCardKey`, never by a manual tap.
+   */
+  readonly shouldScrollToCurrentCard: boolean
+  /** One-shot: the bell was tapped and Overdue should be scrolled to. */
+  readonly shouldScrollToOverdue: boolean
+
+  readonly isInMarkCompleteMode: boolean
+  readonly backdating: DoBackdatedCompletion | null
+}
+
+export const initialDoState: DoState = {
+  load: { kind: 'idle' },
+  tasks: [],
+  habits: [],
+  reminders: [],
+  events: [],
+  lanes: emptyDoLanes,
+  visibility: initialDoVisibility,
+  preferences: defaultDoPreferences,
+  isGoogleCalendarConnected: false,
+  suggestions: [],
+  dismissedSuggestionSources: [],
+  clockAnchor: null,
+  featuredCapacity: 3,
+  selectedCardKey: null,
+  shouldScrollToCurrentCard: false,
+  shouldScrollToOverdue: false,
+  isInMarkCompleteMode: false,
+  backdating: null,
+}
+
+export const doSlice = createSlice({
+  name: 'do',
+  initialState: initialDoState,
+  reducers: {
+    /** Lifecycle: the surface mounted, so classify the retained day against now. */
+    onViewLoaded(state, action: PayloadAction<{ now: Date }>) {
+      Object.assign(state, withLoadedAt(state, action.payload.now))
+    },
+
+    /**
+     * Lifecycle: the available width changed, so the featured lane may show a
+     * different odd count. One primitive field — the arrangement itself is
+     * untouched, which is what keeps the hero still across a resize.
+     */
+    onFeaturedCapacityChanged(
+      state,
+      action: PayloadAction<{ capacity: FeaturedNowCapacity }>,
+    ) {
+      state.featuredCapacity = action.payload.capacity
+    },
+
+    /** Lifecycle: the Google account was linked or unlinked elsewhere. */
+    onGoogleCalendarConnectionChanged(
+      state,
+      action: PayloadAction<{ isConnected: boolean }>,
+    ) {
+      Object.assign(
+        state,
+        withSuggestionsRefreshed({
+          ...state,
+          isGoogleCalendarConnected: action.payload.isConnected,
+        }),
+      )
+    },
+
+    /**
+     * The Visibility surface talking back with the user's new selection. Do
+     * owns no toggle semantics — it installs the selection and regroups, which
+     * is what keeps the filter sheet and this slice from drifting.
+     */
+    childVisibilityDelegatedSelectionChanged(
+      state,
+      action: PayloadAction<{ visibility: DoVisibility; now: Date }>,
+    ) {
+      Object.assign(
+        state,
+        withVisibilityApplied(
+          state,
+          action.payload.visibility,
+          action.payload.now,
+        ),
+      )
+    },
+
+    /** User intent: a short tap prepares a card, and a second tap un-prepares it. */
+    userDidTapCard(
+      state,
+      action: PayloadAction<{ lane: DoLane; endeavorId: string }>,
+    ) {
+      Object.assign(
+        state,
+        withCardSelected(state, action.payload.lane, action.payload.endeavorId),
+      )
+    },
+
+    /** User intent, single primitive field. */
+    userDidDeselectCard(state) {
+      state.selectedCardKey = null
+    },
+
+    /**
+     * User intent: enter or leave bulk mark-complete mode. Entering clears the
+     * preparation cursor — bulk mode has no single prepared card — and the
+     * rings hide while it is on.
+     */
+    userDidToggleMarkCompleteMode(state) {
+      Object.assign(state, withMarkCompleteModeToggled(state))
+    },
+
+    /**
+     * User intent: the attention bell. Canon refuses to arm the jump when
+     * Overdue is empty, so the control never scrolls to nothing.
+     */
+    userDidTapNotifications(state) {
+      if (state.lanes.overdue.length === 0) return
+      state.shouldScrollToOverdue = true
+    },
+
+    /** Lifecycle: the renderer performed the scroll, so the one-shots clear. */
+    onScrollRequestHandled(state) {
+      Object.assign(state, withScrollRequestHandled(state))
+    },
+
+    /** User intent: this nudge is not wanted. Dismissal is per source. */
+    userDidDismissSuggestion(
+      state,
+      action: PayloadAction<{ source: DoSuggestionSource }>,
+    ) {
+      Object.assign(state, withSuggestionDismissed(state, action.payload.source))
+    },
+
+    /**
+     * User intent: open (or re-aim) the compact completion date/time popover.
+     * Re-dispatching with a new instant is how the popover steps the date.
+     */
+    userDidRequestBackdatedCompletion(
+      state,
+      action: PayloadAction<{ endeavorId: string; completionDate: Date }>,
+    ) {
+      Object.assign(
+        state,
+        withBackdatingRequested(
+          state,
+          action.payload.endeavorId,
+          action.payload.completionDate,
+        ),
+      )
+    },
+
+    /** User intent: dismiss the popover without completing anything. */
+    userDidCancelBackdatedCompletion(state) {
+      Object.assign(state, withBackdatingCancelled(state))
+    },
+
+    /**
+     * User intent: confirm a completion, at the instant the popover carries.
+     *
+     * The shift is optimistic — canon closes the row in state, regroups and
+     * advances focus *before* the persist effect resolves, so the card leaves
+     * its lane the moment it is tapped. `markEndeavorCompleteThunk` then
+     * persists, and only its failure arm has anything left to say.
+     */
+    userDidMarkCardComplete(
+      state,
+      action: PayloadAction<{
+        endeavorId: string
+        completionDate: Date
+        now: Date
+      }>,
+    ) {
+      const { endeavorId, completionDate, now } = action.payload
+      const completed = withOptimisticallyCompleted(
+        state,
+        endeavorId,
+        completionDate,
+        now,
+      )
+      Object.assign(state, withAutoAdvanced(completed))
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // --- preferences + flags ------------------------------------------
+      .addCase(loadDoPreferencesThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(state, withPreferencesApplied(state, result.value))
+        } else {
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      .addCase(loadDoPreferencesThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withException(
+            state,
+            DoExceptions.unknown(action.error.message ?? 'Unknown error'),
+          ),
+        )
+      })
+
+      // --- the day's endeavors -------------------------------------------
+      .addCase(fetchDoEndeavorsThunk.pending, (state) => {
+        Object.assign(state, withFetchStarted(state))
+      })
+      .addCase(fetchDoEndeavorsThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(
+            state,
+            withEndeavorsInstalled(
+              state,
+              result.value.endeavors,
+              result.value.now,
+            ),
+          )
+        } else {
+          // Canon keeps the retained day usable and clears only the spinner.
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      .addCase(fetchDoEndeavorsThunk.rejected, (state, action) => {
+        // Cancellation is the one silent exit (`UZF-14`): a superseded refresh
+        // must never paint an exception over a day that is still good.
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withException(
+            state,
+            DoExceptions.unknown(action.error.message ?? 'Unknown error'),
+          ),
+        )
+      })
+
+      // --- Clear Expired --------------------------------------------------
+      .addCase(clearExpiredThunk.pending, (state) => {
+        Object.assign(state, withFetchStarted(state))
+      })
+      // The whole point of the arm: every provider mutation has already been
+      // awaited, and the refetched snapshot lands here in ONE install. No
+      // intermediate state is ever observable, so a half-cleared day cannot
+      // be painted (`DayProgressRings.md`: *"then refetches the Do query and
+      // atomically replaces the visible snapshot"*).
+      .addCase(clearExpiredThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(
+            state,
+            withEndeavorsInstalled(
+              state,
+              result.value.endeavors,
+              result.value.now,
+            ),
+          )
+        } else {
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      .addCase(clearExpiredThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withException(
+            state,
+            DoExceptions.unknown(action.error.message ?? 'Unknown error'),
+          ),
+        )
+      })
+
+      // --- one completion --------------------------------------------------
+      // No `.pending` arm on purpose: `userDidMarkCardComplete` has already
+      // moved the card out of its lane, and a spinner here would contradict
+      // that optimism. Only the failure has anything left to report.
+      .addCase(markEndeavorCompleteThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (!result.ok) {
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      .addCase(markEndeavorCompleteThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withException(
+            state,
+            DoExceptions.unknown(action.error.message ?? 'Unknown error'),
+          ),
+        )
+      })
+  },
+})
+
+export const {
+  childVisibilityDelegatedSelectionChanged,
+  onFeaturedCapacityChanged,
+  onGoogleCalendarConnectionChanged,
+  onScrollRequestHandled,
+  onViewLoaded,
+  userDidCancelBackdatedCompletion,
+  userDidDeselectCard,
+  userDidDismissSuggestion,
+  userDidMarkCardComplete,
+  userDidRequestBackdatedCompletion,
+  userDidTapCard,
+  userDidTapNotifications,
+  userDidToggleMarkCompleteMode,
+} = doSlice.actions

--- a/packages/app/src/features/do/DoFeaturedNow.ts
+++ b/packages/app/src/features/do/DoFeaturedNow.ts
@@ -1,0 +1,216 @@
+/**
+ * The featured "Now" lane — the port of `featuredNowScore` and
+ * `selectFeaturedNowTasks` (`Kro/Models/Endeavors.swift`, ~line 128), specified
+ * by `DoLanes.md` § 3 and `docs/Features/Do.md`'s *Responsive Now lane*.
+ *
+ * Two pure steps, deliberately kept apart the way canon keeps them apart so
+ * the ranking can be retuned without touching the layout:
+ *
+ * 1. **Score** every pending task/habit, drop the zeroes, rank.
+ * 2. **Arrange** the survivors hero-centred at an odd size, and take the
+ *    centred window the available width can show (3, 5, 7 or 9).
+ *
+ * ## The one deliberate change: the clock is a parameter
+ *
+ * Canon's `featuredNowScore` is a computed property that reads `Date()`
+ * internally, so the same endeavor scores differently on two consecutive
+ * reads and no test can pin a boundary. Here `now` is passed in, exactly as
+ * canon already does for `isDueNow(withinHours:now:)`. Nothing else about the
+ * weights, the thresholds or the ordering changes.
+ */
+import {
+  type Endeavor,
+  EndeavorStatus as Status,
+  type ReconciliationContext,
+  SECONDS_PER_HOUR,
+  defaultReconciliationContext,
+  hasBeenCompleted,
+} from '@kro/core'
+import { isActionableDoKind } from './DoRules'
+
+/** The odd card counts the responsive lane supports. */
+export const FEATURED_NOW_CAPACITIES = [3, 5, 7, 9] as const
+
+export type FeaturedNowCapacity = (typeof FEATURED_NOW_CAPACITIES)[number]
+
+/** Canon's hard ceiling — the lane never ranks more than nine. */
+export const FEATURED_NOW_MAX = 9
+
+/**
+ * The weights, verbatim from canon's table.
+ *
+ * | Factor | Weight |
+ * |---|---|
+ * | Overdue | +100 |
+ * | Due within 2h | +50 |
+ * | Due within 6h | +25 |
+ * | Has a due date at all | +10 |
+ * | Ongoing | +30 |
+ * | Has an estimated duration | +5 |
+ * | Reward points above the default | +3 |
+ */
+export const FEATURED_NOW_WEIGHTS = {
+  overdue: 100,
+  dueWithinTwoHours: 50,
+  dueWithinSixHours: 25,
+  hasDueDate: 10,
+  ongoing: 30,
+  hasDuration: 5,
+  aboveDefaultPoints: 3,
+} as const
+
+/** The two proximity thresholds, in hours. Fixed by canon, not the preference. */
+const IMMINENT_HOURS = 2
+const UPCOMING_HOURS = 6
+
+/** The reward-points bar canon nudges above. */
+const DEFAULT_SESSION_POINTS = 10
+
+/**
+ * `Endeavor.featuredNowScore`, with `now` injected.
+ *
+ * Zero means "no relevance to now" and is the exclusion signal the selection
+ * below acts on. Note the proximity thresholds are canon's own 2h / 6h
+ * constants, **not** `do.nowThresholdHours`: the preference moves the Due Soon
+ * *lane* boundary, and canon never wires it into the score.
+ */
+export const featuredNowScore = (
+  endeavor: Endeavor,
+  now: Date,
+  context: ReconciliationContext = defaultReconciliationContext(),
+): number => {
+  if (!isActionableDoKind(endeavor, context)) return 0
+  if (hasBeenCompleted(endeavor)) return 0
+
+  let score = 0
+
+  const due = endeavor.due
+  if (due !== null) {
+    if (due.getTime() < now.getTime()) {
+      score += FEATURED_NOW_WEIGHTS.overdue
+    } else {
+      const hoursUntilDue =
+        (due.getTime() - now.getTime()) / 1000 / SECONDS_PER_HOUR
+      if (hoursUntilDue <= IMMINENT_HOURS) {
+        score += FEATURED_NOW_WEIGHTS.dueWithinTwoHours
+      } else if (hoursUntilDue <= UPCOMING_HOURS) {
+        score += FEATURED_NOW_WEIGHTS.dueWithinSixHours
+      }
+    }
+    score += FEATURED_NOW_WEIGHTS.hasDueDate
+  }
+
+  if (endeavor.status === Status.ongoing) score += FEATURED_NOW_WEIGHTS.ongoing
+  if (endeavor.duration !== null) score += FEATURED_NOW_WEIGHTS.hasDuration
+  if ((endeavor.sessionPoints ?? 0) > DEFAULT_SESSION_POINTS) {
+    score += FEATURED_NOW_WEIGHTS.aboveDefaultPoints
+  }
+
+  return score
+}
+
+/**
+ * `selectFeaturedNowTasks` — up to nine, odd-sized once three exist, arranged
+ * from the centre outward so the top scorer is the hero.
+ *
+ * Canon's five rules, in order:
+ * 1. score every candidate;
+ * 2. drop every zero — no relevance to now;
+ * 3. keep the top nine, ties broken by the **earlier due date**;
+ * 4. once three or more survive, drop the lowest-ranked to keep the count odd;
+ * 5. arrange centre-out — rank 1 lands left of the hero, rank 2 right, rank 3
+ *    two left, and so on, so any centred 3/5/7/9 window keeps the hero.
+ *
+ * One- and two-card days keep every card, so a two-card lane is legitimately
+ * even — `DoLanes.md`'s "3, 5, 7, or 9" describes the full lane, not the
+ * degenerate ones.
+ *
+ * **Determinism.** Ranking is score-desc then due-asc, and `Array.sort` is
+ * stable, so a full tie (same score, same due) resolves to the input pool's
+ * own first-appearance order — which reconciliation already fixes. Canon's
+ * `sorted` is unstable and leaves that case arbitrary; keeping the stable
+ * result is a gain, not a divergence.
+ */
+export const selectFeaturedNowEndeavors = (
+  candidates: readonly Endeavor[],
+  now: Date,
+  context: ReconciliationContext = defaultReconciliationContext(),
+): readonly Endeavor[] => {
+  const scored = candidates
+    .map((endeavor) => ({
+      endeavor,
+      score: featuredNowScore(endeavor, now, context),
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => {
+      if (left.score !== right.score) return right.score - left.score
+      const leftDue = left.endeavor.due?.getTime() ?? Number.POSITIVE_INFINITY
+      const rightDue = right.endeavor.due?.getTime() ?? Number.POSITIVE_INFINITY
+      return leftDue - rightDue
+    })
+    .map((entry) => entry.endeavor)
+
+  const top = scored.slice(0, FEATURED_NOW_MAX)
+  // Rule 4: an even count of three or more loses its weakest card, because an
+  // even lane has no single centre for the hero to occupy.
+  if (top.length >= 3 && top.length % 2 === 0) top.pop()
+  if (top.length <= 1) return top
+
+  return arrangeHeroCentred(top)
+}
+
+/**
+ * Canon's centre-out placement: `arranged[centre] = ranked[0]`, then odd ranks
+ * step leading and even ranks step trailing by `(rank + 1) / 2`.
+ *
+ * For three cards that is `[second, first, third]` — the layout canon's own
+ * test pins.
+ */
+const arrangeHeroCentred = (ranked: readonly Endeavor[]): readonly Endeavor[] => {
+  const arranged: (Endeavor | undefined)[] = new Array(ranked.length)
+  const centre = Math.floor(ranked.length / 2)
+  arranged[centre] = ranked[0]
+
+  for (let rank = 1; rank < ranked.length; rank += 1) {
+    const distance = Math.floor((rank + 1) / 2)
+    const index = rank % 2 === 0 ? centre + distance : centre - distance
+    arranged[index] = ranked[rank]
+  }
+
+  return arranged.filter((endeavor): endeavor is Endeavor => endeavor !== undefined)
+}
+
+/**
+ * The largest supported odd count that fits — `docs/Features/Do.md`'s
+ * *"largest fitting odd count"* decision, expressed over **how many cards fit**
+ * rather than a pixel width, because the pixel thresholds are the render
+ * layer's (#17) and would be a fiction here.
+ *
+ * Three is the floor: canon's lane *"remains focused at compact widths"* and
+ * never drops below its hero-plus-two shape.
+ */
+export const featuredNowCapacityFor = (
+  cardsThatFit: number,
+): FeaturedNowCapacity => {
+  if (cardsThatFit >= 9) return 9
+  if (cardsThatFit >= 7) return 7
+  if (cardsThatFit >= 5) return 5
+  return 3
+}
+
+/**
+ * The centred window of a hero-centred arrangement at a given capacity — the
+ * *"additional ranked cards fill outward symmetrically"* rule, read backwards.
+ *
+ * Narrowing drops flankers from both ends at once, so the hero never moves and
+ * a resize never reshuffles the lane.
+ */
+export const centredFeaturedWindow = (
+  arranged: readonly Endeavor[],
+  capacity: FeaturedNowCapacity,
+): readonly Endeavor[] => {
+  if (arranged.length <= capacity) return arranged
+  const drop = arranged.length - capacity
+  const leading = Math.floor(drop / 2)
+  return arranged.slice(leading, leading + capacity)
+}

--- a/packages/app/src/features/do/DoMocks.ts
+++ b/packages/app/src/features/do/DoMocks.ts
@@ -1,0 +1,393 @@
+/**
+ * The Do feature's canned fixtures (`RC-31`, `UZF-18`).
+ *
+ * Two exports, and every suite in this folder consumes them rather than
+ * building a day or a `DoState` inline:
+ *
+ * - **`doEndeavorFixtures`** — one endeavor per lane and per boundary the
+ *   canon doc and the Swift disagree about or leave implicit. They are
+ *   positioned relative to `DO_MOCK_NOW`, which is a *fixed* instant, so the
+ *   lane a fixture belongs to is a fact about the fixture rather than about
+ *   the day the suite happens to run.
+ * - **`doStateMocks`** — the states the surface claims to support, each built
+ *   by running the real Shifters over those fixtures. A mock assembled by hand
+ *   could describe a state the reducer can never actually produce.
+ *
+ * `DO_MOCK_NOW` is deliberately mid-morning: late enough for "earlier today"
+ * to exist, early enough for "later today" to exist, so a single instant
+ * exercises Overdue, Due Soon, Next and Anytime at once.
+ */
+import {
+  type Endeavor,
+  EndeavorHost,
+  EndeavorKind,
+  type EndeavorRecord,
+  EndeavorStatus,
+  PerformResolution,
+  endeavorRecordFromEndeavor,
+  makeEndeavor,
+  makePerform,
+} from '@kro/core'
+import { type DoState, initialDoState } from './DoFeature'
+import {
+  withEndeavorsInstalled,
+  withException,
+  withFetchStarted,
+  withMarkCompleteModeToggled,
+  withSuggestionDismissed,
+} from './DoShifters'
+import { DoExceptions } from './DoException'
+import { DoSuggestionSource } from './DoSuggestions'
+
+/** Tuesday 17 March 2026, 10:00 local. Every fixture below is relative to it. */
+export const DO_MOCK_NOW = new Date(2026, 2, 17, 10, 0, 0)
+
+/** A local wall-clock instant in March 2026 — the fixtures' only date builder. */
+export const doMockAt = (
+  day: number,
+  hour: number,
+  minute = 0,
+  second = 0,
+): Date => new Date(2026, 2, day, hour, minute, second)
+
+const task = (params: {
+  readonly id: string
+  readonly title: string
+  readonly due?: Date | null
+  readonly status?: EndeavorStatus
+  readonly completed?: Date | null
+  readonly kind?: EndeavorKind
+  readonly duration?: number | null
+  readonly sessionPoints?: number | null
+}): Endeavor =>
+  makeEndeavor({
+    id: params.id,
+    title: params.title,
+    kind: params.kind ?? EndeavorKind.task,
+    status: params.status ?? EndeavorStatus.pending,
+    due: params.due ?? null,
+    completed: params.completed ?? null,
+    duration: params.duration ?? null,
+    sessionPoints: params.sessionPoints ?? null,
+    hostedBy: [EndeavorHost.local],
+  })
+
+/**
+ * One endeavor per lane, plus every boundary worth pinning.
+ *
+ * The comment on each names the lane canon puts it in at `DO_MOCK_NOW`; the
+ * table-driven suite in `__tests__/DoRules.test.ts` asserts exactly that.
+ */
+export const doEndeavorFixtures = {
+  // --- Overdue: pending, due earlier today ---------------------------------
+  /** Due 08:00 today — Overdue. */
+  overdueThisMorning: task({
+    id: 'overdue-morning',
+    title: 'Send the invoice',
+    due: doMockAt(17, 8, 0),
+  }),
+  /** Due one minute ago — still Overdue, not Due Soon. */
+  overdueOneMinuteAgo: task({
+    id: 'overdue-one-minute',
+    title: 'Call the plumber',
+    due: doMockAt(17, 9, 59),
+  }),
+  /** Due at 00:00 **today** — Overdue, because the due day is still today. */
+  overdueAtMidnightToday: task({
+    id: 'overdue-midnight-today',
+    title: 'File yesterday’s notes',
+    due: doMockAt(17, 0, 0),
+  }),
+
+  // --- Due Soon: due within the window, or ongoing -------------------------
+  /** Due at exactly `now` — Due Soon: `isDueNow` is `due >= now`. */
+  dueAtExactlyNow: task({
+    id: 'due-exactly-now',
+    title: 'Stand-up',
+    due: doMockAt(17, 10, 0),
+  }),
+  /** Due in exactly two hours — Due Soon: the window is inclusive. */
+  dueInExactlyTwoHours: task({
+    id: 'due-two-hours',
+    title: 'Prep the deck',
+    due: doMockAt(17, 12, 0),
+  }),
+  /** Due one second past the window — Next, not Due Soon. */
+  dueOneSecondPastWindow: task({
+    id: 'due-past-window',
+    title: 'Review the PR',
+    due: doMockAt(17, 12, 0, 1),
+  }),
+  /** Ongoing with no due date — Due Soon's ongoing tail, never Anytime. */
+  ongoingUndated: task({
+    id: 'ongoing-undated',
+    title: 'Draft the proposal',
+    status: EndeavorStatus.ongoing,
+  }),
+  /** Ongoing and due tomorrow — still Due Soon, via the ongoing tail. */
+  ongoingDueTomorrow: task({
+    id: 'ongoing-due-tomorrow',
+    title: 'Ship the migration',
+    status: EndeavorStatus.ongoing,
+    due: doMockAt(18, 9, 0),
+  }),
+  /**
+   * Ongoing **and** overdue — the overlap. Overdue wins; the ongoing tail
+   * excludes it explicitly, so it appears once, not twice.
+   */
+  ongoingAndOverdue: task({
+    id: 'ongoing-overdue',
+    title: 'Finish the audit',
+    status: EndeavorStatus.ongoing,
+    due: doMockAt(17, 8, 30),
+  }),
+
+  // --- Expired: pending, due yesterday or earlier --------------------------
+  /** Due 23:59 yesterday — Expired one minute later, not Overdue. */
+  expiredLastNight: task({
+    id: 'expired-last-night',
+    title: 'Renew the domain',
+    due: doMockAt(16, 23, 59),
+  }),
+  /** Due a week ago — Expired. */
+  expiredLastWeek: task({
+    id: 'expired-last-week',
+    title: 'Return the library book',
+    due: doMockAt(10, 9, 0),
+  }),
+
+  // --- Next: due later today, beyond the window ----------------------------
+  dueLateToday: task({
+    id: 'due-late-today',
+    title: 'Water the plants',
+    due: doMockAt(17, 18, 0),
+  }),
+
+  // --- No lane at all ------------------------------------------------------
+  /**
+   * Due tomorrow morning — in **no** lane. Not Next (not today), not Anytime
+   * (it has a due date). Canon's behaviour, and nowhere in the doc.
+   */
+  dueTomorrowMorning: task({
+    id: 'due-tomorrow',
+    title: 'Dentist',
+    due: doMockAt(18, 9, 0),
+  }),
+  /** Due at 00:00 tomorrow — the other side of the midnight edge, so no lane. */
+  dueAtMidnightTonight: task({
+    id: 'due-midnight-tonight',
+    title: 'Rollover the ledger',
+    due: doMockAt(18, 0, 0),
+  }),
+  /**
+   * Skipped, and was due this morning. `hasBeenCompleted` counts skipped, so
+   * it leaves every actionable lane; Completed Today needs `closed`, so it
+   * does not appear there either. It is in no lane.
+   */
+  skippedThisMorning: task({
+    id: 'skipped-morning',
+    title: 'Optional stretch goal',
+    status: EndeavorStatus.skipped,
+    due: doMockAt(17, 8, 0),
+  }),
+
+  // --- Anytime -------------------------------------------------------------
+  anytimeTask: task({ id: 'anytime-task', title: 'Tidy the desk' }),
+
+  // --- Habits --------------------------------------------------------------
+  /** A habit due later this morning — Due Soon, and in the gold denominator. */
+  habitDueSoon: task({
+    id: 'habit-due-soon',
+    title: 'Morning run',
+    kind: EndeavorKind.habit,
+    due: doMockAt(17, 11, 0),
+  }),
+  /** An undated habit — Anytime, and still one of today's habits. */
+  habitUndated: task({
+    id: 'habit-undated',
+    title: 'Read ten pages',
+    kind: EndeavorKind.habit,
+  }),
+  /** A habit completed this morning — Completed Today, and fills the gold ring. */
+  habitCompletedToday: task({
+    id: 'habit-completed',
+    title: 'Meditate',
+    kind: EndeavorKind.habit,
+    status: EndeavorStatus.closed,
+    completed: doMockAt(17, 7, 0),
+  }),
+
+  // --- Completed Today -----------------------------------------------------
+  /** Closed today with a due date today — Completed Today, fills the emerald ring. */
+  completedTodayTask: task({
+    id: 'completed-today',
+    title: 'Book the flights',
+    status: EndeavorStatus.closed,
+    due: doMockAt(17, 9, 0),
+    completed: doMockAt(17, 9, 30),
+  }),
+  /** Closed yesterday — in no lane today, and in no ring. */
+  completedYesterdayTask: task({
+    id: 'completed-yesterday',
+    title: 'Pay the electricity bill',
+    status: EndeavorStatus.closed,
+    due: doMockAt(16, 12, 0),
+    completed: doMockAt(16, 12, 30),
+  }),
+  /**
+   * Closed today with **no** host timestamp, carrying today's completion on a
+   * performance instead — canon's fallback for a provider that advanced the
+   * row before returning one.
+   */
+  completedTodayViaPerformance: makeEndeavor({
+    id: 'completed-via-performance',
+    title: 'Weekly review',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.closed,
+    due: doMockAt(17, 8, 0),
+    hostedBy: [EndeavorHost.local],
+    performances: [
+      makePerform({
+        date: doMockAt(17, 8, 30),
+        duration: 900,
+        resolution: PerformResolution.complete,
+        completedAt: doMockAt(17, 8, 45),
+      }),
+    ],
+  }),
+
+  // --- Other kinds ---------------------------------------------------------
+  /** A reminder due today: outside every task lane, inside the emerald ring. */
+  reminderDueToday: task({
+    id: 'reminder-due-today',
+    title: 'Bins out',
+    kind: EndeavorKind.reminder,
+    due: doMockAt(17, 20, 0),
+  }),
+  /** A reminder completed today — Completed Today, and fills the emerald ring. */
+  reminderCompletedToday: task({
+    id: 'reminder-completed',
+    title: 'Take the vitamins',
+    kind: EndeavorKind.reminder,
+    status: EndeavorStatus.closed,
+    due: doMockAt(17, 8, 0),
+    completed: doMockAt(17, 8, 5),
+  }),
+  /** A calendar event: installed in its own channel, in no task lane and no ring. */
+  eventToday: makeEndeavor({
+    id: 'event-today',
+    title: 'Design review',
+    kind: EndeavorKind.calendarEvent,
+    start: doMockAt(17, 14, 0),
+    duration: 3600,
+    hostedBy: [EndeavorHost.googleCalendar],
+  }),
+
+  // --- Scoring shapes ------------------------------------------------------
+  /** Undated, not ongoing, no duration, no points — scores 0, so never featured. */
+  zeroScoreTask: task({ id: 'zero-score', title: 'Someday, maybe' }),
+  /** Undated but ongoing — scores 30, so it *is* featured. */
+  ongoingZeroDueTask: task({
+    id: 'ongoing-no-due',
+    title: 'Ongoing chore',
+    status: EndeavorStatus.ongoing,
+  }),
+  /** Due in four hours with a duration and rich reward — 25 + 10 + 5 + 3. */
+  richUpcomingTask: task({
+    id: 'rich-upcoming',
+    title: 'Write the retro',
+    due: doMockAt(17, 14, 0),
+    duration: 1800,
+    sessionPoints: 25,
+  }),
+} as const
+
+/** The whole fixture day, in one array — what a fetch would install. */
+export const doFixtureDay: readonly Endeavor[] = Object.values(
+  doEndeavorFixtures,
+)
+
+/**
+ * The same day as stored rows, for seeding a stubbed `LocalStore`.
+ *
+ * A Producer suite reads what the store holds, so the fixtures have to arrive
+ * as records; going through the real codec is also what keeps the round-trip
+ * honest rather than asserting against a hand-written row.
+ */
+export const doFixtureRecords = (
+  now: Date = DO_MOCK_NOW,
+): readonly EndeavorRecord[] =>
+  doFixtureDay.map((endeavor) => endeavorRecordFromEndeavor(endeavor, { now }))
+
+const loadedDay = withEndeavorsInstalled(
+  initialDoState,
+  doFixtureDay,
+  DO_MOCK_NOW,
+)
+
+/**
+ * The states the Do surface claims to support.
+ *
+ * Each is produced by the real Shifters, so a variant here is by construction
+ * a state the reducer can actually reach.
+ */
+export const doStateMocks = {
+  /** Nothing asked for yet — first paint before the surface mounts. */
+  idle: initialDoState,
+
+  /** A read is in flight and nothing has landed. */
+  loading: withFetchStarted(initialDoState),
+
+  /** The ordinary day: every lane populated, every boundary represented. */
+  loadedTypicalDay: loadedDay,
+
+  /** A day with nothing in it — the true empty state. */
+  loadedEmptyDay: withEndeavorsInstalled(initialDoState, [], DO_MOCK_NOW),
+
+  /**
+   * A refresh failed **after** a good day was already showing. The lanes are
+   * untouched, which is the whole reason `load` sits beside the day.
+   */
+  failedRefreshKeepingTheDay: withException(
+    loadedDay,
+    DoExceptions.fetchFailed('the store is unavailable'),
+  ),
+
+  /** Bulk mark-complete mode is on, so the rings hide. */
+  inMarkCompleteMode: withMarkCompleteModeToggled(loadedDay),
+
+  /** The rings' kill switch is on — the ordinary shipping configuration. */
+  ringsEnabled: {
+    ...loadedDay,
+    preferences: { ...loadedDay.preferences, activityRingsEnabled: true },
+  } satisfies DoState,
+
+  /** Auto-advance turned on by the user; otherwise the ordinary day. */
+  autoAdvanceEnabled: {
+    ...loadedDay,
+    preferences: { ...loadedDay.preferences, autoAdvanceAfterComplete: true },
+  } satisfies DoState,
+
+  /** Google Calendar offerable and unlinked — the connect nudge is showing. */
+  suggestionOffered: {
+    ...loadedDay,
+    preferences: { ...loadedDay.preferences, googleCalendarEnabled: true },
+    suggestions: [
+      {
+        source: DoSuggestionSource.googleCalendar,
+        title: 'Google Calendar',
+        subtitle: 'See all your events in one place.',
+        actionTitle: 'Connect',
+      },
+    ],
+  } satisfies DoState,
+
+  /** …and the same day once the user has turned that nudge down. */
+  suggestionDismissed: withSuggestionDismissed(
+    {
+      ...loadedDay,
+      preferences: { ...loadedDay.preferences, googleCalendarEnabled: true },
+    },
+    DoSuggestionSource.googleCalendar,
+  ),
+}

--- a/packages/app/src/features/do/DoProducer.ts
+++ b/packages/app/src/features/do/DoProducer.ts
@@ -1,0 +1,301 @@
+/**
+ * The Do surface's Producers (`RC-3`, `RC-6`, `RC-7`, `RC-25`) — canon's
+ * `produceLoadDoPreferencesEffect`, `produceFetchEndeavorsEffect`,
+ * `produceClearExpiredEffect` and `produceMarkCompleteEffect`.
+ *
+ * Four thunks, one shape: read the store through `extra.localStore`, never
+ * throw, always resolve a `Result`. None of them reads a clock — `now` is an
+ * argument, so a suite states the instant it is asking about and the reducer
+ * classifies against the same value the effect used.
+ *
+ * ## Why none of them takes `getState()`
+ *
+ * `RC-3` allows a narrow, named read; these need none. Clear Expired in
+ * particular re-reads the day and recomputes its own targets rather than
+ * trusting a set the caller selected earlier, so a snapshot that went stale
+ * between the tap and the dispatch cannot close the wrong rows. It also keeps
+ * the thunk free of `RootState`, which would otherwise make the store's own
+ * type circular through the slice that registers it.
+ *
+ * ## A malformed row is skipped, never fatal
+ *
+ * `endeavorFromRecord` fails only on an unknown `kind` or `status`, and
+ * canon's caller *"treats the failure as skip this row"*. One corrupt row must
+ * not blank a user's whole day, so the day is built from what decodes.
+ */
+import {
+  type Endeavor,
+  type EndeavorRecord,
+  EndeavorStatus,
+  FeatureFlags,
+  type LocalStore,
+  type ReconciliationContext,
+  type Result,
+  deferFromRecord,
+  doAutoAdvanceAfterCompleteOption,
+  doNowThresholdHoursOption,
+  doShowSuggestionsOption,
+  endeavorFromRecord,
+  endeavorRecordFromEndeavor,
+  err,
+  livingChildRecords,
+  makeFeatureFlagOverrideStore,
+  makeHardcodedFeatureFlagService,
+  makePreferences,
+  makeReconciliationContext,
+  ok,
+  overridesAsAssignments,
+  performFromRecord,
+  preferenceBool,
+  preferenceInt,
+  reconcile,
+  resolvedKind,
+} from '@kro/core'
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import type { ThunkExtra } from '../../library/store'
+import { type DoException, DoExceptions } from './DoException'
+import type { DoPreferences } from './DoFeature'
+import { doClearExpiredTargets } from './DoRules'
+
+/**
+ * A whole-day snapshot and the instant it was read at, so the reducer
+ * classifies against the same value the effect used rather than against a
+ * second, later clock reading.
+ */
+export interface DoDaySnapshot {
+  readonly endeavors: readonly Endeavor[]
+  readonly now: Date
+}
+
+const messageOf = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+/**
+ * Every stored endeavor, hydrated with its relations.
+ *
+ * The two child stores are read **once each** and grouped in memory rather
+ * than queried per endeavor: a day with a hundred rows would otherwise cost
+ * two hundred extra round-trips through IndexedDB.
+ */
+const readStoredEndeavors = async (
+  localStore: LocalStore,
+): Promise<readonly Endeavor[]> => {
+  const [endeavorRecords, deferRecords, performanceRecords] = await Promise.all([
+    localStore.endeavors.all(),
+    localStore.defers.all(),
+    localStore.performances.all(),
+  ])
+
+  const defersByEndeavor = new Map<string, ReturnType<typeof deferFromRecord>[]>()
+  for (const record of livingChildRecords(deferRecords)) {
+    const bucket = defersByEndeavor.get(record.endeavorId) ?? []
+    bucket.push(deferFromRecord(record))
+    defersByEndeavor.set(record.endeavorId, bucket)
+  }
+
+  const performancesByEndeavor = new Map<
+    string,
+    ReturnType<typeof performFromRecord>[]
+  >()
+  for (const record of livingChildRecords(performanceRecords)) {
+    const bucket = performancesByEndeavor.get(record.endeavorId) ?? []
+    bucket.push(performFromRecord(record))
+    performancesByEndeavor.set(record.endeavorId, bucket)
+  }
+
+  const endeavors: Endeavor[] = []
+  for (const record of endeavorRecords) {
+    const hydrated = endeavorFromRecord(record, {
+      defers: defersByEndeavor.get(record.id) ?? [],
+      performances: performancesByEndeavor.get(record.id) ?? [],
+    })
+    if (hydrated.ok) endeavors.push(hydrated.value)
+  }
+  return endeavors
+}
+
+/**
+ * Rewrites one stored endeavor, preserving its sync watermark.
+ *
+ * `lastSyncedAtEpochMillis` is carried forward from the row on disk: dropping
+ * it would present an already-synced endeavor to the next push sweep as if it
+ * had never left the device.
+ */
+const persistEndeavor = async (
+  localStore: LocalStore,
+  endeavor: Endeavor,
+  now: Date,
+  context: ReconciliationContext,
+): Promise<void> => {
+  const existing: EndeavorRecord | null = await localStore.endeavors.get(
+    endeavor.id,
+  )
+  await localStore.endeavors.put(
+    endeavorRecordFromEndeavor(endeavor, {
+      now,
+      lastSyncedAtEpochMillis: existing?.lastSyncedAtEpochMillis ?? null,
+      resolvedKind: resolvedKind(endeavor, context),
+    }),
+  )
+}
+
+/**
+ * The three `do.*` preferences and the two flags the surface AND's them with,
+ * resolved in one pass.
+ *
+ * The flag service is built from the **injected** key-value store's persisted
+ * `debug.ff.*` overrides layered over the `statusQuo` baseline. The boundary
+ * is still injected — `makeHardcodedFeatureFlagService` is a pure in-memory
+ * resolver over data that arrived through `extra`, the same way a Mapper is
+ * pure over a payload that did. Layering the overrides at construction (rather
+ * than `applyPersistedOverrides` afterwards) keeps the baseline visible
+ * underneath, which is what the Debug flag list renders.
+ */
+export const loadDoPreferencesThunk = createAsyncThunk<
+  Result<DoPreferences, DoException>,
+  void,
+  { extra: ThunkExtra }
+>('do/onDoPreferencesLoadCompleted', async (_arg, { extra }) => {
+  try {
+    const store = extra.localStore.preferences
+    const preferences = makePreferences(store)
+    const flags = makeHardcodedFeatureFlagService({
+      overrides: overridesAsAssignments(
+        makeFeatureFlagOverrideStore(store).all(),
+      ),
+    })
+
+    return ok({
+      showSuggestions: preferenceBool(preferences, doShowSuggestionsOption),
+      nowThresholdHours: preferenceInt(preferences, doNowThresholdHoursOption),
+      autoAdvanceAfterComplete: preferenceBool(
+        preferences,
+        doAutoAdvanceAfterCompleteOption,
+      ),
+      activityRingsEnabled: flags.isEnabled(FeatureFlags.doActivityRings),
+      googleCalendarEnabled: flags.isEnabled(FeatureFlags.googleCalendar),
+    })
+  } catch (error) {
+    return err(DoExceptions.preferencesLoadFailed(messageOf(error)))
+  }
+})
+
+/**
+ * The Do vista's single fetch — canon's per-surface `produceFetchEndeavorsEffect`.
+ *
+ * **One** read for the whole day: tasks, habits, reminders and events come out
+ * of the same snapshot, which is what lets the reducer install them together
+ * and lets the lanes and the rings *"update together without repeated
+ * whole-screen regrouping"*. Reconciliation runs here so the reducer receives
+ * an already-collapsed list, honouring `#12`'s reconcile-before-grouping
+ * contract at the earliest point that has the data.
+ */
+export const fetchDoEndeavorsThunk = createAsyncThunk<
+  Result<DoDaySnapshot, DoException>,
+  { now: Date },
+  { extra: ThunkExtra }
+>('do/onEndeavorsFetchCompleted', async ({ now }, { extra }) => {
+  try {
+    const context = makeReconciliationContext({ now })
+    const stored = await readStoredEndeavors(extra.localStore)
+    return ok({ endeavors: reconcile(stored, context), now })
+  } catch (error) {
+    return err(DoExceptions.fetchFailed(messageOf(error)))
+  }
+})
+
+/**
+ * **Clear Expired** — close every expired endeavor, then refetch once.
+ *
+ * The two phases must never race, and the order is the whole feature: *"first
+ * commits each old provider occurrence, then refetches the Do query and
+ * atomically replaces the visible snapshot"*, which is what lets a recurring
+ * item's occurrence for **today** appear immediately once the old one is out
+ * of the way.
+ *
+ * So every mutation is awaited — sequentially, one row at a time, exactly as
+ * canon's `for` loop does — before a single read runs, and the reducer sees
+ * one install. Nothing partial is ever observable in state: a failure halfway
+ * through resolves `err` and the reducer leaves the retained day exactly as it
+ * was, even though some rows on disk have already been closed. That asymmetry
+ * is canon's too, and the follow-up refetch is what reconciles it.
+ *
+ * The target set is recomputed here from a fresh read (see the module note),
+ * and is the **Expired** lane only — `DoRules.doClearExpiredTargets` carries
+ * the reasoning and the doc divergence.
+ */
+export const clearExpiredThunk = createAsyncThunk<
+  Result<DoDaySnapshot, DoException>,
+  { now: Date },
+  { extra: ThunkExtra }
+>('do/onClearExpiredCompleted', async ({ now }, { extra }) => {
+  const context = makeReconciliationContext({ now })
+
+  let targets: readonly Endeavor[]
+  try {
+    const stored = reconcile(await readStoredEndeavors(extra.localStore), context)
+    targets = doClearExpiredTargets(stored, now, context)
+  } catch (error) {
+    return err(DoExceptions.fetchFailed(messageOf(error)))
+  }
+
+  try {
+    for (const target of targets) {
+      // Closed, but deliberately **not** stamped as completed: clearing is an
+      // acknowledgement, not an achievement. A completion date here would put
+      // expired work into Completed Today and let it fill a ring.
+      await persistEndeavor(
+        extra.localStore,
+        { ...target, status: EndeavorStatus.closed },
+        now,
+        context,
+      )
+    }
+  } catch {
+    return err(DoExceptions.clearExpiredMutationFailed())
+  }
+
+  try {
+    const refreshed = await readStoredEndeavors(extra.localStore)
+    return ok({ endeavors: reconcile(refreshed, context), now })
+  } catch {
+    return err(DoExceptions.clearExpiredRefreshFailed())
+  }
+})
+
+/**
+ * Persist one confirmed completion, at the instant the popover carried.
+ *
+ * The reducer has already closed the row optimistically, so this thunk's
+ * success has nothing to say and only its failure reaches state. `completionDate`
+ * is passed separately from `now` on purpose: the user may have backdated the
+ * completion, and the row must record when it was *done*, not when it was
+ * *saved*.
+ */
+export const markEndeavorCompleteThunk = createAsyncThunk<
+  Result<Endeavor, DoException>,
+  { endeavorId: string; completionDate: Date; now: Date },
+  { extra: ThunkExtra }
+>(
+  'do/onMarkCompleteCompleted',
+  async ({ endeavorId, completionDate, now }, { extra }) => {
+    try {
+      const context = makeReconciliationContext({ now })
+      const stored = await readStoredEndeavors(extra.localStore)
+      const target = stored.find((endeavor) => endeavor.id === endeavorId)
+      if (target === undefined) {
+        return err(DoExceptions.endeavorNotFound(endeavorId))
+      }
+
+      const completed: Endeavor = {
+        ...target,
+        status: EndeavorStatus.closed,
+        completed: completionDate,
+      }
+      await persistEndeavor(extra.localStore, completed, now, context)
+      return ok(completed)
+    } catch (error) {
+      return err(DoExceptions.markCompleteFailed(messageOf(error)))
+    }
+  },
+)

--- a/packages/app/src/features/do/DoProducer.ts
+++ b/packages/app/src/features/do/DoProducer.ts
@@ -187,8 +187,8 @@ export const loadDoPreferencesThunk = createAsyncThunk<
  * of the same snapshot, which is what lets the reducer install them together
  * and lets the lanes and the rings *"update together without repeated
  * whole-screen regrouping"*. Reconciliation runs here so the reducer receives
- * an already-collapsed list, honouring `#12`'s reconcile-before-grouping
- * contract at the earliest point that has the data.
+ * the raw stored list; `withEndeavorsInstalled` reconciles exactly once at
+ * install (`#12`'s reconcile-before-grouping contract, single pass).
  */
 export const fetchDoEndeavorsThunk = createAsyncThunk<
   Result<DoDaySnapshot, DoException>,
@@ -196,9 +196,10 @@ export const fetchDoEndeavorsThunk = createAsyncThunk<
   { extra: ThunkExtra }
 >('do/onEndeavorsFetchCompleted', async ({ now }, { extra }) => {
   try {
-    const context = makeReconciliationContext({ now })
     const stored = await readStoredEndeavors(extra.localStore)
-    return ok({ endeavors: reconcile(stored, context), now })
+    // Raw pass-through: the install shifter owns the single reconcile pass
+    // (#12's reconcile-before-grouping contract, applied exactly once).
+    return ok({ endeavors: stored, now })
   } catch (error) {
     return err(DoExceptions.fetchFailed(messageOf(error)))
   }
@@ -257,7 +258,7 @@ export const clearExpiredThunk = createAsyncThunk<
 
   try {
     const refreshed = await readStoredEndeavors(extra.localStore)
-    return ok({ endeavors: reconcile(refreshed, context), now })
+    return ok({ endeavors: refreshed, now })
   } catch {
     return err(DoExceptions.clearExpiredRefreshFailed())
   }

--- a/packages/app/src/features/do/DoRings.ts
+++ b/packages/app/src/features/do/DoRings.ts
@@ -1,0 +1,129 @@
+/**
+ * The day-progress rings — the port of canon's `tasksRingProgress(now:)` /
+ * `habitsRingProgress(now:)` (`Kro/Application/Do/DoSelectors.swift`),
+ * specified by `docs/Features/DayProgressRings.md`.
+ *
+ * Two ratios and one rule that is easy to get wrong and expensive when it is:
+ *
+ * > **Visibility filters deliberately do not change the rings.** *"Your
+ * > progress through the day is a fact about the day, not about what you're
+ * > currently looking at — a ring that jumped when you toggled a filter would
+ * > be reporting the filter, not the day."*
+ *
+ * Structurally, that is why every function here takes the **raw** channels
+ * (`tasks`, `reminders`, `habits`) and never a lane: the lanes have the lens
+ * baked into them, so a ring derived from one could not help but move when the
+ * user hid a kind. Nothing in this file accepts a lens.
+ *
+ * `null` is the third answer and is not the same as `0`: an empty denominator
+ * means the ring is **not drawn at all**, because *"an empty gold track would
+ * read as 'you've done none of your habits' when in fact there were none to
+ * do."*
+ */
+import {
+  type Endeavor,
+  EndeavorKind as Kind,
+  type ReconciliationContext,
+  defaultReconciliationContext,
+  isSameCalendarDay,
+  resolvedKind,
+} from '@kro/core'
+import { isCompletedToday } from './DoRules'
+
+/** One ring's standing: what is expected today and how much of it is done. */
+export interface DoRing {
+  readonly expected: number
+  readonly completed: number
+  /** `completed / expected`, clamped to `0…1`. */
+  readonly progress: number
+}
+
+/**
+ * `completed ÷ expected`, clamped — or `null` for an empty denominator, which
+ * the caller renders as *no ring*, never as an empty track.
+ */
+const ringOf = (
+  expected: readonly Endeavor[],
+  now: Date,
+  context: ReconciliationContext,
+): DoRing | null => {
+  if (expected.length === 0) return null
+  const completed = expected.filter((endeavor) =>
+    isCompletedToday(endeavor, now, context),
+  ).length
+  return {
+    expected: expected.length,
+    completed,
+    progress: Math.min(1, Math.max(0, completed / expected.length)),
+  }
+}
+
+/**
+ * The inner emerald ring: **every task due today, including the overdue ones**.
+ *
+ * - *Overdue* — past its due time but still due today — still counts, because
+ *   it is still expected of you today.
+ * - *Expired* — past due on an earlier day — is excluded outright, *"rather
+ *   than dragging the ring down forever"*. It falls out for free: an expired
+ *   task's due date is not today.
+ * - An **undated** task is not expected today and is counted neither way.
+ * - Habits are excluded by the resolved-kind guard, so a habit that came from
+ *   an outside list is *"counted once as a habit, never a second time as a
+ *   task"*.
+ *
+ * Canon additionally routes Apple-Reminders-linked rows through
+ * `AppleReminderKindResolver.isRelevantToToday`, which admits undated active
+ * reminders. Web has no EventKit host (the epic puts Apple Reminders and Apple
+ * Calendar out of scope — Google Calendar is the external host), so that
+ * branch has no reachable input here and is deliberately not ported; the
+ * remaining `due` term is canon's own fallback for every other host.
+ */
+export const tasksRing = (
+  input: {
+    readonly tasks: readonly Endeavor[]
+    readonly reminders: readonly Endeavor[]
+  },
+  now: Date,
+  context: ReconciliationContext = defaultReconciliationContext(),
+): DoRing | null => {
+  const expected = [...input.tasks, ...input.reminders].filter((endeavor) => {
+    const kind = resolvedKind(endeavor, context)
+    if (kind !== Kind.task && kind !== Kind.reminder) return false
+    const due = endeavor.due
+    return due !== null && isSameCalendarDay(due, now)
+  })
+  return ringOf(expected, now, context)
+}
+
+/**
+ * The outer gold ring: **every habit for today**.
+ *
+ * Strictly `resolvedKind === habit`, and — unlike tasks — **not** filtered by
+ * due date: *"an undated habit is still one of today's habits."* The
+ * shadow-aware kind partition has already collapsed any external mirror, so
+ * nothing counted here is also counted as a task.
+ */
+export const habitsRing = (
+  habits: readonly Endeavor[],
+  now: Date,
+  context: ReconciliationContext = defaultReconciliationContext(),
+): DoRing | null => {
+  const expected = habits.filter(
+    (endeavor) => resolvedKind(endeavor, context) === Kind.habit,
+  )
+  return ringOf(expected, now, context)
+}
+
+/**
+ * Whether the header draws rings at all.
+ *
+ * The `doActivityRings` flag is a kill switch, not a rollout gate (it ships
+ * enabled), and bulk mark-complete mode suppresses them so *"nothing competes
+ * with the instruction for attention."* Whether each individual ring is drawn
+ * is still its own `null` check — this only answers whether the readout is on
+ * the screen.
+ */
+export const areDoRingsVisible = (input: {
+  readonly activityRingsEnabled: boolean
+  readonly isInMarkCompleteMode: boolean
+}): boolean => input.activityRingsEnabled && !input.isInMarkCompleteMode

--- a/packages/app/src/features/do/DoRules.ts
+++ b/packages/app/src/features/do/DoRules.ts
@@ -1,0 +1,553 @@
+/**
+ * The Do lanes — the pure port of canon's `applyRegroup`
+ * (`Kro/Application/Do/DoShifters.swift`) and the `Endeavor` temporal
+ * predicates it stands on (`Kro/Models/Endeavors.swift`), specified by
+ * `Kro/Application/Now/DoLanes.md`.
+ *
+ * Everything here is a **pure function of `(endeavors, lens, now)`**. There is
+ * no clock read, no store, no service: `now` is always a parameter, so a lane
+ * is answerable at any instant and a midnight-boundary test states the instant
+ * it is asking about instead of mocking a global (`UZF-10`, `UZF-11`). Canon's
+ * own predicates read `Date()` inside the property; the parameterised
+ * `isDueNow(withinHours:now:)` / `isDueNext(withinHours:now:)` pair it added
+ * for the `do.nowThresholdHours` preference is the shape ported here, applied
+ * to `isOverdue` and `featuredNowScore` as well.
+ *
+ * ## Kind is the RESOLVED kind, everywhere
+ *
+ * Canon guards every lane on `resolvedKind` — the kind after source
+ * reconciliation, not the kind Kro last persisted — because *"kind filters
+ * always evaluate the resolved classification rather than the last stored
+ * fallback"*. `packages/core/src/vistas` still reads plain `kind` with a doc
+ * note at each site saying that adopting `resolvedKind` is a vistas-lane
+ * change (see `ResolvedKind.ts` and `EndeavorComputedState.ts`). This lane
+ * does **not** edit those files: it re-states the three computed-state guards
+ * locally against `resolvedKind`, which is what canon does and what makes a
+ * daily reminder participate here as a Habit.
+ *
+ * ## Boundary semantics the doc does not state (read out of the Swift)
+ *
+ * - `isDueNow` is `due >= now`, `isOverdue` is `due < now`: an endeavor due at
+ *   *exactly* `now` is **Due Soon**, never Overdue.
+ * - The Due-Soon window is **inclusive** (`<= hours`) and Next is strictly
+ *   `> hours`: exactly-two-hours-away is Due Soon, not Next.
+ * - Overdue vs Expired splits on the **calendar day of the due date**, not on
+ *   a rolling 24h window — something due 23:59 yesterday is Expired at 00:01
+ *   today, two minutes later.
+ * - `isDueNext` additionally requires `isDueToday`, so a **pending task due
+ *   tomorrow appears in no lane at all**: not Next (not today), not Anytime
+ *   (it has a due date). That is canon's behaviour, not an omission here.
+ * - The ongoing tail of the Due-Soon lane is **appended after** the due-sorted
+ *   head and is itself unsorted, so Due Soon is not globally due-ordered — the
+ *   doc's "sorted by due date ascending" describes the head only.
+ * - `hasBeenCompleted` also counts `skipped`, `reviewing` and `qa`, while
+ *   Completed Today requires `status === closed`; a **skipped** endeavor
+ *   therefore leaves every lane and appears in none.
+ */
+import {
+  type Endeavor,
+  EndeavorComputedState,
+  type EndeavorHost,
+  type EndeavorKind,
+  EndeavorKind as Kind,
+  EndeavorStatus as Status,
+  type EndeavorsLens,
+  EndeavorsVistas,
+  PerformResolution,
+  type ReconciliationContext,
+  SECONDS_PER_HOUR,
+  defaultReconciliationContext,
+  hasBeenCompleted,
+  isSameCalendarDay,
+  resolvedKind,
+} from '@kro/core'
+
+// ---------------------------------------------------------------------------
+// Lanes
+// ---------------------------------------------------------------------------
+
+/**
+ * The section tags canon uses in `selectedCardKey` (`"sectionTag:endeavorID"`)
+ * and in its auto-advance priority list. Kept as canon's literal strings so a
+ * key minted here is the same key the iOS surface mints.
+ */
+export const DoLane = {
+  featured: 'featured',
+  now: 'now',
+  overdue: 'overdue',
+  expired: 'expired',
+  next: 'next',
+  anytime: 'anytime',
+  completed: 'completed',
+} as const
+
+export type DoLane = (typeof DoLane)[keyof typeof DoLane]
+
+/** One regroup's output — canon's six card arrays plus Completed Today. */
+export interface DoLanes {
+  readonly featuredNow: readonly Endeavor[]
+  readonly now: readonly Endeavor[]
+  readonly overdue: readonly Endeavor[]
+  readonly expired: readonly Endeavor[]
+  readonly next: readonly Endeavor[]
+  readonly anytime: readonly Endeavor[]
+  readonly completedToday: readonly Endeavor[]
+}
+
+export const emptyDoLanes: DoLanes = {
+  featuredNow: [],
+  now: [],
+  overdue: [],
+  expired: [],
+  next: [],
+  anytime: [],
+  completedToday: [],
+}
+
+/** The fully-qualified card key canon's `selectedCardKey` carries. */
+export const doCardKey = (lane: DoLane, endeavorId: string): string =>
+  `${lane}:${endeavorId}`
+
+// ---------------------------------------------------------------------------
+// Visibility, as the slice stores it
+// ---------------------------------------------------------------------------
+
+/**
+ * The user's visibility choices, held as **arrays** rather than as an
+ * `EndeavorsLens`.
+ *
+ * `EndeavorsLens` carries five `Set`s, and the store's `serializableCheck`
+ * admits `Date` and plain objects only — a `Set` in state would log on every
+ * dispatch and break time-travel, which is why Redux state holds plain
+ * collections and materialises the richer type at the point of use. Do's lens
+ * exposes exactly these four toggles (`EndeavorsVistas.doTab`), so nothing is
+ * lost: `showArchived`, `grouping`, `sort` and `exposes` are static vista
+ * config, not user state.
+ */
+export interface DoVisibility {
+  readonly hiddenKinds: readonly EndeavorKind[]
+  readonly hiddenHosts: readonly EndeavorHost[]
+  readonly hiddenComputedStates: readonly EndeavorComputedState[]
+  readonly hiddenCalendarIds: readonly string[]
+}
+
+/** Nothing hidden — the Do vista's own starting point. */
+export const initialDoVisibility: DoVisibility = {
+  hiddenKinds: [],
+  hiddenHosts: [],
+  hiddenComputedStates: [],
+  hiddenCalendarIds: [],
+}
+
+/**
+ * The Do vista's lens with the user's choices applied — the shape every rule
+ * below reads. Built from `EndeavorsVistas.doTab.lens` so the vista keeps
+ * owning `showArchived: true` (without it the post-filter strips every closed
+ * row and Completed Today could never survive a refetch) and the exposed
+ * toggle set.
+ */
+export const doLensFor = (visibility: DoVisibility): EndeavorsLens => ({
+  ...EndeavorsVistas.doTab.lens,
+  hiddenKinds: new Set(visibility.hiddenKinds),
+  hiddenHosts: new Set(visibility.hiddenHosts),
+  hiddenComputedStates: new Set(visibility.hiddenComputedStates),
+  hiddenCalendarIds: new Set(visibility.hiddenCalendarIds),
+})
+
+// ---------------------------------------------------------------------------
+// Kind & completion predicates
+// ---------------------------------------------------------------------------
+
+/** Canon's `[.task, .habit].contains(resolvedKind)` guard, shared by every lane. */
+export const isActionableDoKind = (
+  endeavor: Endeavor,
+  context: ReconciliationContext,
+): boolean => {
+  const kind = resolvedKind(endeavor, context)
+  return kind === Kind.task || kind === Kind.habit
+}
+
+/**
+ * `EndeavorComputedState.completedToday`, re-stated against `resolvedKind`.
+ *
+ * Normally closed with a host completion timestamp dated today; canon falls
+ * back to the latest `complete` performance when the host never returned one,
+ * which is how a recurring occurrence that the provider already advanced still
+ * reads as done. Deliberately **not** `hasBeenCompleted`, which also counts
+ * skipped / reviewing / qa and would overstate a ring.
+ */
+export const isCompletedToday = (
+  endeavor: Endeavor,
+  now: Date,
+  context: ReconciliationContext,
+): boolean => {
+  const kind = resolvedKind(endeavor, context)
+  if (kind !== Kind.task && kind !== Kind.habit && kind !== Kind.reminder) {
+    return false
+  }
+  if (endeavor.status !== Status.closed) return false
+  const completed = endeavor.completed ?? latestCompletionPerformance(endeavor)
+  if (completed === null) return false
+  return isSameCalendarDay(completed, now)
+}
+
+/** The latest `completedAt` across this endeavor's completed performances. */
+const latestCompletionPerformance = (endeavor: Endeavor): Date | null => {
+  let latest: Date | null = null
+  for (const performance of endeavor.performances) {
+    if (performance.resolution !== PerformResolution.complete) continue
+    const at = performance.completedAt
+    if (at === null) continue
+    if (latest === null || at.getTime() > latest.getTime()) latest = at
+  }
+  return latest
+}
+
+// ---------------------------------------------------------------------------
+// Temporal predicates — canon `Endeavor`, with the clock injected
+// ---------------------------------------------------------------------------
+
+/** `Endeavor.isOverdue` — pending, of an actionable kind, and past its due moment. */
+export const isPastDue = (
+  endeavor: Endeavor,
+  now: Date,
+  context: ReconciliationContext,
+): boolean => {
+  if (!isActionableDoKind(endeavor, context)) return false
+  if (hasBeenCompleted(endeavor)) return false
+  const due = endeavor.due
+  return due !== null && due.getTime() < now.getTime()
+}
+
+/** Past-due **and** due today — the Overdue lane. */
+export const isOverdueToday = (
+  endeavor: Endeavor,
+  now: Date,
+  context: ReconciliationContext,
+): boolean =>
+  isPastDue(endeavor, now, context) &&
+  endeavor.due !== null &&
+  isSameCalendarDay(endeavor.due, now)
+
+/** Past-due and due on an **earlier** day — the Expired lane. */
+export const isExpired = (
+  endeavor: Endeavor,
+  now: Date,
+  context: ReconciliationContext,
+): boolean =>
+  isPastDue(endeavor, now, context) &&
+  endeavor.due !== null &&
+  !isSameCalendarDay(endeavor.due, now)
+
+/** `isDueNow(withinHours:now:)` — due at or after `now`, within the window. */
+export const isDueNow = (
+  endeavor: Endeavor,
+  withinHours: number,
+  now: Date,
+  context: ReconciliationContext,
+): boolean => {
+  if (!isActionableDoKind(endeavor, context)) return false
+  if (hasBeenCompleted(endeavor)) return false
+  const due = endeavor.due
+  if (due === null) return false
+  if (due.getTime() < now.getTime()) return false
+  const secondsUntilDue = (due.getTime() - now.getTime()) / 1000
+  return secondsUntilDue <= withinHours * SECONDS_PER_HOUR
+}
+
+/** `isDueNext(withinHours:now:)` — due later **today**, beyond the window. */
+export const isDueNext = (
+  endeavor: Endeavor,
+  withinHours: number,
+  now: Date,
+  context: ReconciliationContext,
+): boolean => {
+  if (!isActionableDoKind(endeavor, context)) return false
+  if (hasBeenCompleted(endeavor)) return false
+  const due = endeavor.due
+  if (due === null) return false
+  if (!isSameCalendarDay(due, now)) return false
+  const secondsUntilDue = (due.getTime() - now.getTime()) / 1000
+  return secondsUntilDue > withinHours * SECONDS_PER_HOUR
+}
+
+// ---------------------------------------------------------------------------
+// Visibility — the lens, read through the resolved kind
+// ---------------------------------------------------------------------------
+
+/**
+ * Canon's kind + host lens terms, in canon's order.
+ *
+ * The host term is the one that surprises: an endeavor is hidden only when
+ * **every** host it lives on is hidden, so hiding one source never hides an
+ * item that also lives in a visible one, and a host-less (in-memory) row
+ * always survives. That is `lensPredicate`'s rule, restated here only so the
+ * kind term can read the **resolved** kind.
+ */
+export const passesDoKindAndHostLens = (
+  endeavor: Endeavor,
+  lens: EndeavorsLens,
+  context: ReconciliationContext,
+): boolean => {
+  if (lens.hiddenKinds.size > 0) {
+    if (lens.hiddenKinds.has(resolvedKind(endeavor, context))) return false
+  }
+  if (lens.hiddenHosts.size > 0 && endeavor.hostedBy.length > 0) {
+    const everyHostHidden = endeavor.hostedBy.every((host) =>
+      lens.hiddenHosts.has(host),
+    )
+    if (everyHostHidden) return false
+  }
+  return true
+}
+
+/** Whether the lens still shows a computed-state-gated lane. */
+export const isComputedStateVisible = (
+  lens: EndeavorsLens,
+  state: EndeavorComputedState,
+): boolean => !lens.hiddenComputedStates.has(state)
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+/**
+ * Canon's `sorted { ($0.due ?? sentinel) < ($1.due ?? sentinel) }`.
+ *
+ * `Array.prototype.sort` is stable (ES2019), where Swift's `sorted` is not —
+ * so two endeavors with the same due moment keep the reconciled pool's own
+ * first-appearance order here, and are arbitrary there. That is a strict
+ * *gain* in determinism over canon, never a change to the ordering canon
+ * actually specifies.
+ */
+const byDueAscending = (
+  endeavors: readonly Endeavor[],
+  missing: 'first' | 'last',
+): readonly Endeavor[] => {
+  const sentinel =
+    missing === 'first' ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY
+  const keyOf = (endeavor: Endeavor) => endeavor.due?.getTime() ?? sentinel
+  return [...endeavors].sort((left, right) => keyOf(left) - keyOf(right))
+}
+
+// ---------------------------------------------------------------------------
+// The regroup
+// ---------------------------------------------------------------------------
+
+export interface DoPartitionInput {
+  /** Canon's `allTasks`: the resolved task channel **plus** habits. */
+  readonly tasks: readonly Endeavor[]
+  /** Canon's `allReminders`, which only Completed Today draws from. */
+  readonly reminders: readonly Endeavor[]
+  readonly lens: EndeavorsLens
+  /** `do.nowThresholdHours` (canon default 2). */
+  readonly nowThresholdHours: number
+  readonly now: Date
+  readonly context?: ReconciliationContext
+}
+
+/**
+ * The pending, visible, actionable pool every lane except Completed Today is
+ * drawn from — canon's `pendingEndeavors` local, term for term.
+ */
+export const pendingDoEndeavors = (
+  input: DoPartitionInput,
+): readonly Endeavor[] => {
+  const context = input.context ?? defaultReconciliationContext()
+  return input.tasks.filter(
+    (endeavor) =>
+      isActionableDoKind(endeavor, context) &&
+      !hasBeenCompleted(endeavor) &&
+      !isCompletedToday(endeavor, input.now, context) &&
+      passesDoKindAndHostLens(endeavor, input.lens, context),
+  )
+}
+
+/**
+ * `applyRegroup`'s six task lanes, minus the featured one (which needs the
+ * score — see `DoFeaturedNow.ts` and `partitionDoLanes`).
+ */
+export const partitionDoTaskLanes = (
+  input: DoPartitionInput,
+  /**
+   * The pending pool, when the caller already has it. The featured lane is
+   * scored from the same pool, so the Shifter computes it once and hands it
+   * to both rather than filtering the day twice.
+   */
+  pending: readonly Endeavor[] = pendingDoEndeavors(input),
+): Omit<DoLanes, 'featuredNow'> => {
+  const context = input.context ?? defaultReconciliationContext()
+  const { lens, now, nowThresholdHours } = input
+
+  const overdue = isComputedStateVisible(lens, EndeavorComputedState.overdue)
+    ? byDueAscending(
+        pending.filter((endeavor) => isOverdueToday(endeavor, now, context)),
+        'first',
+      )
+    : []
+
+  const expired = isComputedStateVisible(lens, EndeavorComputedState.expired)
+    ? byDueAscending(
+        pending.filter((endeavor) => isExpired(endeavor, now, context)),
+        'first',
+      )
+    : []
+
+  // Due Soon = the due-sorted window, then the ongoing tail appended as-is.
+  // Canon appends after sorting, so the tail is deliberately not due-ordered.
+  const dueSoon = byDueAscending(
+    pending.filter((endeavor) =>
+      isDueNow(endeavor, nowThresholdHours, now, context),
+    ),
+    'last',
+  )
+  const ongoing = pending.filter(
+    (endeavor) =>
+      endeavor.status === Status.ongoing &&
+      !isPastDue(endeavor, now, context) &&
+      !isDueNow(endeavor, nowThresholdHours, now, context),
+  )
+
+  const next = byDueAscending(
+    pending.filter((endeavor) =>
+      isDueNext(endeavor, nowThresholdHours, now, context),
+    ),
+    'last',
+  )
+
+  // No temporal sort — canon applies none, so the pool's order is the lane's.
+  const anytime = pending.filter(
+    (endeavor) => endeavor.due === null && endeavor.status !== Status.ongoing,
+  )
+
+  const completedToday = isComputedStateVisible(
+    lens,
+    EndeavorComputedState.completedToday,
+  )
+    ? [...input.tasks, ...input.reminders].filter(
+        (endeavor) =>
+          isCompletedToday(endeavor, now, context) &&
+          passesDoKindAndHostLens(endeavor, lens, context),
+      )
+    : []
+
+  return {
+    now: [...dueSoon, ...ongoing],
+    overdue,
+    expired,
+    next,
+    anytime,
+    completedToday,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auto-advance
+// ---------------------------------------------------------------------------
+
+/**
+ * The lanes auto-advance walks, in canon's priority order: the featured hero
+ * first, then the rest of Due Soon, Overdue, Expired, Next and Anytime.
+ *
+ * Events and Completed Today are absent by construction — the lanes below only
+ * ever hold pending tasks and habits — which is exactly canon's *"events /
+ * completed / hidden never enter"*. Expired sits beside Overdue on purpose:
+ * both are past-due and Do lets the user complete either, so advance must be
+ * able to land on one.
+ */
+export const doAutoAdvanceLaneOrder: readonly DoLane[] = [
+  DoLane.featured,
+  DoLane.now,
+  DoLane.overdue,
+  DoLane.expired,
+  DoLane.next,
+  DoLane.anytime,
+]
+
+/**
+ * Canon's `heroFirstSearchOrder` — centre, then outward alternating leading /
+ * trailing. The featured lane is arranged hero-centred, so walking it in index
+ * order would advance to the *second*-ranked card first.
+ */
+export const heroFirstSearchOrder = (cardCount: number): readonly number[] => {
+  if (cardCount <= 0) return []
+  const centre = Math.floor(cardCount / 2)
+  const indices = [centre]
+  if (centre === 0) return indices
+  for (let distance = 1; distance <= centre; distance += 1) {
+    indices.push(centre - distance)
+    const trailing = centre + distance
+    if (trailing < cardCount) indices.push(trailing)
+  }
+  return indices
+}
+
+/**
+ * `nextActionableCardKeySelector` — the key of the highest-priority card still
+ * actionable, or `null` when nothing is left.
+ *
+ * The same endeavor can appear in more than one lane (the hero is usually also
+ * in Due Soon); the first lane it appears in, in priority order, wins.
+ */
+export const nextActionableCardKey = (lanes: DoLanes): string | null => {
+  for (const lane of doAutoAdvanceLaneOrder) {
+    const cards = laneCards(lanes, lane)
+    const order =
+      lane === DoLane.featured
+        ? heroFirstSearchOrder(cards.length)
+        : cards.map((_, index) => index)
+    for (const index of order) {
+      const endeavor = cards[index]
+      if (endeavor !== undefined) return doCardKey(lane, endeavor.id)
+    }
+  }
+  return null
+}
+
+/** The endeavors one lane holds. */
+export const laneCards = (
+  lanes: DoLanes,
+  lane: DoLane,
+): readonly Endeavor[] => {
+  switch (lane) {
+    case DoLane.featured:
+      return lanes.featuredNow
+    case DoLane.now:
+      return lanes.now
+    case DoLane.overdue:
+      return lanes.overdue
+    case DoLane.expired:
+      return lanes.expired
+    case DoLane.next:
+      return lanes.next
+    case DoLane.anytime:
+      return lanes.anytime
+    case DoLane.completed:
+      return lanes.completedToday
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Clear Expired
+// ---------------------------------------------------------------------------
+
+/**
+ * The endeavors **Clear Expired** closes.
+ *
+ * Canon's reducer arm is `allTasks.filter { (resolvedKind == .task ||
+ * resolvedKind == .habit) && isOverdue && !isDueToday }` — past-due **and not
+ * due today**, i.e. the Expired lane alone. `DoLanes.md` says the action
+ * "clears all `isOverdue` tasks (both today's Overdue and Expired)"; the code
+ * says otherwise and the code is the tie-breaker, so today's Overdue is left
+ * alone. The divergence is named in this PR; if canon rules for the doc, this
+ * predicate is the one line that changes.
+ *
+ * Note it reads the **raw** pool, never the Expired lane: a user who hid the
+ * Expired state still clears everything the action names.
+ */
+export const doClearExpiredTargets = (
+  tasks: readonly Endeavor[],
+  now: Date,
+  context: ReconciliationContext = defaultReconciliationContext(),
+): readonly Endeavor[] =>
+  tasks.filter((endeavor) => isExpired(endeavor, now, context))

--- a/packages/app/src/features/do/DoSelectors.ts
+++ b/packages/app/src/features/do/DoSelectors.ts
@@ -1,0 +1,193 @@
+/**
+ * The Do surface's Selectors (`RC-5`, `RC-20`) — canon's `DoSelectors.swift`.
+ *
+ * Every derived read the surface performs lives here, built with
+ * `createSelector` over `RootState` alone. None of them reads a clock: the
+ * reducer parked the instant it last partitioned against in `clockAnchor`, and
+ * the clock-dependent selectors below read it as ordinary state. That is
+ * canon's own arrangement, for canon's own reason — a pure selector cannot
+ * consult a clock, and a view must not either.
+ *
+ * **The rings read the raw channels, never a lane.** `applyRegroup` bakes the
+ * visibility selection into every lane, so a ring derived from one would jump
+ * whenever the user hid a kind — *"reporting the filter, not the day"*. The
+ * two ring selectors below take `tasks` / `reminders` / `habits` and nothing
+ * else, which makes that guarantee structural rather than remembered.
+ */
+import { createSelector } from '@reduxjs/toolkit'
+import type { RootState } from '../../library/store'
+import type { DoException } from './DoException'
+import type { DoState } from './DoFeature'
+import { centredFeaturedWindow } from './DoFeaturedNow'
+import { areDoRingsVisible, habitsRing, tasksRing } from './DoRings'
+import {
+  type DoLanes,
+  doClearExpiredTargets,
+  nextActionableCardKey,
+} from './DoRules'
+import { areDoSuggestionsVisible } from './DoSuggestions'
+
+const selectDoSlice = (state: RootState): DoState => state.do
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+export const selectIsDoLoading = createSelector(
+  [selectDoSlice],
+  (slice) => slice.load.kind === 'loading',
+)
+
+export const selectDoException = createSelector(
+  [selectDoSlice],
+  (slice): DoException | null =>
+    slice.load.kind === 'failed' ? slice.load.exception : null,
+)
+
+/**
+ * `hasNoEndeavorsGloballySelector` — the true empty state, told apart from a
+ * day whose lanes are empty only because everything in it is filtered or done.
+ */
+export const selectHasNoDoEndeavors = createSelector(
+  [selectDoSlice],
+  (slice) =>
+    slice.tasks.length === 0 &&
+    slice.reminders.length === 0 &&
+    slice.events.length === 0,
+)
+
+// ---------------------------------------------------------------------------
+// Lanes
+// ---------------------------------------------------------------------------
+
+export const selectDoLanes = createSelector(
+  [selectDoSlice],
+  (slice): DoLanes => slice.lanes,
+)
+
+/**
+ * The featured lane as the current width can show it: the centred 3/5/7/9
+ * window of the hero-centred arrangement.
+ *
+ * Narrowing drops flankers from both ends at once, so the hero never moves and
+ * a resize *"uses wider windows to expose more ranked work without displacing
+ * the central hero"*.
+ */
+export const selectDoFeaturedNowLane = createSelector(
+  [selectDoSlice],
+  (slice) => centredFeaturedWindow(slice.lanes.featuredNow, slice.featuredCapacity),
+)
+
+/**
+ * The bell badge — `overdueTasks.count + expiredTasks.count`, i.e. *"all tasks
+ * that have missed their deadline"*.
+ */
+export const selectDoNotificationBadgeCount = createSelector(
+  [selectDoLanes],
+  (lanes) => lanes.overdue.length + lanes.expired.length,
+)
+
+/**
+ * The header's "N left today" — `overdue + expired + now + next + anytime`.
+ *
+ * Neither the featured lane nor Completed Today contributes: featured is a
+ * re-presentation of cards already counted in the others, and completed work
+ * is by definition not left.
+ */
+export const selectDoRemainingTodayCount = createSelector(
+  [selectDoLanes],
+  (lanes) =>
+    lanes.overdue.length +
+    lanes.expired.length +
+    lanes.now.length +
+    lanes.next.length +
+    lanes.anytime.length,
+)
+
+// ---------------------------------------------------------------------------
+// Day-progress rings
+// ---------------------------------------------------------------------------
+
+/**
+ * The inner emerald ring, evaluated at the reducer's last clock reading.
+ *
+ * `null` — no ring drawn — both when nothing is expected today and before the
+ * first regroup has stamped an instant to classify against.
+ */
+export const selectDoTasksRing = createSelector([selectDoSlice], (slice) =>
+  slice.clockAnchor === null
+    ? null
+    : tasksRing(
+        { tasks: slice.tasks, reminders: slice.reminders },
+        slice.clockAnchor,
+      ),
+)
+
+/** The outer gold ring, evaluated at the reducer's last clock reading. */
+export const selectDoHabitsRing = createSelector([selectDoSlice], (slice) =>
+  slice.clockAnchor === null
+    ? null
+    : habitsRing(slice.habits, slice.clockAnchor),
+)
+
+/** Whether the readout is on screen at all — the flag AND'd with bulk mode. */
+export const selectAreDoRingsVisible = createSelector(
+  [selectDoSlice],
+  (slice) =>
+    areDoRingsVisible({
+      activityRingsEnabled: slice.preferences.activityRingsEnabled,
+      isInMarkCompleteMode: slice.isInMarkCompleteMode,
+    }),
+)
+
+// ---------------------------------------------------------------------------
+// Suggestions
+// ---------------------------------------------------------------------------
+
+export const selectDoSuggestions = createSelector(
+  [selectDoSlice],
+  (slice) => slice.suggestions,
+)
+
+/** `showSuggestions` — the preference AND'd with "there is something to show". */
+export const selectAreDoSuggestionsVisible = createSelector(
+  [selectDoSlice],
+  (slice) =>
+    areDoSuggestionsVisible({
+      showSuggestionsPreference: slice.preferences.showSuggestions,
+      suggestions: slice.suggestions,
+    }),
+)
+
+// ---------------------------------------------------------------------------
+// Auto-advance and Clear Expired
+// ---------------------------------------------------------------------------
+
+/**
+ * `nextActionableCardKeySelector` — where focus would land if the prepared
+ * card were completed right now, or `null` when nothing is left.
+ *
+ * Exposed as well as used by the Shifter so the surface can label the
+ * affordance without predicting the order itself.
+ */
+export const selectDoNextActionableCardKey = createSelector(
+  [selectDoLanes],
+  (lanes) => nextActionableCardKey(lanes),
+)
+
+/**
+ * What **Clear Expired** would close.
+ *
+ * Read from the raw task channel and the parked instant, never from the
+ * Expired lane: a user who has hidden the Expired state still clears
+ * everything the action names. The Producer recomputes this from a fresh read
+ * before it mutates anything; this selector exists so the surface can label
+ * the action and hide it when there is nothing to clear.
+ */
+export const selectDoClearExpiredTargets = createSelector(
+  [selectDoSlice],
+  (slice) =>
+    slice.clockAnchor === null
+      ? []
+      : doClearExpiredTargets(slice.tasks, slice.clockAnchor),
+)

--- a/packages/app/src/features/do/DoShifters.ts
+++ b/packages/app/src/features/do/DoShifters.ts
@@ -1,0 +1,354 @@
+/**
+ * The Do surface's Shifters (`RC-4`, `RC-19`) — canon's `applyRegroup`,
+ * `applyFetchedEndeavors`, `applyGenerateSuggestions`, `applyAutoAdvance` and
+ * `synchronizeHabitMirror`, as pure `with…(state, args) => DoState` functions.
+ *
+ * Every one returns a brand-new plain object; none reads a clock, a service or
+ * a random source. Where canon's mutating method reaches for `date()`, the
+ * instant arrives here as an argument — which is the whole reason a midnight
+ * boundary is testable at all.
+ *
+ * **`clockAnchor` is the regroup's own record.** Every Shifter that
+ * re-partitions stamps it, so a later Selector answers against the instant the
+ * lanes were actually built from rather than against whatever the clock says
+ * when the component renders.
+ */
+import {
+  type Endeavor,
+  EndeavorKind as Kind,
+  EndeavorStatus as Status,
+  makeReconciliationContext,
+  partitionByKindResolvingShadows,
+  reconcile,
+  resolvedKind,
+} from '@kro/core'
+import type { DoException } from './DoException'
+import type {
+  DoBackdatedCompletion,
+  DoPreferences,
+  DoState,
+} from './DoFeature'
+import { selectFeaturedNowEndeavors } from './DoFeaturedNow'
+import {
+  type DoLane,
+  type DoPartitionInput,
+  type DoVisibility,
+  doCardKey,
+  doLensFor,
+  nextActionableCardKey,
+  partitionDoTaskLanes,
+  pendingDoEndeavors,
+} from './DoRules'
+import {
+  type DoSuggestionSource,
+  generateDoSuggestions,
+} from './DoSuggestions'
+
+/**
+ * `applyRegroup` — rebuild every lane from the retained channels.
+ *
+ * Called whenever the pool, the visibility selection or `nowThresholdHours`
+ * changes, and on view load. The pending pool is filtered once and handed to
+ * both the lane partition and the featured scorer, exactly as canon's single
+ * `pendingEndeavors` local serves both.
+ *
+ * > **Redundancy: the lanes are cached in state on purpose.** They are derived
+ * > data, which `UZF-11` would ordinarily have a Selector compute. Canon
+ * > partitions once per snapshot and parks the result, because the Do surface
+ * > re-reads the lanes on every card interaction and *"each refreshed Do
+ * > snapshot is reconciled, partitioned, and grouped once before it becomes
+ * > visible, so the rings and ordinary lanes update together without repeated
+ * > whole-screen regrouping"*. The single write point below is what keeps the
+ * > cache honest.
+ */
+const withLanesRegrouped = (state: DoState, now: Date): DoState => {
+  const context = makeReconciliationContext({ now })
+  const input: DoPartitionInput = {
+    tasks: state.tasks,
+    reminders: state.reminders,
+    lens: doLensFor(state.visibility),
+    nowThresholdHours: state.preferences.nowThresholdHours,
+    now,
+    context,
+  }
+
+  const pending = pendingDoEndeavors(input)
+  const taskLanes = partitionDoTaskLanes(input, pending)
+  const featuredNow = selectFeaturedNowEndeavors(pending, now, context)
+
+  return {
+    ...state,
+    clockAnchor: now,
+    lanes: { featuredNow, ...taskLanes },
+  }
+}
+
+/** `applyGenerateSuggestions` — rebuild the nudges from integration state. */
+export function withSuggestionsRefreshed(state: DoState): DoState {
+  return {
+    ...state,
+    suggestions: generateDoSuggestions({
+      integrations: {
+        googleCalendarEnabled: state.preferences.googleCalendarEnabled,
+        googleCalendarConnected: state.isGoogleCalendarConnected,
+      },
+      dismissedSources: state.dismissedSuggestionSources,
+    }),
+  }
+}
+
+/**
+ * One concern: the surface is on screen at `now`, so classify the retained day
+ * against it. Canon's `onViewAppearing` regroups before its fetch returns, so
+ * a returning user sees the already-laid-out day immediately.
+ */
+export function withLoadedAt(state: DoState, now: Date): DoState {
+  return withSuggestionsRefreshed(withLanesRegrouped(state, now))
+}
+
+/** One concern: a read is in flight, so any prior exception is cleared. */
+export function withFetchStarted(state: DoState): DoState {
+  return { ...state, load: { kind: 'loading' } }
+}
+
+/**
+ * One concern: the read failed.
+ *
+ * The channels and the lanes are untouched — canon *"keeps existing data but
+ * clears the refresh spinner so the UI doesn't get stuck loading"*, which is
+ * why `load` is a field beside the day rather than the container of it.
+ */
+export function withException(state: DoState, exception: DoException): DoState {
+  return { ...state, load: { kind: 'failed', exception } }
+}
+
+/**
+ * `applyFetchedEndeavors` — install ONE reconciled snapshot atomically.
+ *
+ * Reconciliation runs **before** the kind split and before partitioning, which
+ * is the `#12` call-order contract: *"source-linked rows are reconciled before
+ * filtering, grouping, or presentation"*. Reconciling later could never repair
+ * a stale row, because the filter would already have dropped the fresh
+ * evidence that proves it stale.
+ *
+ * Every channel is replaced in the same return value, so task, habit and event
+ * channels cannot briefly disagree — that is what makes Clear Expired's
+ * refetch atomic from the surface's point of view.
+ */
+export function withEndeavorsInstalled(
+  state: DoState,
+  endeavors: readonly Endeavor[],
+  now: Date,
+): DoState {
+  const context = makeReconciliationContext({ now })
+  const reconciled = reconcile(endeavors, context)
+  const split = partitionByKindResolvingShadows(reconciled, context)
+
+  return withSuggestionsRefreshed(
+    withLanesRegrouped(
+      {
+        ...state,
+        load: { kind: 'loaded' },
+        // Canon's `allTasks = split.tasks + split.habits`: visible habits
+        // render as ordinary cards and take the ordinary card actions.
+        tasks: [...split.tasks, ...split.habits],
+        habits: split.habits,
+        reminders: split.reminders,
+        events: split.events,
+      },
+      now,
+    ),
+  )
+}
+
+/**
+ * One concern: the preferences and kill-switch flags landed.
+ *
+ * The regroup is not optional — `nowThresholdHours` moves the Due Soon / Next
+ * boundary, so lanes built under the seeded default are wrong the instant the
+ * real value arrives. It is skipped only before the first regroup, when there
+ * is no instant to classify against yet.
+ */
+export function withPreferencesApplied(
+  state: DoState,
+  preferences: DoPreferences,
+): DoState {
+  const applied: DoState = { ...state, preferences }
+  const anchor = state.clockAnchor
+  return withSuggestionsRefreshed(
+    anchor === null ? applied : withLanesRegrouped(applied, anchor),
+  )
+}
+
+/** One concern: the user changed what they want to see, so the lanes rebuild. */
+export function withVisibilityApplied(
+  state: DoState,
+  visibility: DoVisibility,
+  now: Date,
+): DoState {
+  return withLanesRegrouped({ ...state, visibility }, now)
+}
+
+/**
+ * One concern: this nudge is dismissed for good.
+ *
+ * Dismissal is recorded against the **source**, not against a card built from
+ * copy, so re-wording a nudge can never resurrect one the user turned down.
+ */
+export function withSuggestionDismissed(
+  state: DoState,
+  source: DoSuggestionSource,
+): DoState {
+  if (state.dismissedSuggestionSources.includes(source)) return state
+  return withSuggestionsRefreshed({
+    ...state,
+    dismissedSuggestionSources: [...state.dismissedSuggestionSources, source],
+  })
+}
+
+/**
+ * One concern: a card was tapped. Tapping the prepared card un-prepares it.
+ *
+ * A manual tap never arms `shouldScrollToCurrentCard` — only auto-advance
+ * does, so the surface cannot scroll under a finger that just chose a card.
+ */
+export function withCardSelected(
+  state: DoState,
+  lane: DoLane,
+  endeavorId: string,
+): DoState {
+  const key = doCardKey(lane, endeavorId)
+  return {
+    ...state,
+    selectedCardKey: state.selectedCardKey === key ? null : key,
+    shouldScrollToCurrentCard: false,
+  }
+}
+
+/**
+ * One concern: bulk mark-complete mode flipped.
+ *
+ * Entering clears the preparation cursor and any half-open backdating popover
+ * — bulk mode has no single prepared card, and the rings hide while it is on.
+ */
+export function withMarkCompleteModeToggled(state: DoState): DoState {
+  const isEntering = !state.isInMarkCompleteMode
+  return {
+    ...state,
+    isInMarkCompleteMode: isEntering,
+    selectedCardKey: isEntering ? null : state.selectedCardKey,
+    backdating: isEntering ? null : state.backdating,
+    shouldScrollToCurrentCard: false,
+  }
+}
+
+/** One concern: both scroll one-shots are spent. */
+export function withScrollRequestHandled(state: DoState): DoState {
+  return {
+    ...state,
+    shouldScrollToCurrentCard: false,
+    shouldScrollToOverdue: false,
+  }
+}
+
+/** One concern: the completion popover is open on a card, aimed at an instant. */
+export function withBackdatingRequested(
+  state: DoState,
+  endeavorId: string,
+  completionDate: Date,
+): DoState {
+  const backdating: DoBackdatedCompletion = { endeavorId, completionDate }
+  return { ...state, backdating }
+}
+
+/** One concern: the popover closed without completing anything. */
+export function withBackdatingCancelled(state: DoState): DoState {
+  if (state.backdating === null) return state
+  return { ...state, backdating: null }
+}
+
+/**
+ * `synchronizeHabitMirror` — keep the rings' gold denominator aligned after a
+ * card mutation, since habits live in `tasks` as well as in `habits`.
+ */
+const withHabitMirrorSynchronized = (state: DoState): DoState => {
+  const context = makeReconciliationContext({
+    now: state.clockAnchor ?? undefined,
+  })
+  return {
+    ...state,
+    habits: state.tasks.filter(
+      (endeavor) => resolvedKind(endeavor, context) === Kind.habit,
+    ),
+  }
+}
+
+/**
+ * One concern: a completion was confirmed, so close the row here and now.
+ *
+ * Optimistic by design: canon closes the endeavor in state, regroups and
+ * advances focus *before* the persist resolves, so the card leaves its lane
+ * the moment it is tapped.
+ *
+ * **The completion timestamp is stamped here, where canon leaves it `nil`.**
+ * On iOS the host owns the timestamp and hands it back on the next fetch; on
+ * web this store *is* the host and the persist writes exactly this instant, so
+ * stamping it keeps the optimistic state and the refetched state identical —
+ * and it is what makes the two things the specs promise actually happen at the
+ * tap: the card appears in Completed Today (`DoLanes.md` § 9) and the matching
+ * arc *"sweeps forward to its new value"* (`DayProgressRings.md`). A
+ * completion backdated to an earlier day correctly does neither.
+ *
+ * An unknown id is a no-op — a stale card key must not empty the day.
+ */
+export function withOptimisticallyCompleted(
+  state: DoState,
+  endeavorId: string,
+  completionDate: Date,
+  now: Date,
+): DoState {
+  const index = state.tasks.findIndex((endeavor) => endeavor.id === endeavorId)
+  if (index === -1) return state
+  const target = state.tasks[index] as Endeavor
+
+  const tasks = [...state.tasks]
+  tasks[index] = {
+    ...target,
+    status: Status.closed,
+    completed: completionDate,
+  }
+
+  return withLanesRegrouped(
+    withHabitMirrorSynchronized({ ...state, tasks, backdating: null }),
+    now,
+  )
+}
+
+/**
+ * `applyAutoAdvance` — move focus to the new front of the queue.
+ *
+ * Off by default: the `do.autoAdvanceAfterComplete` preference *is* the
+ * rollout gate, so nothing changes for a user who never turned it on. Bulk
+ * mark-complete mode has no preparation cursor to advance and always falls
+ * into the clearing branch. When nothing actionable is left, focus clears
+ * without jumping anywhere.
+ *
+ * The invariant this exists to hold: `selectedCardKey` and
+ * `shouldScrollToCurrentCard` change **together**, so the renderer can never
+ * scroll without a fresh target.
+ */
+export function withAutoAdvanced(state: DoState): DoState {
+  const nextKey =
+    state.preferences.autoAdvanceAfterComplete && !state.isInMarkCompleteMode
+      ? nextActionableCardKey(state.lanes)
+      : null
+
+  if (nextKey === null) {
+    return { ...state, selectedCardKey: null, shouldScrollToCurrentCard: false }
+  }
+  return {
+    ...state,
+    selectedCardKey: nextKey,
+    shouldScrollToCurrentCard: true,
+  }
+}

--- a/packages/app/src/features/do/DoSuggestions.ts
+++ b/packages/app/src/features/do/DoSuggestions.ts
@@ -1,0 +1,98 @@
+/**
+ * The Suggestions lane — the port of canon's `applyGenerateSuggestions`
+ * (`Kro/Application/Do/DoShifters.swift`), specified by `DoLanes.md` § 1.
+ *
+ * Integration nudges: one card per connectable source, *"suppressed once
+ * dismissed for the session"*, and hidden entirely once the user has connected
+ * that source. The whole lane is additionally gated on the
+ * `do.showSuggestions` preference, and canon shows it only when at least one
+ * card survives — an empty lane is not an empty state, it is no lane.
+ *
+ * ## Which sources exist on web
+ *
+ * Canon offers three: Google Calendar, Apple Reminders and Apple Calendar. The
+ * epic puts both Apple hosts permanently out of scope for this product —
+ * EventKit has no web counterpart and *"Google Calendar is the flagship
+ * external host"* — so this port declares the one source that can actually be
+ * connected here. Adding a source later is a member on `DoSuggestionSource`
+ * plus a branch in `generateDoSuggestions`; nothing else changes, which is why
+ * the per-source dismissal set is keyed by source rather than by a minted card
+ * id.
+ *
+ * Canon keys dismissal on `SuggestionCardModel.id`, a hash of the card's copy.
+ * Keying on the **source** instead is deliberate: it means re-wording a nudge
+ * cannot resurrect one the user already dismissed.
+ */
+
+export const DoSuggestionSource = {
+  googleCalendar: 'googleCalendar',
+} as const
+
+export type DoSuggestionSource =
+  (typeof DoSuggestionSource)[keyof typeof DoSuggestionSource]
+
+export const doSuggestionSources: readonly DoSuggestionSource[] = [
+  DoSuggestionSource.googleCalendar,
+]
+
+/**
+ * One nudge. The copy is canon's, verbatim; it lives in the domain tier rather
+ * than the view because `RC-8`'s reasoning applies to any user-facing string
+ * decided by a `kind` — a view that assembled it would let two surfaces drift.
+ */
+export interface DoSuggestion {
+  readonly source: DoSuggestionSource
+  readonly title: string
+  readonly subtitle: string
+  readonly actionTitle: string
+}
+
+/** What the lane needs to know about the world to decide what to offer. */
+export interface DoIntegrationState {
+  /** The `googleCalendar` feature flag. Canon's `isGoogleCalendarEnabled`. */
+  readonly googleCalendarEnabled: boolean
+  /** Whether the user has already linked their account. */
+  readonly googleCalendarConnected: boolean
+}
+
+const GOOGLE_CALENDAR_SUGGESTION: DoSuggestion = {
+  source: DoSuggestionSource.googleCalendar,
+  title: 'Google Calendar',
+  subtitle: 'See all your events in one place.',
+  actionTitle: 'Connect',
+}
+
+/**
+ * `applyGenerateSuggestions` — the cards to show, in canon's declaration order.
+ *
+ * Canon's Google clause is `isGoogleCalendarEnabled && !isGoogleCalendarConnected`:
+ * the flag has to be on for the nudge to be *offerable*, and the account has to
+ * be unlinked for it to still be *worth offering*.
+ */
+export const generateDoSuggestions = (input: {
+  readonly integrations: DoIntegrationState
+  readonly dismissedSources: readonly DoSuggestionSource[]
+}): readonly DoSuggestion[] => {
+  const dismissed = new Set(input.dismissedSources)
+  const suggestions: DoSuggestion[] = []
+
+  if (
+    input.integrations.googleCalendarEnabled &&
+    !input.integrations.googleCalendarConnected &&
+    !dismissed.has(DoSuggestionSource.googleCalendar)
+  ) {
+    suggestions.push(GOOGLE_CALENDAR_SUGGESTION)
+  }
+
+  return suggestions
+}
+
+/**
+ * `showSuggestions = userWantsSuggestions && !suggestions.isEmpty` — the
+ * preference gate AND'd with "there is something to show".
+ */
+export const areDoSuggestionsVisible = (input: {
+  readonly showSuggestionsPreference: boolean
+  readonly suggestions: readonly DoSuggestion[]
+}): boolean =>
+  input.showSuggestionsPreference && input.suggestions.length > 0

--- a/packages/app/src/features/do/__tests__/DoException.test.ts
+++ b/packages/app/src/features/do/__tests__/DoException.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { type DoException, DoExceptions } from '../DoException'
+
+describe('DoExceptions', () => {
+  it('marks a failed refresh recoverable, so the surface can offer a retry', () => {
+    const exception = DoExceptions.fetchFailed('the store is unavailable')
+    expect(exception.kind).toBe('fetchFailed')
+    expect(exception.recoverable).toBe(true)
+  })
+
+  it('marks a stale card key unrecoverable — retrying cannot find it either', () => {
+    expect(DoExceptions.endeavorNotFound('gone').recoverable).toBe(false)
+  })
+
+  it('keeps the two Clear Expired failures apart, because they mean different things', () => {
+    // One says nothing was cleared; the other says everything was cleared but
+    // today's occurrences did not come back. The user's next move differs.
+    expect(DoExceptions.clearExpiredMutationFailed().kind).toBe(
+      'clearExpiredMutationFailed',
+    )
+    expect(DoExceptions.clearExpiredRefreshFailed().kind).toBe(
+      'clearExpiredRefreshFailed',
+    )
+    expect(DoExceptions.clearExpiredMutationFailed().message).not.toBe(
+      DoExceptions.clearExpiredRefreshFailed().message,
+    )
+  })
+
+  it('carries canon’s own copy rather than the raw cause', () => {
+    expect(DoExceptions.clearExpiredMutationFailed().message).toBe(
+      "Couldn't clear every expired endeavor.",
+    )
+  })
+
+  it('folds the developer-facing cause into the message, never into the kind', () => {
+    const exception = DoExceptions.preferencesLoadFailed('storage is gone')
+    expect(exception.kind).toBe('preferencesLoadFailed')
+    expect(exception.message).toContain('storage is gone')
+  })
+
+  it('offers the generic fallback a defensive rejected arm can land in', () => {
+    const exception: DoException = DoExceptions.unknown('kaboom')
+    expect(exception.kind).toBe('unknown')
+    expect(exception.recoverable).toBe(true)
+  })
+
+  it('narrows exhaustively on kind — the discriminant is the whole contract', () => {
+    const copyFor = (exception: DoException): string => {
+      switch (exception.kind) {
+        case 'preferencesLoadFailed':
+        case 'fetchFailed':
+        case 'clearExpiredMutationFailed':
+        case 'clearExpiredRefreshFailed':
+        case 'markCompleteFailed':
+        case 'endeavorNotFound':
+        case 'unknown':
+          return exception.kind
+      }
+    }
+    expect(copyFor(DoExceptions.markCompleteFailed('disk full'))).toBe(
+      'markCompleteFailed',
+    )
+  })
+})

--- a/packages/app/src/features/do/__tests__/DoFeature.test.ts
+++ b/packages/app/src/features/do/__tests__/DoFeature.test.ts
@@ -1,0 +1,637 @@
+import { EndeavorKind, EndeavorStatus } from '@kro/core'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { DoExceptions } from '../DoException'
+import {
+  type DoState,
+  childVisibilityDelegatedSelectionChanged,
+  doSlice,
+  initialDoState,
+  onFeaturedCapacityChanged,
+  onGoogleCalendarConnectionChanged,
+  onScrollRequestHandled,
+  onViewLoaded,
+  userDidCancelBackdatedCompletion,
+  userDidDeselectCard,
+  userDidDismissSuggestion,
+  userDidMarkCardComplete,
+  userDidRequestBackdatedCompletion,
+  userDidTapCard,
+  userDidTapNotifications,
+  userDidToggleMarkCompleteMode,
+} from '../DoFeature'
+import {
+  DO_MOCK_NOW,
+  doEndeavorFixtures,
+  doMockAt,
+  doStateMocks,
+} from '../DoMocks'
+import {
+  clearExpiredThunk,
+  fetchDoEndeavorsThunk,
+  loadDoPreferencesThunk,
+  markEndeavorCompleteThunk,
+} from '../DoProducer'
+import { DoLane, doCardKey, initialDoVisibility } from '../DoRules'
+import { DoSuggestionSource } from '../DoSuggestions'
+
+const reduce = (state: DoState, action: Parameters<typeof doSlice.reducer>[1]) =>
+  doSlice.reducer(state, action)
+
+const loaded = doStateMocks.loadedTypicalDay
+
+const abortError = () => {
+  const error = new Error('Aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle events
+// ---------------------------------------------------------------------------
+
+describe('onViewLoaded', () => {
+  it('classifies the retained day against the instant it carries', () => {
+    const stale = { ...loaded, lanes: initialDoState.lanes, clockAnchor: null }
+    const next = reduce(stale, onViewLoaded({ now: DO_MOCK_NOW }))
+    expect(next.clockAnchor).toEqual(DO_MOCK_NOW)
+    expect(next.lanes.overdue.length).toBeGreaterThan(0)
+  })
+
+  it('re-classifies the same day later in the day', () => {
+    const evening = reduce(loaded, onViewLoaded({ now: doMockAt(17, 19, 0) }))
+    expect(evening.lanes.next).toEqual([])
+  })
+
+  it('leaves an untouched initial state empty rather than inventing lanes', () => {
+    const next = reduce(initialDoState, onViewLoaded({ now: DO_MOCK_NOW }))
+    expect(next.lanes.now).toEqual([])
+    expect(next.clockAnchor).toEqual(DO_MOCK_NOW)
+  })
+})
+
+describe('onFeaturedCapacityChanged', () => {
+  it('records a wider window', () => {
+    expect(
+      reduce(loaded, onFeaturedCapacityChanged({ capacity: 9 })).featuredCapacity,
+    ).toBe(9)
+  })
+
+  it('leaves the arrangement untouched, so the hero does not move on resize', () => {
+    const wider = reduce(loaded, onFeaturedCapacityChanged({ capacity: 7 }))
+    expect(wider.lanes.featuredNow).toEqual(loaded.lanes.featuredNow)
+  })
+
+  it('is a no-op when the capacity has not actually changed', () => {
+    const same = reduce(loaded, onFeaturedCapacityChanged({ capacity: 3 }))
+    expect(same.featuredCapacity).toBe(loaded.featuredCapacity)
+  })
+})
+
+describe('onGoogleCalendarConnectionChanged', () => {
+  const offering: DoState = {
+    ...loaded,
+    preferences: { ...loaded.preferences, googleCalendarEnabled: true },
+  }
+
+  it('withdraws the connect nudge once the account is linked', () => {
+    const offered = reduce(
+      offering,
+      onGoogleCalendarConnectionChanged({ isConnected: false }),
+    )
+    expect(offered.suggestions).toHaveLength(1)
+
+    const linked = reduce(
+      offered,
+      onGoogleCalendarConnectionChanged({ isConnected: true }),
+    )
+    expect(linked.suggestions).toEqual([])
+  })
+
+  it('offers it again if the account is unlinked', () => {
+    const linked = reduce(
+      offering,
+      onGoogleCalendarConnectionChanged({ isConnected: true }),
+    )
+    const unlinked = reduce(
+      linked,
+      onGoogleCalendarConnectionChanged({ isConnected: false }),
+    )
+    expect(unlinked.suggestions).toHaveLength(1)
+  })
+
+  it('offers nothing while the flag is off, whatever the account does', () => {
+    const next = reduce(
+      loaded,
+      onGoogleCalendarConnectionChanged({ isConnected: false }),
+    )
+    expect(next.suggestions).toEqual([])
+  })
+})
+
+describe('childVisibilityDelegatedSelectionChanged', () => {
+  it('installs the selection and regroups in one step', () => {
+    const next = reduce(
+      loaded,
+      childVisibilityDelegatedSelectionChanged({
+        visibility: {
+          ...initialDoVisibility,
+          hiddenComputedStates: ['expired'],
+        },
+        now: DO_MOCK_NOW,
+      }),
+    )
+    expect(next.lanes.expired).toEqual([])
+    expect(next.visibility.hiddenComputedStates).toEqual(['expired'])
+  })
+
+  it('never touches the raw channels the rings read', () => {
+    const next = reduce(
+      loaded,
+      childVisibilityDelegatedSelectionChanged({
+        visibility: { ...initialDoVisibility, hiddenKinds: [EndeavorKind.habit] },
+        now: DO_MOCK_NOW,
+      }),
+    )
+    expect(next.habits).toEqual(loaded.habits)
+  })
+
+  it('restores everything when the selection is cleared', () => {
+    const hidden = reduce(
+      loaded,
+      childVisibilityDelegatedSelectionChanged({
+        visibility: { ...initialDoVisibility, hiddenComputedStates: ['overdue'] },
+        now: DO_MOCK_NOW,
+      }),
+    )
+    const shown = reduce(
+      hidden,
+      childVisibilityDelegatedSelectionChanged({
+        visibility: initialDoVisibility,
+        now: DO_MOCK_NOW,
+      }),
+    )
+    expect(shown.lanes.overdue).toEqual(loaded.lanes.overdue)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Card preparation
+// ---------------------------------------------------------------------------
+
+describe('userDidTapCard', () => {
+  it('prepares the tapped card', () => {
+    const next = reduce(
+      loaded,
+      userDidTapCard({ lane: DoLane.overdue, endeavorId: 'abc' }),
+    )
+    expect(next.selectedCardKey).toBe(doCardKey(DoLane.overdue, 'abc'))
+  })
+
+  it('un-prepares it when the same card is tapped again', () => {
+    const once = reduce(
+      loaded,
+      userDidTapCard({ lane: DoLane.overdue, endeavorId: 'abc' }),
+    )
+    const twice = reduce(
+      once,
+      userDidTapCard({ lane: DoLane.overdue, endeavorId: 'abc' }),
+    )
+    expect(twice.selectedCardKey).toBeNull()
+  })
+
+  it('keeps the same endeavor in two lanes independently selectable', () => {
+    const inNow = reduce(
+      loaded,
+      userDidTapCard({ lane: DoLane.now, endeavorId: 'abc' }),
+    )
+    const inFeatured = reduce(
+      inNow,
+      userDidTapCard({ lane: DoLane.featured, endeavorId: 'abc' }),
+    )
+    expect(inFeatured.selectedCardKey).toBe(doCardKey(DoLane.featured, 'abc'))
+  })
+})
+
+describe('userDidDeselectCard', () => {
+  it('clears the preparation cursor', () => {
+    const prepared = reduce(
+      loaded,
+      userDidTapCard({ lane: DoLane.now, endeavorId: 'abc' }),
+    )
+    expect(reduce(prepared, userDidDeselectCard()).selectedCardKey).toBeNull()
+  })
+
+  it('is harmless when nothing was prepared', () => {
+    expect(reduce(loaded, userDidDeselectCard()).selectedCardKey).toBeNull()
+  })
+
+  it('leaves the lanes alone', () => {
+    const next = reduce(loaded, userDidDeselectCard())
+    expect(next.lanes).toEqual(loaded.lanes)
+  })
+})
+
+describe('userDidToggleMarkCompleteMode', () => {
+  it('enters bulk mode', () => {
+    expect(
+      reduce(loaded, userDidToggleMarkCompleteMode()).isInMarkCompleteMode,
+    ).toBe(true)
+  })
+
+  it('drops the preparation cursor on the way in', () => {
+    const prepared = reduce(
+      loaded,
+      userDidTapCard({ lane: DoLane.now, endeavorId: 'abc' }),
+    )
+    expect(
+      reduce(prepared, userDidToggleMarkCompleteMode()).selectedCardKey,
+    ).toBeNull()
+  })
+
+  it('leaves bulk mode on a second toggle', () => {
+    const inMode = reduce(loaded, userDidToggleMarkCompleteMode())
+    expect(
+      reduce(inMode, userDidToggleMarkCompleteMode()).isInMarkCompleteMode,
+    ).toBe(false)
+  })
+})
+
+describe('userDidTapNotifications', () => {
+  it('arms the jump to Overdue when there is something to jump to', () => {
+    expect(reduce(loaded, userDidTapNotifications()).shouldScrollToOverdue).toBe(
+      true,
+    )
+  })
+
+  it('refuses to arm the jump on a day with nothing overdue', () => {
+    expect(
+      reduce(doStateMocks.loadedEmptyDay, userDidTapNotifications())
+        .shouldScrollToOverdue,
+    ).toBe(false)
+  })
+
+  it('does not disturb the preparation cursor', () => {
+    const prepared = reduce(
+      loaded,
+      userDidTapCard({ lane: DoLane.now, endeavorId: 'abc' }),
+    )
+    expect(reduce(prepared, userDidTapNotifications()).selectedCardKey).toBe(
+      doCardKey(DoLane.now, 'abc'),
+    )
+  })
+})
+
+describe('onScrollRequestHandled', () => {
+  it('spends the overdue jump', () => {
+    const armed = reduce(loaded, userDidTapNotifications())
+    expect(reduce(armed, onScrollRequestHandled()).shouldScrollToOverdue).toBe(
+      false,
+    )
+  })
+
+  it('spends the auto-advance scroll', () => {
+    const armed: DoState = { ...loaded, shouldScrollToCurrentCard: true }
+    expect(
+      reduce(armed, onScrollRequestHandled()).shouldScrollToCurrentCard,
+    ).toBe(false)
+  })
+
+  it('is harmless when nothing was armed', () => {
+    const next = reduce(loaded, onScrollRequestHandled())
+    expect(next.shouldScrollToOverdue).toBe(false)
+    expect(next.shouldScrollToCurrentCard).toBe(false)
+  })
+})
+
+describe('userDidDismissSuggestion', () => {
+  const offering: DoState = {
+    ...loaded,
+    preferences: { ...loaded.preferences, googleCalendarEnabled: true },
+  }
+
+  it('removes the dismissed nudge', () => {
+    const offered = reduce(
+      offering,
+      onGoogleCalendarConnectionChanged({ isConnected: false }),
+    )
+    const next = reduce(
+      offered,
+      userDidDismissSuggestion({ source: DoSuggestionSource.googleCalendar }),
+    )
+    expect(next.suggestions).toEqual([])
+  })
+
+  it('remembers the dismissal, so a later refresh does not resurrect it', () => {
+    const dismissed = reduce(
+      offering,
+      userDidDismissSuggestion({ source: DoSuggestionSource.googleCalendar }),
+    )
+    const refreshed = reduce(
+      dismissed,
+      onGoogleCalendarConnectionChanged({ isConnected: false }),
+    )
+    expect(refreshed.suggestions).toEqual([])
+  })
+
+  it('is idempotent', () => {
+    const once = reduce(
+      offering,
+      userDidDismissSuggestion({ source: DoSuggestionSource.googleCalendar }),
+    )
+    const twice = reduce(
+      once,
+      userDidDismissSuggestion({ source: DoSuggestionSource.googleCalendar }),
+    )
+    expect(twice.dismissedSuggestionSources).toEqual([
+      DoSuggestionSource.googleCalendar,
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Backdated completion
+// ---------------------------------------------------------------------------
+
+describe('userDidRequestBackdatedCompletion', () => {
+  const yesterday = doMockAt(16, 18, 0)
+
+  it('opens the popover aimed at a card and an instant', () => {
+    const next = reduce(
+      loaded,
+      userDidRequestBackdatedCompletion({
+        endeavorId: 'abc',
+        completionDate: yesterday,
+      }),
+    )
+    expect(next.backdating).toEqual({
+      endeavorId: 'abc',
+      completionDate: yesterday,
+    })
+  })
+
+  it('steps the instant without opening a second popover', () => {
+    const opened = reduce(
+      loaded,
+      userDidRequestBackdatedCompletion({
+        endeavorId: 'abc',
+        completionDate: yesterday,
+      }),
+    )
+    const stepped = reduce(
+      opened,
+      userDidRequestBackdatedCompletion({
+        endeavorId: 'abc',
+        completionDate: DO_MOCK_NOW,
+      }),
+    )
+    expect(stepped.backdating?.completionDate).toEqual(DO_MOCK_NOW)
+  })
+
+  it('re-aims at a different card', () => {
+    const opened = reduce(
+      loaded,
+      userDidRequestBackdatedCompletion({
+        endeavorId: 'abc',
+        completionDate: yesterday,
+      }),
+    )
+    const moved = reduce(
+      opened,
+      userDidRequestBackdatedCompletion({
+        endeavorId: 'def',
+        completionDate: yesterday,
+      }),
+    )
+    expect(moved.backdating?.endeavorId).toBe('def')
+  })
+})
+
+describe('userDidCancelBackdatedCompletion', () => {
+  it('closes the popover', () => {
+    const opened = reduce(
+      loaded,
+      userDidRequestBackdatedCompletion({
+        endeavorId: 'abc',
+        completionDate: DO_MOCK_NOW,
+      }),
+    )
+    expect(
+      reduce(opened, userDidCancelBackdatedCompletion()).backdating,
+    ).toBeNull()
+  })
+
+  it('completes nothing on the way out', () => {
+    const opened = reduce(
+      loaded,
+      userDidRequestBackdatedCompletion({
+        endeavorId: doEndeavorFixtures.overdueThisMorning.id,
+        completionDate: DO_MOCK_NOW,
+      }),
+    )
+    const cancelled = reduce(opened, userDidCancelBackdatedCompletion())
+    expect(cancelled.lanes.overdue).toEqual(loaded.lanes.overdue)
+  })
+
+  it('is harmless when no popover was open', () => {
+    expect(reduce(loaded, userDidCancelBackdatedCompletion())).toBe(loaded)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Completion + auto-advance
+// ---------------------------------------------------------------------------
+
+describe('userDidMarkCardComplete', () => {
+  const targetId = doEndeavorFixtures.overdueThisMorning.id
+
+  it('moves the card into Completed Today at the tap', () => {
+    const next = reduce(
+      loaded,
+      userDidMarkCardComplete({
+        endeavorId: targetId,
+        completionDate: DO_MOCK_NOW,
+        now: DO_MOCK_NOW,
+      }),
+    )
+    expect(next.lanes.completedToday.map((endeavor) => endeavor.id)).toContain(
+      targetId,
+    )
+    expect(
+      next.tasks.find((endeavor) => endeavor.id === targetId)?.status,
+    ).toBe(EndeavorStatus.closed)
+  })
+
+  it('clears focus without jumping while auto-advance is off', () => {
+    const next = reduce(
+      loaded,
+      userDidMarkCardComplete({
+        endeavorId: targetId,
+        completionDate: DO_MOCK_NOW,
+        now: DO_MOCK_NOW,
+      }),
+    )
+    expect(next.selectedCardKey).toBeNull()
+    expect(next.shouldScrollToCurrentCard).toBe(false)
+  })
+
+  it('focuses the new front of the queue when auto-advance is on', () => {
+    const next = reduce(
+      doStateMocks.autoAdvanceEnabled,
+      userDidMarkCardComplete({
+        endeavorId: targetId,
+        completionDate: DO_MOCK_NOW,
+        now: DO_MOCK_NOW,
+      }),
+    )
+    expect(next.selectedCardKey).not.toBeNull()
+    expect(next.shouldScrollToCurrentCard).toBe(true)
+    // The completed card is never the new focus.
+    expect(next.selectedCardKey).not.toContain(targetId)
+  })
+
+  it('is a no-op for a card key the day no longer holds', () => {
+    const next = reduce(
+      loaded,
+      userDidMarkCardComplete({
+        endeavorId: 'gone',
+        completionDate: DO_MOCK_NOW,
+        now: DO_MOCK_NOW,
+      }),
+    )
+    expect(next.lanes).toEqual(loaded.lanes)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Thunk lifecycle arms
+// ---------------------------------------------------------------------------
+
+describe('the fetch lifecycle arms', () => {
+  it('shows the spinner on pending and clears any prior exception', () => {
+    const failed = {
+      ...loaded,
+      load: { kind: 'failed' as const, exception: DoExceptions.fetchFailed('x') },
+    }
+    const next = reduce(
+      failed,
+      fetchDoEndeavorsThunk.pending('req', { now: DO_MOCK_NOW }),
+    )
+    expect(next.load).toEqual({ kind: 'loading' })
+  })
+
+  it('degrades an unexpected rejection to the generic exception', () => {
+    const next = reduce(
+      loaded,
+      fetchDoEndeavorsThunk.rejected(new Error('kaboom'), 'req', {
+        now: DO_MOCK_NOW,
+      }),
+    )
+    expect(next.load.kind).toBe('failed')
+    if (next.load.kind === 'failed') {
+      expect(next.load.exception.kind).toBe('unknown')
+    }
+  })
+
+  it('stays silent when a newer refresh aborted this one', () => {
+    const next = reduce(
+      loaded,
+      fetchDoEndeavorsThunk.rejected(abortError(), 'req', { now: DO_MOCK_NOW }),
+    )
+    expect(next.load).toEqual(loaded.load)
+  })
+})
+
+describe('the Clear Expired lifecycle arms', () => {
+  it('shows the spinner while the mutations run', () => {
+    const next = reduce(
+      loaded,
+      clearExpiredThunk.pending('req', { now: DO_MOCK_NOW }),
+    )
+    expect(next.load).toEqual({ kind: 'loading' })
+  })
+
+  it('degrades an unexpected rejection to the generic exception', () => {
+    const next = reduce(
+      loaded,
+      clearExpiredThunk.rejected(new Error('kaboom'), 'req', {
+        now: DO_MOCK_NOW,
+      }),
+    )
+    expect(next.load.kind).toBe('failed')
+  })
+
+  it('stays silent on an aborted clear', () => {
+    const next = reduce(
+      loaded,
+      clearExpiredThunk.rejected(abortError(), 'req', { now: DO_MOCK_NOW }),
+    )
+    expect(next.load).toEqual(loaded.load)
+  })
+})
+
+describe('the preferences and completion lifecycle arms', () => {
+  it('degrades an unexpected preferences rejection to the generic exception', () => {
+    const next = reduce(
+      loaded,
+      loadDoPreferencesThunk.rejected(new Error('kaboom'), 'req'),
+    )
+    expect(next.load.kind).toBe('failed')
+  })
+
+  it('says nothing on a successful persist — the optimistic shift already spoke', () => {
+    const next = reduce(
+      loaded,
+      markEndeavorCompleteThunk.fulfilled(
+        { ok: true, value: doEndeavorFixtures.overdueThisMorning },
+        'req',
+        {
+          endeavorId: doEndeavorFixtures.overdueThisMorning.id,
+          completionDate: DO_MOCK_NOW,
+          now: DO_MOCK_NOW,
+        },
+      ),
+    )
+    expect(next).toEqual(loaded)
+  })
+
+  it('stays silent on an aborted completion', () => {
+    const next = reduce(
+      loaded,
+      markEndeavorCompleteThunk.rejected(abortError(), 'req', {
+        endeavorId: 'abc',
+        completionDate: DO_MOCK_NOW,
+        now: DO_MOCK_NOW,
+      }),
+    )
+    expect(next.load).toEqual(loaded.load)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The invariant every test above depends on
+// ---------------------------------------------------------------------------
+
+describe('the injected clock', () => {
+  it('is the feature’s only source of time — nothing here reads the wall clock', () => {
+    // Every lane boundary, every score and every ring is answered against a
+    // `now` that arrived in a payload or a thunk argument. A single ambient
+    // clock read anywhere in the feature would make a midnight case
+    // untestable and would let a reducer and its Selectors disagree.
+    // Vitest runs with the package root as its cwd (jsdom leaves
+    // `import.meta.url` without a file scheme, so it cannot be used here).
+    const featureDir = join(process.cwd(), 'src', 'features', 'do')
+    const offenders = readdirSync(featureDir)
+      .filter((name) => name.endsWith('.ts') && name !== 'DoMocks.ts')
+      .filter((name) => {
+        const source = readFileSync(join(featureDir, name), 'utf8').replace(
+          /\/\*[\s\S]*?\*\//g,
+          '',
+        )
+        return /\bDate\.now\s*\(|\bnew Date\s*\(/.test(source)
+      })
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/app/src/features/do/__tests__/DoFeaturedNow.test.ts
+++ b/packages/app/src/features/do/__tests__/DoFeaturedNow.test.ts
@@ -1,0 +1,227 @@
+import {
+  type Endeavor,
+  EndeavorKind,
+  EndeavorStatus,
+  makeEndeavor,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  FEATURED_NOW_MAX,
+  centredFeaturedWindow,
+  featuredNowCapacityFor,
+  featuredNowScore,
+  selectFeaturedNowEndeavors,
+} from '../DoFeaturedNow'
+import { DO_MOCK_NOW, doEndeavorFixtures, doMockAt } from '../DoMocks'
+
+const scoreOf = (endeavor: Endeavor) => featuredNowScore(endeavor, DO_MOCK_NOW)
+
+const candidate = (params: {
+  readonly id: string
+  readonly due?: Date | null
+  readonly status?: EndeavorStatus
+  readonly duration?: number | null
+  readonly sessionPoints?: number | null
+  readonly kind?: EndeavorKind
+}): Endeavor =>
+  makeEndeavor({
+    id: params.id,
+    title: params.id,
+    kind: params.kind ?? EndeavorKind.task,
+    status: params.status ?? EndeavorStatus.pending,
+    due: params.due ?? null,
+    duration: params.duration ?? null,
+    sessionPoints: params.sessionPoints ?? null,
+  })
+
+describe('featuredNowScore', () => {
+  it('gives an overdue task the dominating 100, plus 10 for having a due date', () => {
+    expect(scoreOf(doEndeavorFixtures.overdueThisMorning)).toBe(110)
+  })
+
+  it('gives a task due inside two hours 50 + 10', () => {
+    expect(scoreOf(doEndeavorFixtures.dueInExactlyTwoHours)).toBe(60)
+  })
+
+  it('gives a task due inside six hours 25 + 10, plus duration and reward nudges', () => {
+    // Due in four hours, 30 minutes long, worth 25 points: 25 + 10 + 5 + 3.
+    expect(scoreOf(doEndeavorFixtures.richUpcomingTask)).toBe(43)
+  })
+
+  it('scores an undated, idle, unmeasured task zero — no relevance to now', () => {
+    expect(scoreOf(doEndeavorFixtures.zeroScoreTask)).toBe(0)
+  })
+
+  it('lifts an undated task out of zero purely by being ongoing', () => {
+    expect(scoreOf(doEndeavorFixtures.ongoingZeroDueTask)).toBe(30)
+  })
+
+  it('scores a completed endeavor zero however urgent it looked', () => {
+    expect(scoreOf(doEndeavorFixtures.completedTodayTask)).toBe(0)
+  })
+
+  it('scores a reminder zero — the lane is tasks and habits only', () => {
+    expect(scoreOf(doEndeavorFixtures.reminderDueToday)).toBe(0)
+  })
+
+  it('scores a habit exactly as it scores a task', () => {
+    const due = doMockAt(17, 11, 0)
+    expect(scoreOf(candidate({ id: 'h', due, kind: EndeavorKind.habit }))).toBe(
+      scoreOf(candidate({ id: 't', due, kind: EndeavorKind.task })),
+    )
+  })
+
+  it('treats the six-hour band as inclusive and the moment past it as unscored', () => {
+    expect(scoreOf(candidate({ id: 'six', due: doMockAt(17, 16, 0) }))).toBe(35)
+    expect(scoreOf(candidate({ id: 'past-six', due: doMockAt(17, 16, 0, 1) }))).toBe(10)
+  })
+
+  it('nudges only above the default ten reward points, never at it', () => {
+    expect(scoreOf(candidate({ id: 'at-ten', sessionPoints: 10 }))).toBe(0)
+    expect(scoreOf(candidate({ id: 'above-ten', sessionPoints: 11 }))).toBe(3)
+  })
+
+  it('does not consult the Due Soon preference — 2h and 6h are canon constants', () => {
+    // Widening `nowThresholdHours` moves the LANE boundary, never the score.
+    const dueInFive = candidate({ id: 'five', due: doMockAt(17, 15, 0) })
+    expect(featuredNowScore(dueInFive, DO_MOCK_NOW)).toBe(35)
+  })
+})
+
+describe('selectFeaturedNowEndeavors', () => {
+  const overdue = candidate({ id: 'overdue', due: doMockAt(17, 8, 0) }) // 110
+  const imminent = candidate({ id: 'imminent', due: doMockAt(17, 11, 0) }) // 60
+  const soon = candidate({ id: 'soon', due: doMockAt(17, 14, 0) }) // 35
+  const ongoing = candidate({ id: 'ongoing', status: EndeavorStatus.ongoing }) // 30
+  const later = candidate({ id: 'later', due: doMockAt(17, 20, 0) }) // 10
+
+  it('centres the top scorer and flanks it, so three cards read [2nd, 1st, 3rd]', () => {
+    const lane = selectFeaturedNowEndeavors([soon, overdue, imminent], DO_MOCK_NOW)
+    expect(lane.map((endeavor) => endeavor.id)).toEqual([
+      'imminent',
+      'overdue',
+      'soon',
+    ])
+  })
+
+  it('excludes every zero-scoring endeavor', () => {
+    const lane = selectFeaturedNowEndeavors(
+      [overdue, doEndeavorFixtures.zeroScoreTask, imminent],
+      DO_MOCK_NOW,
+    )
+    expect(lane.map((endeavor) => endeavor.id)).not.toContain(
+      doEndeavorFixtures.zeroScoreTask.id,
+    )
+  })
+
+  it('drops the weakest card to keep the count odd', () => {
+    const lane = selectFeaturedNowEndeavors(
+      [overdue, imminent, soon, ongoing],
+      DO_MOCK_NOW,
+    )
+    expect(lane).toHaveLength(3)
+    expect(lane.map((endeavor) => endeavor.id)).not.toContain('ongoing')
+  })
+
+  it('keeps both cards on a two-card day rather than dropping to one', () => {
+    const lane = selectFeaturedNowEndeavors([overdue, imminent], DO_MOCK_NOW)
+    expect(lane.map((endeavor) => endeavor.id)).toEqual(['imminent', 'overdue'])
+  })
+
+  it('never ranks more than nine, and stays odd at the ceiling', () => {
+    const many = Array.from({ length: 14 }, (_, index) =>
+      candidate({
+        id: `task-${index}`,
+        due: doMockAt(17, 9, 0, index),
+      }),
+    )
+    const lane = selectFeaturedNowEndeavors(many, DO_MOCK_NOW)
+    expect(lane).toHaveLength(FEATURED_NOW_MAX)
+  })
+
+  it('breaks a score tie on the earlier due date', () => {
+    const early = candidate({ id: 'early', due: doMockAt(17, 10, 30) })
+    const late = candidate({ id: 'late', due: doMockAt(17, 11, 30) })
+    const third = candidate({ id: 'third', due: doMockAt(17, 11, 45) })
+    // Same score (50 + 10) for all three, so due-asc decides the hero.
+    expect(scoreOf(early)).toBe(scoreOf(late))
+    const lane = selectFeaturedNowEndeavors([late, third, early], DO_MOCK_NOW)
+    expect(lane[1]?.id).toBe('early')
+  })
+
+  it('is deterministic on a full tie: the pool order decides, and repeats', () => {
+    const a = candidate({ id: 'a', due: doMockAt(17, 11, 0) })
+    const b = candidate({ id: 'b', due: doMockAt(17, 11, 0) })
+    const c = candidate({ id: 'c', due: doMockAt(17, 11, 0) })
+    const first = selectFeaturedNowEndeavors([a, b, c], DO_MOCK_NOW)
+    const second = selectFeaturedNowEndeavors([a, b, c], DO_MOCK_NOW)
+    expect(first.map((endeavor) => endeavor.id)).toEqual(['b', 'a', 'c'])
+    expect(second.map((endeavor) => endeavor.id)).toEqual(
+      first.map((endeavor) => endeavor.id),
+    )
+  })
+
+  it('is empty when nothing scores', () => {
+    expect(
+      selectFeaturedNowEndeavors([doEndeavorFixtures.zeroScoreTask], DO_MOCK_NOW),
+    ).toEqual([])
+  })
+
+  it('keeps the hero centred at five and at seven', () => {
+    const seven = [overdue, imminent, soon, ongoing, later].concat([
+      candidate({ id: 'extra-1', due: doMockAt(17, 11, 1) }),
+      candidate({ id: 'extra-2', due: doMockAt(17, 11, 2) }),
+    ])
+    const lane = selectFeaturedNowEndeavors(seven, DO_MOCK_NOW)
+    expect(lane).toHaveLength(7)
+    expect(lane[3]?.id).toBe('overdue')
+  })
+})
+
+describe('featuredNowCapacityFor', () => {
+  it('takes the largest supported odd count that fits', () => {
+    expect(featuredNowCapacityFor(9)).toBe(9)
+    expect(featuredNowCapacityFor(8)).toBe(7)
+    expect(featuredNowCapacityFor(6)).toBe(5)
+  })
+
+  it('floors at three, because the lane stays focused rather than collapsing', () => {
+    expect(featuredNowCapacityFor(1)).toBe(3)
+    expect(featuredNowCapacityFor(0)).toBe(3)
+  })
+
+  it('never exceeds nine however wide the window gets', () => {
+    expect(featuredNowCapacityFor(40)).toBe(9)
+  })
+})
+
+describe('centredFeaturedWindow', () => {
+  // A hero-centred seven: rank 1 is at the centre, ranks 6 and 7 at the ends.
+  const arranged = ['rank6', 'rank4', 'rank2', 'hero', 'rank3', 'rank5', 'rank7'].map(
+    (id) => candidate({ id, due: doMockAt(17, 11, 0) }),
+  )
+
+  it('keeps the hero centred when the width narrows', () => {
+    const window = centredFeaturedWindow(arranged, 3)
+    expect(window.map((endeavor) => endeavor.id)).toEqual([
+      'rank2',
+      'hero',
+      'rank3',
+    ])
+  })
+
+  it('drops the lowest-ranked flankers from both ends, never one', () => {
+    const window = centredFeaturedWindow(arranged, 5)
+    expect(window.map((endeavor) => endeavor.id)).toEqual([
+      'rank4',
+      'rank2',
+      'hero',
+      'rank3',
+      'rank5',
+    ])
+  })
+
+  it('returns the whole lane when it already fits', () => {
+    expect(centredFeaturedWindow(arranged, 9)).toEqual(arranged)
+  })
+})

--- a/packages/app/src/features/do/__tests__/DoMocks.test.ts
+++ b/packages/app/src/features/do/__tests__/DoMocks.test.ts
@@ -1,0 +1,101 @@
+import { endeavorFromRecord } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { initialDoState } from '../DoFeature'
+import {
+  DO_MOCK_NOW,
+  doEndeavorFixtures,
+  doFixtureDay,
+  doFixtureRecords,
+  doMockAt,
+  doStateMocks,
+} from '../DoMocks'
+
+/**
+ * The fixtures are load-bearing: every other suite in this folder asserts
+ * against them, so a fixture that quietly stopped meaning what its name says
+ * would turn a real regression into a green run.
+ */
+
+describe('DO_MOCK_NOW', () => {
+  it('sits mid-morning, so both "earlier today" and "later today" exist', () => {
+    expect(DO_MOCK_NOW.getHours()).toBeGreaterThan(2)
+    expect(DO_MOCK_NOW.getHours()).toBeLessThan(21)
+  })
+
+  it('is a fixed instant, not a clock reading', () => {
+    expect(DO_MOCK_NOW).toEqual(doMockAt(17, 10, 0))
+  })
+
+  it('is the same on every read', () => {
+    expect(DO_MOCK_NOW.getTime()).toBe(doMockAt(17, 10, 0).getTime())
+  })
+})
+
+describe('doFixtureDay', () => {
+  it('holds every named fixture exactly once', () => {
+    const ids = doFixtureDay.map((endeavor) => endeavor.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids).toHaveLength(Object.keys(doEndeavorFixtures).length)
+  })
+
+  it('gives every fixture a distinct id, so a lane assertion cannot alias', () => {
+    for (const [name, fixture] of Object.entries(doEndeavorFixtures)) {
+      expect(fixture.id, `${name} has an id`).not.toBe('')
+    }
+  })
+
+  it('covers every lane the partition can produce', () => {
+    const lanes = doStateMocks.loadedTypicalDay.lanes
+    expect(lanes.overdue.length).toBeGreaterThan(0)
+    expect(lanes.expired.length).toBeGreaterThan(0)
+    expect(lanes.now.length).toBeGreaterThan(0)
+    expect(lanes.next.length).toBeGreaterThan(0)
+    expect(lanes.anytime.length).toBeGreaterThan(0)
+    expect(lanes.completedToday.length).toBeGreaterThan(0)
+    expect(lanes.featuredNow.length).toBeGreaterThan(0)
+  })
+})
+
+describe('doFixtureRecords', () => {
+  it('round-trips every fixture back through the persistence codec', () => {
+    for (const record of doFixtureRecords()) {
+      const hydrated = endeavorFromRecord(record)
+      expect(hydrated.ok, `${record.id} decodes`).toBe(true)
+    }
+  })
+
+  it('keeps the ids stable across the round trip, so a store can be seeded by id', () => {
+    expect(doFixtureRecords().map((record) => record.id)).toEqual(
+      doFixtureDay.map((endeavor) => endeavor.id),
+    )
+  })
+
+  it('accepts the instant a suite wants the rows stamped at', () => {
+    const stamped = doFixtureRecords(doMockAt(18, 9, 0))
+    expect(stamped[0]?.updatedAtEpochMillis).toBe(doMockAt(18, 9, 0).getTime())
+  })
+})
+
+describe('doStateMocks', () => {
+  it('starts from the slice’s own initial state rather than a hand-built one', () => {
+    expect(doStateMocks.idle).toBe(initialDoState)
+  })
+
+  it('produces every variant through the real Shifters', () => {
+    expect(doStateMocks.loading.load).toEqual({ kind: 'loading' })
+    expect(doStateMocks.loadedTypicalDay.load).toEqual({ kind: 'loaded' })
+    expect(doStateMocks.failedRefreshKeepingTheDay.load.kind).toBe('failed')
+  })
+
+  it('keeps the failed-refresh variant holding the good day it failed over', () => {
+    expect(doStateMocks.failedRefreshKeepingTheDay.lanes).toEqual(
+      doStateMocks.loadedTypicalDay.lanes,
+    )
+  })
+
+  it('offers an empty day distinct from an unloaded one', () => {
+    expect(doStateMocks.loadedEmptyDay.load).toEqual({ kind: 'loaded' })
+    expect(doStateMocks.loadedEmptyDay.tasks).toEqual([])
+    expect(doStateMocks.idle.load).toEqual({ kind: 'idle' })
+  })
+})

--- a/packages/app/src/features/do/__tests__/DoProducer.test.ts
+++ b/packages/app/src/features/do/__tests__/DoProducer.test.ts
@@ -1,0 +1,373 @@
+import {
+  type EndeavorRecord,
+  type EndeavorStore,
+  EndeavorStatus,
+  type LocalStore,
+  featureFlagOverrideKey,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { makeInMemoryLocalStore } from '../../../services/localStore/InMemoryLocalStore'
+import { type AppStore, makeStore, stubbedThunkExtra } from '../../../library/store'
+import {
+  DO_MOCK_NOW,
+  doEndeavorFixtures,
+  doFixtureRecords,
+  doMockAt,
+} from '../DoMocks'
+import {
+  clearExpiredThunk,
+  fetchDoEndeavorsThunk,
+  loadDoPreferencesThunk,
+  markEndeavorCompleteThunk,
+} from '../DoProducer'
+
+/**
+ * A store wired to a stubbed `LocalStore` — every suite here goes through
+ * `makeStore(extra)`, never a second `configureStore` (`RC-22`, `RC-35`), and
+ * never the network.
+ */
+const storeWith = (localStore: LocalStore): AppStore =>
+  makeStore({ ...stubbedThunkExtra, localStore })
+
+const seeded = (records: readonly EndeavorRecord[] = doFixtureRecords()) =>
+  makeInMemoryLocalStore({ endeavors: records })
+
+/** Wraps the endeavor store so a suite can log calls or make one of them fail. */
+const instrument = (
+  localStore: LocalStore,
+  hooks: {
+    readonly log?: string[]
+    readonly failPutAfter?: number
+    readonly failAllAfter?: number
+  },
+): LocalStore => {
+  let puts = 0
+  let alls = 0
+  const inner = localStore.endeavors
+  const endeavors: EndeavorStore = {
+    ...inner,
+    all: async () => {
+      alls += 1
+      hooks.log?.push(`all#${alls}`)
+      if (hooks.failAllAfter !== undefined && alls > hooks.failAllAfter) {
+        throw new Error('read failed')
+      }
+      return inner.all()
+    },
+    get: (id) => inner.get(id),
+    put: async (record) => {
+      puts += 1
+      hooks.log?.push(`put#${puts}:${record.id}`)
+      if (hooks.failPutAfter !== undefined && puts > hooks.failPutAfter) {
+        throw new Error('write failed')
+      }
+      return inner.put(record)
+    },
+  }
+  return { ...localStore, endeavors }
+}
+
+// ---------------------------------------------------------------------------
+// Preferences + flags
+// ---------------------------------------------------------------------------
+
+describe('loadDoPreferencesThunk', () => {
+  it('falls back to every option default on a fresh install', async () => {
+    const store = storeWith(seeded())
+    const result = await store.dispatch(loadDoPreferencesThunk())
+
+    expect(result.payload).toEqual({
+      ok: true,
+      value: {
+        showSuggestions: true,
+        nowThresholdHours: 2,
+        autoAdvanceAfterComplete: false,
+        // Both ship enabled in the statusQuo baseline.
+        activityRingsEnabled: true,
+        googleCalendarEnabled: true,
+      },
+    })
+  })
+
+  it('reads a preference the user has changed', async () => {
+    const localStore = seeded()
+    localStore.preferences.set('kro:do.nowThresholdHours', 6)
+    localStore.preferences.set('kro:do.autoAdvanceAfterComplete', true)
+
+    const store = storeWith(localStore)
+    await store.dispatch(loadDoPreferencesThunk())
+
+    expect(store.getState().do.preferences.nowThresholdHours).toBe(6)
+    expect(store.getState().do.preferences.autoAdvanceAfterComplete).toBe(true)
+  })
+
+  it('honours a persisted debug override of the rings kill switch', async () => {
+    const localStore = seeded()
+    localStore.preferences.set(featureFlagOverrideKey('doActivityRings'), false)
+
+    const store = storeWith(localStore)
+    await store.dispatch(loadDoPreferencesThunk())
+
+    expect(store.getState().do.preferences.activityRingsEnabled).toBe(false)
+  })
+
+  it('resolves an exception rather than throwing when the store is unreadable', async () => {
+    const localStore = seeded()
+    const broken: LocalStore = {
+      ...localStore,
+      preferences: {
+        ...localStore.preferences,
+        keys: () => {
+          throw new Error('storage is gone')
+        },
+      },
+    }
+    const store = storeWith(broken)
+    await store.dispatch(loadDoPreferencesThunk())
+
+    const { load } = store.getState().do
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') {
+      expect(load.exception.kind).toBe('preferencesLoadFailed')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The day's fetch
+// ---------------------------------------------------------------------------
+
+describe('fetchDoEndeavorsThunk', () => {
+  it('installs the whole day in one pass', async () => {
+    const store = storeWith(seeded())
+    await store.dispatch(fetchDoEndeavorsThunk({ now: DO_MOCK_NOW }))
+
+    const { load, lanes, habits, events } = store.getState().do
+    expect(load).toEqual({ kind: 'loaded' })
+    expect(lanes.overdue.length).toBeGreaterThan(0)
+    expect(lanes.expired).toHaveLength(2)
+    expect(habits.length).toBeGreaterThan(0)
+    expect(events).toHaveLength(1)
+  })
+
+  it('classifies against the instant it was given, not the wall clock', async () => {
+    const store = storeWith(seeded())
+    // 19:00: the 18:00 task has slipped into Overdue and Next is empty.
+    await store.dispatch(fetchDoEndeavorsThunk({ now: doMockAt(17, 19, 0) }))
+
+    const { lanes, clockAnchor } = store.getState().do
+    expect(clockAnchor).toEqual(doMockAt(17, 19, 0))
+    expect(lanes.next).toEqual([])
+    expect(lanes.overdue.map((endeavor) => endeavor.id)).toContain(
+      doEndeavorFixtures.dueLateToday.id,
+    )
+  })
+
+  it('yields an empty day from an empty store', async () => {
+    const store = storeWith(makeInMemoryLocalStore())
+    await store.dispatch(fetchDoEndeavorsThunk({ now: DO_MOCK_NOW }))
+    expect(store.getState().do.lanes.now).toEqual([])
+  })
+
+  it('keeps the retained day when the read fails', async () => {
+    const localStore = seeded()
+    const store = storeWith(localStore)
+    await store.dispatch(fetchDoEndeavorsThunk({ now: DO_MOCK_NOW }))
+    const goodLanes = store.getState().do.lanes
+
+    const broken = storeWith(instrument(localStore, { failAllAfter: 0 }))
+    await broken.dispatch(fetchDoEndeavorsThunk({ now: DO_MOCK_NOW }))
+    // A different store instance, so assert the shape rather than identity:
+    // the failing dispatch must not have installed anything.
+    expect(broken.getState().do.load.kind).toBe('failed')
+    expect(broken.getState().do.lanes.overdue).toEqual([])
+    expect(goodLanes.overdue.length).toBeGreaterThan(0)
+  })
+
+  it('skips a row whose stored kind no longer decodes, rather than blanking the day', async () => {
+    const records = doFixtureRecords()
+    const corrupted = records.map((record, index) =>
+      index === 0 ? { ...record, kind: 'not-a-kind' } : record,
+    )
+    const store = storeWith(makeInMemoryLocalStore({ endeavors: corrupted }))
+    await store.dispatch(fetchDoEndeavorsThunk({ now: DO_MOCK_NOW }))
+
+    expect(store.getState().do.load).toEqual({ kind: 'loaded' })
+    expect(store.getState().do.tasks.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Clear Expired
+// ---------------------------------------------------------------------------
+
+describe('clearExpiredThunk', () => {
+  it('closes every expired endeavor and leaves today’s overdue alone', async () => {
+    const localStore = seeded()
+    const store = storeWith(localStore)
+    await store.dispatch(fetchDoEndeavorsThunk({ now: DO_MOCK_NOW }))
+    await store.dispatch(clearExpiredThunk({ now: DO_MOCK_NOW }))
+
+    const { lanes } = store.getState().do
+    expect(lanes.expired).toEqual([])
+    expect(lanes.overdue.map((endeavor) => endeavor.id)).toContain(
+      doEndeavorFixtures.overdueThisMorning.id,
+    )
+
+    const cleared = await localStore.endeavors.get(
+      doEndeavorFixtures.expiredLastWeek.id,
+    )
+    expect(cleared?.status).toBe(EndeavorStatus.closed)
+    // Cleared, not completed: an acknowledgement must never fill a ring.
+    expect(cleared?.completed).toBeNull()
+  })
+
+  it('awaits every mutation before the single refetch', async () => {
+    const log: string[] = []
+    const localStore = instrument(seeded(), { log })
+    const store = storeWith(localStore)
+    await store.dispatch(clearExpiredThunk({ now: DO_MOCK_NOW }))
+
+    const firstPut = log.findIndex((entry) => entry.startsWith('put#'))
+    const lastPut = log.map((entry) => entry.startsWith('put#')).lastIndexOf(true)
+    const readsAfterTheLastPut = log
+      .slice(lastPut + 1)
+      .filter((entry) => entry.startsWith('all#'))
+
+    expect(firstPut).toBeGreaterThan(0) // the target read comes first
+    expect(log.filter((entry) => entry.startsWith('put#'))).toHaveLength(2)
+    expect(readsAfterTheLastPut).toHaveLength(1) // exactly one refetch
+  })
+
+  it('installs nothing at all when a mutation fails halfway — no partial day is observable', async () => {
+    const localStore = instrument(seeded(), { failPutAfter: 1 })
+    const store = storeWith(localStore)
+    await store.dispatch(fetchDoEndeavorsThunk({ now: DO_MOCK_NOW }))
+
+    const before = store.getState().do.lanes
+    const seenLanes: unknown[] = []
+    const unsubscribe = store.subscribe(() => {
+      seenLanes.push(store.getState().do.lanes)
+    })
+    await store.dispatch(clearExpiredThunk({ now: DO_MOCK_NOW }))
+    unsubscribe()
+
+    const { load, lanes } = store.getState().do
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') {
+      expect(load.exception.kind).toBe('clearExpiredMutationFailed')
+    }
+    // Every state the reducer produced during the operation carried the same
+    // lanes: there is no instant at which half the day was cleared.
+    expect(lanes).toEqual(before)
+    for (const seen of seenLanes) expect(seen).toEqual(before)
+  })
+
+  it('reports the refresh failure separately once the mutations have landed', async () => {
+    // One read to find the targets succeeds; the refetch after them fails.
+    const localStore = instrument(seeded(), { failAllAfter: 1 })
+    const store = storeWith(localStore)
+    await store.dispatch(clearExpiredThunk({ now: DO_MOCK_NOW }))
+
+    const { load } = store.getState().do
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') {
+      expect(load.exception.kind).toBe('clearExpiredRefreshFailed')
+    }
+  })
+
+  it('is a quiet no-op on a day with nothing expired', async () => {
+    const localStore = makeInMemoryLocalStore({
+      endeavors: doFixtureRecords().filter(
+        (record) =>
+          record.id !== doEndeavorFixtures.expiredLastNight.id &&
+          record.id !== doEndeavorFixtures.expiredLastWeek.id,
+      ),
+    })
+    const log: string[] = []
+    const store = storeWith(instrument(localStore, { log }))
+    await store.dispatch(clearExpiredThunk({ now: DO_MOCK_NOW }))
+
+    expect(log.filter((entry) => entry.startsWith('put#'))).toEqual([])
+    expect(store.getState().do.load).toEqual({ kind: 'loaded' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// One completion
+// ---------------------------------------------------------------------------
+
+describe('markEndeavorCompleteThunk', () => {
+  const targetId = doEndeavorFixtures.overdueThisMorning.id
+
+  it('persists the completion at the instant the popover carried', async () => {
+    const localStore = seeded()
+    const store = storeWith(localStore)
+    const backdated = doMockAt(17, 7, 15)
+
+    await store.dispatch(
+      markEndeavorCompleteThunk({
+        endeavorId: targetId,
+        completionDate: backdated,
+        now: DO_MOCK_NOW,
+      }),
+    )
+
+    const record = await localStore.endeavors.get(targetId)
+    expect(record?.status).toBe(EndeavorStatus.closed)
+    expect(record?.completed).toEqual(backdated)
+  })
+
+  it('reports a stale card key rather than closing the wrong row', async () => {
+    const store = storeWith(seeded())
+    await store.dispatch(
+      markEndeavorCompleteThunk({
+        endeavorId: 'gone',
+        completionDate: DO_MOCK_NOW,
+        now: DO_MOCK_NOW,
+      }),
+    )
+
+    const { load } = store.getState().do
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') expect(load.exception.kind).toBe('endeavorNotFound')
+  })
+
+  it('resolves an exception rather than throwing when the write fails', async () => {
+    const store = storeWith(instrument(seeded(), { failPutAfter: 0 }))
+    await store.dispatch(
+      markEndeavorCompleteThunk({
+        endeavorId: targetId,
+        completionDate: DO_MOCK_NOW,
+        now: DO_MOCK_NOW,
+      }),
+    )
+
+    const { load } = store.getState().do
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') {
+      expect(load.exception.kind).toBe('markCompleteFailed')
+    }
+  })
+
+  it('leaves the sync watermark of an already-synced row intact', async () => {
+    const records = doFixtureRecords().map((record) =>
+      record.id === targetId
+        ? { ...record, lastSyncedAtEpochMillis: 1_700_000_000_000 }
+        : record,
+    )
+    const localStore = makeInMemoryLocalStore({ endeavors: records })
+    const store = storeWith(localStore)
+
+    await store.dispatch(
+      markEndeavorCompleteThunk({
+        endeavorId: targetId,
+        completionDate: DO_MOCK_NOW,
+        now: DO_MOCK_NOW,
+      }),
+    )
+
+    const record = await localStore.endeavors.get(targetId)
+    expect(record?.lastSyncedAtEpochMillis).toBe(1_700_000_000_000)
+  })
+})

--- a/packages/app/src/features/do/__tests__/DoRings.test.ts
+++ b/packages/app/src/features/do/__tests__/DoRings.test.ts
@@ -1,0 +1,228 @@
+import { type Endeavor, EndeavorKind } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { DO_MOCK_NOW, doEndeavorFixtures } from '../DoMocks'
+import { areDoRingsVisible, habitsRing, tasksRing } from '../DoRings'
+import { doLensFor, initialDoVisibility, partitionDoTaskLanes } from '../DoRules'
+
+const {
+  anytimeTask,
+  completedTodayTask,
+  completedYesterdayTask,
+  expiredLastWeek,
+  habitCompletedToday,
+  habitDueSoon,
+  habitUndated,
+  overdueThisMorning,
+  reminderCompletedToday,
+  reminderDueToday,
+} = doEndeavorFixtures
+
+const tasksOf = (endeavors: readonly Endeavor[]) =>
+  endeavors.filter((endeavor) => endeavor.kind !== EndeavorKind.reminder)
+const remindersOf = (endeavors: readonly Endeavor[]) =>
+  endeavors.filter((endeavor) => endeavor.kind === EndeavorKind.reminder)
+
+const ringFor = (endeavors: readonly Endeavor[]) =>
+  tasksRing(
+    { tasks: tasksOf(endeavors), reminders: remindersOf(endeavors) },
+    DO_MOCK_NOW,
+  )
+
+// ---------------------------------------------------------------------------
+// The truth table from DayProgressRings.md
+// ---------------------------------------------------------------------------
+
+describe('the rings truth table', () => {
+  const cases: readonly {
+    readonly state: string
+    readonly endeavors: readonly Endeavor[]
+    readonly tasks: string
+    readonly habits: string
+  }[] = [
+    {
+      state: 'nothing expected today',
+      endeavors: [anytimeTask, expiredLastWeek],
+      tasks: 'absent',
+      habits: 'absent',
+    },
+    {
+      state: 'habits only',
+      endeavors: [habitUndated, habitCompletedToday],
+      tasks: 'absent',
+      habits: '1/2',
+    },
+    {
+      state: 'tasks only',
+      endeavors: [overdueThisMorning, completedTodayTask],
+      tasks: '1/2',
+      habits: 'absent',
+    },
+    {
+      state: 'both, partly done',
+      endeavors: [
+        overdueThisMorning,
+        completedTodayTask,
+        habitDueSoon,
+        habitCompletedToday,
+      ],
+      tasks: '1/2',
+      habits: '1/2',
+    },
+    {
+      state: 'both complete',
+      endeavors: [completedTodayTask, habitCompletedToday],
+      tasks: '1/1',
+      habits: '1/1',
+    },
+  ]
+
+  for (const { state, endeavors, tasks, habits } of cases) {
+    it(`renders ${state} as tasks ${tasks} / habits ${habits}`, () => {
+      const taskRing = ringFor(endeavors)
+      const habitRing = habitsRing(
+        endeavors.filter((endeavor) => endeavor.kind === EndeavorKind.habit),
+        DO_MOCK_NOW,
+      )
+      const describeRing = (ring: { completed: number; expected: number } | null) =>
+        ring === null ? 'absent' : `${ring.completed}/${ring.expected}`
+
+      expect(describeRing(taskRing)).toBe(tasks)
+      expect(describeRing(habitRing)).toBe(habits)
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// The emerald (tasks) ring
+// ---------------------------------------------------------------------------
+
+describe('tasksRing', () => {
+  it('is absent — not empty — when nothing is due today', () => {
+    expect(ringFor([anytimeTask])).toBeNull()
+  })
+
+  it('counts an overdue task, because it is still expected of you today', () => {
+    const ring = ringFor([overdueThisMorning])
+    expect(ring).toEqual({ expected: 1, completed: 0, progress: 0 })
+  })
+
+  it('excludes an expired task outright, so it cannot drag the ring down forever', () => {
+    expect(ringFor([expiredLastWeek])).toBeNull()
+  })
+
+  it('excludes an undated task — it is not expected today either way', () => {
+    expect(ringFor([anytimeTask, overdueThisMorning])?.expected).toBe(1)
+  })
+
+  it('counts a reminder due today alongside tasks', () => {
+    const ring = ringFor([reminderDueToday, reminderCompletedToday])
+    expect(ring).toEqual({ expected: 2, completed: 1, progress: 0.5 })
+  })
+
+  it('never counts a habit a second time as a task', () => {
+    expect(ringFor([habitDueSoon])).toBeNull()
+  })
+
+  it("ignores yesterday's completion", () => {
+    expect(ringFor([completedYesterdayTask])).toBeNull()
+  })
+
+  it('closes at exactly 1 when everything due today is done', () => {
+    expect(ringFor([completedTodayTask])?.progress).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The gold (habits) ring
+// ---------------------------------------------------------------------------
+
+describe('habitsRing', () => {
+  it('counts an undated habit — it is still one of today’s habits', () => {
+    expect(habitsRing([habitUndated], DO_MOCK_NOW)?.expected).toBe(1)
+  })
+
+  it('fills only with habits completed today', () => {
+    const ring = habitsRing(
+      [habitUndated, habitDueSoon, habitCompletedToday],
+      DO_MOCK_NOW,
+    )
+    expect(ring).toEqual({ expected: 3, completed: 1, progress: 1 / 3 })
+  })
+
+  it('is absent on a day with no habits at all', () => {
+    expect(habitsRing([], DO_MOCK_NOW)).toBeNull()
+  })
+
+  it('ignores anything that is not a habit', () => {
+    expect(habitsRing([overdueThisMorning], DO_MOCK_NOW)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Filter independence — the rule the whole file exists for
+// ---------------------------------------------------------------------------
+
+describe('the rings and the visibility selection', () => {
+  it('still counts a habit the user has hidden from every lane', () => {
+    // Hiding the habit kind empties the habit cards from the lanes…
+    const hidingHabits = doLensFor({
+      ...initialDoVisibility,
+      hiddenKinds: [EndeavorKind.habit],
+    })
+    const lanes = partitionDoTaskLanes({
+      tasks: [habitDueSoon, habitUndated, overdueThisMorning],
+      reminders: [],
+      lens: hidingHabits,
+      nowThresholdHours: 2,
+      now: DO_MOCK_NOW,
+    })
+    expect(lanes.now.concat(lanes.anytime)).toEqual([])
+
+    // …and leaves the gold denominator exactly where it was, because the ring
+    // is a fact about the day rather than about what is on screen.
+    expect(
+      habitsRing([habitDueSoon, habitUndated], DO_MOCK_NOW)?.expected,
+    ).toBe(2)
+  })
+
+  it('does not move when the Completed Today lane is hidden', () => {
+    // Hiding the completed state empties that lane; the numerator here is
+    // computed from the channel, so it is untouched.
+    const ring = ringFor([overdueThisMorning, completedTodayTask])
+    expect(ring?.completed).toBe(1)
+  })
+
+  it('counts every host, not only the visible one', () => {
+    const ring = ringFor([overdueThisMorning, reminderDueToday])
+    expect(ring?.expected).toBe(2)
+  })
+})
+
+describe('areDoRingsVisible', () => {
+  it('shows the readout when the kill switch is on and bulk mode is off', () => {
+    expect(
+      areDoRingsVisible({
+        activityRingsEnabled: true,
+        isInMarkCompleteMode: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('hides it in bulk mark-complete mode, so nothing competes with the instruction', () => {
+    expect(
+      areDoRingsVisible({
+        activityRingsEnabled: true,
+        isInMarkCompleteMode: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('hides it when the flag is off', () => {
+    expect(
+      areDoRingsVisible({
+        activityRingsEnabled: false,
+        isInMarkCompleteMode: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/app/src/features/do/__tests__/DoRules.test.ts
+++ b/packages/app/src/features/do/__tests__/DoRules.test.ts
@@ -1,0 +1,663 @@
+import {
+  EndeavorComputedState,
+  EndeavorHost,
+  EndeavorKind,
+  defaultReconciliationContext,
+  makeEndeavor,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  DO_MOCK_NOW,
+  doEndeavorFixtures,
+  doFixtureDay,
+  doMockAt,
+} from '../DoMocks'
+import {
+  DoLane,
+  type DoPartitionInput,
+  type DoVisibility,
+  doCardKey,
+  doClearExpiredTargets,
+  doLensFor,
+  emptyDoLanes,
+  heroFirstSearchOrder,
+  initialDoVisibility,
+  doAutoAdvanceLaneOrder,
+  isActionableDoKind,
+  isCompletedToday,
+  isComputedStateVisible,
+  isDueNext,
+  isDueNow,
+  isExpired,
+  isOverdueToday,
+  isPastDue,
+  laneCards,
+  nextActionableCardKey,
+  partitionDoTaskLanes,
+  passesDoKindAndHostLens,
+  pendingDoEndeavors,
+} from '../DoRules'
+
+const inputFor = (
+  overrides: Partial<DoPartitionInput> = {},
+): DoPartitionInput => ({
+  tasks: doFixtureDay.filter(
+    (endeavor) => endeavor.kind !== EndeavorKind.calendarEvent && endeavor.kind !== EndeavorKind.reminder,
+  ),
+  reminders: doFixtureDay.filter(
+    (endeavor) => endeavor.kind === EndeavorKind.reminder,
+  ),
+  lens: doLensFor(initialDoVisibility),
+  nowThresholdHours: 2,
+  now: DO_MOCK_NOW,
+  ...overrides,
+})
+
+/** Every task lane the given endeavor id lands in, in canon's lane order. */
+const lanesContaining = (
+  id: string,
+  input: DoPartitionInput = inputFor(),
+): readonly DoLane[] => {
+  const lanes = partitionDoTaskLanes(input)
+  const found: DoLane[] = []
+  const has = (list: readonly { id: string }[]) =>
+    list.some((endeavor) => endeavor.id === id)
+  if (has(lanes.overdue)) found.push(DoLane.overdue)
+  if (has(lanes.now)) found.push(DoLane.now)
+  if (has(lanes.expired)) found.push(DoLane.expired)
+  if (has(lanes.next)) found.push(DoLane.next)
+  if (has(lanes.anytime)) found.push(DoLane.anytime)
+  if (has(lanes.completedToday)) found.push(DoLane.completed)
+  return found
+}
+
+// ---------------------------------------------------------------------------
+// The table-driven lane suite from DoLanes.md
+// ---------------------------------------------------------------------------
+
+describe('the Do lanes, over one fixture day', () => {
+  const cases: readonly {
+    readonly fixture: keyof typeof doEndeavorFixtures
+    readonly lanes: readonly DoLane[]
+    readonly why: string
+  }[] = [
+    {
+      fixture: 'overdueThisMorning',
+      lanes: [DoLane.overdue],
+      why: 'pending and due earlier today',
+    },
+    {
+      fixture: 'overdueOneMinuteAgo',
+      lanes: [DoLane.overdue],
+      why: 'one minute past due is already Overdue, never still Due Soon',
+    },
+    {
+      fixture: 'overdueAtMidnightToday',
+      lanes: [DoLane.overdue],
+      why: 'due at 00:00 today is due TODAY, so Overdue rather than Expired',
+    },
+    {
+      fixture: 'dueAtExactlyNow',
+      lanes: [DoLane.now],
+      why: 'the Due Soon boundary is closed: due >= now',
+    },
+    {
+      fixture: 'dueInExactlyTwoHours',
+      lanes: [DoLane.now],
+      why: 'the window is inclusive, so exactly two hours away is still Due Soon',
+    },
+    {
+      fixture: 'dueOneSecondPastWindow',
+      lanes: [DoLane.next],
+      why: 'one second past the window crosses into Next',
+    },
+    {
+      fixture: 'ongoingUndated',
+      lanes: [DoLane.now],
+      why: 'ongoing work stays visible in Due Soon and never falls to Anytime',
+    },
+    {
+      fixture: 'ongoingDueTomorrow',
+      lanes: [DoLane.now],
+      why: 'the ongoing tail ignores the due date entirely',
+    },
+    {
+      fixture: 'ongoingAndOverdue',
+      lanes: [DoLane.overdue],
+      why: 'the ongoing + overdue overlap resolves to Overdue alone, never both',
+    },
+    {
+      fixture: 'expiredLastNight',
+      lanes: [DoLane.expired],
+      why: 'due 23:59 yesterday is Expired one minute later — the split is by day',
+    },
+    {
+      fixture: 'expiredLastWeek',
+      lanes: [DoLane.expired],
+      why: 'long past its day',
+    },
+    {
+      fixture: 'dueLateToday',
+      lanes: [DoLane.next],
+      why: 'due later today, beyond the window',
+    },
+    {
+      fixture: 'dueTomorrowMorning',
+      lanes: [],
+      why: 'Next requires due-today and Anytime requires no due date, so neither takes it',
+    },
+    {
+      fixture: 'dueAtMidnightTonight',
+      lanes: [],
+      why: '00:00 tomorrow is the far side of the midnight edge',
+    },
+    {
+      fixture: 'skippedThisMorning',
+      lanes: [],
+      why: 'skipped counts as completed for the lanes but not for Completed Today',
+    },
+    {
+      fixture: 'anytimeTask',
+      lanes: [DoLane.anytime],
+      why: 'no due date and not ongoing',
+    },
+    {
+      fixture: 'habitDueSoon',
+      lanes: [DoLane.now],
+      why: 'habits are actionable alongside tasks',
+    },
+    {
+      fixture: 'habitUndated',
+      lanes: [DoLane.anytime],
+      why: 'an undated habit is pickable whenever',
+    },
+    {
+      fixture: 'habitCompletedToday',
+      lanes: [DoLane.completed],
+      why: 'closed with a completion stamped today',
+    },
+    {
+      fixture: 'completedTodayTask',
+      lanes: [DoLane.completed],
+      why: 'the ordinary completed-today case',
+    },
+    {
+      fixture: 'completedYesterdayTask',
+      lanes: [],
+      why: "yesterday's completion is not today's record",
+    },
+    {
+      fixture: 'completedTodayViaPerformance',
+      lanes: [DoLane.completed],
+      why: 'the performance carries the completion the host never returned',
+    },
+    {
+      fixture: 'reminderDueToday',
+      lanes: [],
+      why: 'reminders are not an actionable Do kind — they have their own lane',
+    },
+    {
+      fixture: 'reminderCompletedToday',
+      lanes: [DoLane.completed],
+      why: 'Completed Today draws from reminders as well as tasks',
+    },
+    {
+      fixture: 'eventToday',
+      lanes: [],
+      why: 'events are neither partitioned nor completed here',
+    },
+  ]
+
+  for (const { fixture, lanes, why } of cases) {
+    it(`puts ${fixture} in [${lanes.join(', ') || 'no lane'}] — ${why}`, () => {
+      expect(lanesContaining(doEndeavorFixtures[fixture].id)).toEqual(lanes)
+    })
+  }
+})
+
+describe('lane ordering', () => {
+  it('sorts Overdue oldest-first so the longest-missed task leads', () => {
+    const { overdue } = partitionDoTaskLanes(inputFor())
+    expect(overdue.map((endeavor) => endeavor.id)).toEqual([
+      doEndeavorFixtures.overdueAtMidnightToday.id,
+      doEndeavorFixtures.overdueThisMorning.id,
+      doEndeavorFixtures.ongoingAndOverdue.id,
+      doEndeavorFixtures.overdueOneMinuteAgo.id,
+    ])
+  })
+
+  it('sorts Expired oldest-first', () => {
+    const { expired } = partitionDoTaskLanes(inputFor())
+    expect(expired.map((endeavor) => endeavor.id)).toEqual([
+      doEndeavorFixtures.expiredLastWeek.id,
+      doEndeavorFixtures.expiredLastNight.id,
+    ])
+  })
+
+  it('appends the ongoing tail after the due-sorted head, unsorted', () => {
+    const { now } = partitionDoTaskLanes(inputFor())
+    expect(now.map((endeavor) => endeavor.id)).toEqual([
+      doEndeavorFixtures.dueAtExactlyNow.id,
+      doEndeavorFixtures.habitDueSoon.id,
+      doEndeavorFixtures.dueInExactlyTwoHours.id,
+      // The tail: pool order, not due order — `ongoingDueTomorrow` is due
+      // *later* than nothing above it yet still sits last but one.
+      doEndeavorFixtures.ongoingUndated.id,
+      doEndeavorFixtures.ongoingDueTomorrow.id,
+      doEndeavorFixtures.ongoingZeroDueTask.id,
+    ])
+  })
+
+  it('leaves Anytime in pool order — canon applies no temporal sort', () => {
+    const { anytime } = partitionDoTaskLanes(inputFor())
+    expect(anytime.map((endeavor) => endeavor.id)).toEqual([
+      doEndeavorFixtures.anytimeTask.id,
+      doEndeavorFixtures.habitUndated.id,
+      doEndeavorFixtures.zeroScoreTask.id,
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Predicates, at the boundary
+// ---------------------------------------------------------------------------
+
+describe('isPastDue', () => {
+  it('is true one millisecond after the due moment', () => {
+    const due = doMockAt(17, 10, 0)
+    const endeavor = makeEndeavor({ id: 'x', title: 'x', kind: EndeavorKind.task, due })
+    expect(isPastDue(endeavor, new Date(due.getTime() + 1), defaultReconciliationContext())).toBe(true)
+  })
+
+  it('is false at exactly the due moment — that instant still belongs to Due Soon', () => {
+    const due = doMockAt(17, 10, 0)
+    const endeavor = makeEndeavor({ id: 'x', title: 'x', kind: EndeavorKind.task, due })
+    expect(isPastDue(endeavor, due, defaultReconciliationContext())).toBe(false)
+  })
+
+  it('is false for a closed endeavor, however long past due', () => {
+    expect(
+      isPastDue(doEndeavorFixtures.completedYesterdayTask, DO_MOCK_NOW, defaultReconciliationContext()),
+    ).toBe(false)
+  })
+})
+
+describe('isOverdueToday / isExpired', () => {
+  it('calls a task due one minute before midnight Expired the next morning', () => {
+    const endeavor = doEndeavorFixtures.expiredLastNight
+    expect(isExpired(endeavor, DO_MOCK_NOW, defaultReconciliationContext())).toBe(true)
+    expect(isOverdueToday(endeavor, DO_MOCK_NOW, defaultReconciliationContext())).toBe(false)
+  })
+
+  it('moves a task from Overdue to Expired the moment the calendar day turns', () => {
+    // Due 23:59 on the 16th. The 30 seconds either side of midnight are the
+    // whole rule: nothing about the task changes, only which day `now` is on.
+    const endeavor = doEndeavorFixtures.expiredLastNight
+    const thatEvening = doMockAt(16, 23, 59, 30)
+    const justAfterMidnight = doMockAt(17, 0, 0, 30)
+
+    expect(isOverdueToday(endeavor, thatEvening, defaultReconciliationContext())).toBe(true)
+    expect(isExpired(endeavor, thatEvening, defaultReconciliationContext())).toBe(false)
+
+    expect(
+      isOverdueToday(endeavor, justAfterMidnight, defaultReconciliationContext()),
+    ).toBe(false)
+    expect(isExpired(endeavor, justAfterMidnight, defaultReconciliationContext())).toBe(true)
+  })
+
+  it('never calls the same endeavor both Overdue and Expired', () => {
+    for (const endeavor of doFixtureDay) {
+      const both =
+        isOverdueToday(endeavor, DO_MOCK_NOW, defaultReconciliationContext()) &&
+        isExpired(endeavor, DO_MOCK_NOW, defaultReconciliationContext())
+      expect(both).toBe(false)
+    }
+  })
+})
+
+describe('isDueNow / isDueNext against the nowThresholdHours preference', () => {
+  const dueInFourHours = makeEndeavor({
+    id: 'four-hours',
+    title: 'Four hours out',
+    kind: EndeavorKind.task,
+    due: doMockAt(17, 14, 0),
+  })
+
+  it('is Next at the default two-hour window', () => {
+    expect(isDueNow(dueInFourHours, 2, DO_MOCK_NOW, defaultReconciliationContext())).toBe(false)
+    expect(isDueNext(dueInFourHours, 2, DO_MOCK_NOW, defaultReconciliationContext())).toBe(true)
+  })
+
+  it('becomes Due Soon once the user widens the window to six hours', () => {
+    expect(isDueNow(dueInFourHours, 6, DO_MOCK_NOW, defaultReconciliationContext())).toBe(true)
+    expect(isDueNext(dueInFourHours, 6, DO_MOCK_NOW, defaultReconciliationContext())).toBe(false)
+  })
+
+  it('never lets a task due tomorrow into Next, however wide the window', () => {
+    expect(
+      isDueNext(doEndeavorFixtures.dueTomorrowMorning, 24, DO_MOCK_NOW, defaultReconciliationContext()),
+    ).toBe(false)
+  })
+})
+
+describe('isCompletedToday', () => {
+  it('accepts a closed endeavor whose host stamped today', () => {
+    expect(
+      isCompletedToday(doEndeavorFixtures.completedTodayTask, DO_MOCK_NOW, defaultReconciliationContext()),
+    ).toBe(true)
+  })
+
+  it('falls back to the latest completed performance when the host stamped nothing', () => {
+    expect(
+      isCompletedToday(
+        doEndeavorFixtures.completedTodayViaPerformance,
+        DO_MOCK_NOW,
+        defaultReconciliationContext(),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects a skipped endeavor — skipping is not completing', () => {
+    expect(
+      isCompletedToday(doEndeavorFixtures.skippedThisMorning, DO_MOCK_NOW, defaultReconciliationContext()),
+    ).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Visibility
+// ---------------------------------------------------------------------------
+
+describe('the visibility selection', () => {
+  it('empties the Expired lane when the user hides the expired state', () => {
+    const visibility: DoVisibility = {
+      ...initialDoVisibility,
+      hiddenComputedStates: [EndeavorComputedState.expired],
+    }
+    const lanes = partitionDoTaskLanes(inputFor({ lens: doLensFor(visibility) }))
+    expect(lanes.expired).toEqual([])
+    expect(lanes.overdue.length).toBeGreaterThan(0)
+  })
+
+  it('drops habits from every lane when the habit kind is hidden', () => {
+    const visibility: DoVisibility = {
+      ...initialDoVisibility,
+      hiddenKinds: [EndeavorKind.habit],
+    }
+    const lanes = partitionDoTaskLanes(inputFor({ lens: doLensFor(visibility) }))
+    expect(lanes.now.map((endeavor) => endeavor.id)).not.toContain(
+      doEndeavorFixtures.habitDueSoon.id,
+    )
+    expect(lanes.anytime.map((endeavor) => endeavor.id)).not.toContain(
+      doEndeavorFixtures.habitUndated.id,
+    )
+  })
+
+  it('keeps a multi-host endeavor while one of its hosts is still visible', () => {
+    const shared = makeEndeavor({
+      id: 'multi-host',
+      title: 'Shared task',
+      kind: EndeavorKind.task,
+      due: doMockAt(17, 11, 0),
+      hostedBy: [EndeavorHost.local, EndeavorHost.supabase],
+    })
+    const lens = doLensFor({
+      ...initialDoVisibility,
+      hiddenHosts: [EndeavorHost.local],
+    })
+    expect(passesDoKindAndHostLens(shared, lens, defaultReconciliationContext())).toBe(true)
+
+    const bothHidden = doLensFor({
+      ...initialDoVisibility,
+      hiddenHosts: [EndeavorHost.local, EndeavorHost.supabase],
+    })
+    expect(passesDoKindAndHostLens(shared, bothHidden, defaultReconciliationContext())).toBe(false)
+  })
+})
+
+describe('pendingDoEndeavors', () => {
+  it('keeps only actionable, uncompleted kinds', () => {
+    const pending = pendingDoEndeavors(inputFor())
+    const ids = pending.map((endeavor) => endeavor.id)
+    expect(ids).toContain(doEndeavorFixtures.anytimeTask.id)
+    expect(ids).not.toContain(doEndeavorFixtures.reminderDueToday.id)
+    expect(ids).not.toContain(doEndeavorFixtures.completedTodayTask.id)
+  })
+
+  it('excludes an endeavor completed today even before its status settles', () => {
+    const pending = pendingDoEndeavors(inputFor())
+    expect(pending.map((endeavor) => endeavor.id)).not.toContain(
+      doEndeavorFixtures.completedTodayViaPerformance.id,
+    )
+  })
+
+  it('is empty for an empty day', () => {
+    expect(pendingDoEndeavors(inputFor({ tasks: [], reminders: [] }))).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Auto-advance
+// ---------------------------------------------------------------------------
+
+describe('heroFirstSearchOrder', () => {
+  it('walks a three-card lane centre, leading, trailing', () => {
+    expect(heroFirstSearchOrder(3)).toEqual([1, 0, 2])
+  })
+
+  it('walks a nine-card lane outward from the hero', () => {
+    expect(heroFirstSearchOrder(9)).toEqual([4, 3, 5, 2, 6, 1, 7, 0, 8])
+  })
+
+  it('returns nothing for an empty lane', () => {
+    expect(heroFirstSearchOrder(0)).toEqual([])
+  })
+})
+
+describe('nextActionableCardKey', () => {
+  const cardOf = (id: string) => ({ ...doEndeavorFixtures.anytimeTask, id })
+
+  it('prefers the featured hero over every other lane', () => {
+    const key = nextActionableCardKey({
+      ...emptyDoLanes,
+      featuredNow: [cardOf('flanker'), cardOf('hero'), cardOf('other')],
+      overdue: [cardOf('overdue')],
+    })
+    expect(key).toBe(doCardKey(DoLane.featured, 'hero'))
+  })
+
+  it('falls through the documented order once the featured lane is empty', () => {
+    const key = nextActionableCardKey({
+      ...emptyDoLanes,
+      expired: [cardOf('expired')],
+      next: [cardOf('next')],
+    })
+    expect(key).toBe(doCardKey(DoLane.expired, 'expired'))
+  })
+
+  it('is null when nothing actionable is left, so focus clears without jumping', () => {
+    expect(
+      nextActionableCardKey({
+        ...emptyDoLanes,
+        completedToday: [cardOf('done')],
+      }),
+    ).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Clear Expired
+// ---------------------------------------------------------------------------
+
+describe('doClearExpiredTargets', () => {
+  it('names every expired endeavor', () => {
+    const targets = doClearExpiredTargets(doFixtureDay, DO_MOCK_NOW)
+    expect(targets.map((endeavor) => endeavor.id).sort()).toEqual(
+      [
+        doEndeavorFixtures.expiredLastNight.id,
+        doEndeavorFixtures.expiredLastWeek.id,
+      ].sort(),
+    )
+  })
+
+  it("leaves today's overdue alone — the code's set, not the doc's", () => {
+    const targets = doClearExpiredTargets(doFixtureDay, DO_MOCK_NOW).map(
+      (endeavor) => endeavor.id,
+    )
+    expect(targets).not.toContain(doEndeavorFixtures.overdueThisMorning.id)
+    expect(targets).not.toContain(doEndeavorFixtures.ongoingAndOverdue.id)
+  })
+
+  it('is empty on a day with nothing expired', () => {
+    expect(
+      doClearExpiredTargets([doEndeavorFixtures.anytimeTask], DO_MOCK_NOW),
+    ).toEqual([])
+  })
+})
+
+describe('doCardKey', () => {
+  it('mints canon’s "lane:id" shape', () => {
+    expect(doCardKey(DoLane.overdue, 'abc')).toBe('overdue:abc')
+  })
+
+  it('keys the same endeavor differently per lane, so one selection cannot span two', () => {
+    expect(doCardKey(DoLane.featured, 'abc')).not.toBe(doCardKey(DoLane.now, 'abc'))
+  })
+
+  it('keeps the completed tag distinct from the rest', () => {
+    expect(doCardKey(DoLane.completed, 'abc')).toBe('completed:abc')
+  })
+})
+
+describe('doLensFor', () => {
+  it('keeps the vista’s showArchived so Completed Today survives a refetch', () => {
+    expect(doLensFor(initialDoVisibility).showArchived).toBe(true)
+  })
+
+  it('materialises the user’s hidden kinds as a set', () => {
+    const lens = doLensFor({
+      ...initialDoVisibility,
+      hiddenKinds: [EndeavorKind.habit],
+    })
+    expect(lens.hiddenKinds.has(EndeavorKind.habit)).toBe(true)
+  })
+
+  it('hides nothing by default', () => {
+    const lens = doLensFor(initialDoVisibility)
+    expect(lens.hiddenKinds.size + lens.hiddenHosts.size).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The small predicates the lanes are assembled from
+// ---------------------------------------------------------------------------
+
+describe('isActionableDoKind', () => {
+  it('admits a task', () => {
+    expect(
+      isActionableDoKind(
+        doEndeavorFixtures.anytimeTask,
+        defaultReconciliationContext(),
+      ),
+    ).toBe(true)
+  })
+
+  it('admits a habit, which Do treats as an ordinary card', () => {
+    expect(
+      isActionableDoKind(
+        doEndeavorFixtures.habitUndated,
+        defaultReconciliationContext(),
+      ),
+    ).toBe(true)
+  })
+
+  it('refuses a reminder and an event — neither is completed from a lane', () => {
+    expect(
+      isActionableDoKind(
+        doEndeavorFixtures.reminderDueToday,
+        defaultReconciliationContext(),
+      ),
+    ).toBe(false)
+    expect(
+      isActionableDoKind(
+        doEndeavorFixtures.eventToday,
+        defaultReconciliationContext(),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('isComputedStateVisible', () => {
+  it('is true while nothing is hidden', () => {
+    expect(
+      isComputedStateVisible(
+        doLensFor(initialDoVisibility),
+        EndeavorComputedState.overdue,
+      ),
+    ).toBe(true)
+  })
+
+  it('is false for the state the user hid', () => {
+    const lens = doLensFor({
+      ...initialDoVisibility,
+      hiddenComputedStates: [EndeavorComputedState.completedToday],
+    })
+    expect(
+      isComputedStateVisible(lens, EndeavorComputedState.completedToday),
+    ).toBe(false)
+  })
+
+  it('leaves the sibling states alone', () => {
+    const lens = doLensFor({
+      ...initialDoVisibility,
+      hiddenComputedStates: [EndeavorComputedState.expired],
+    })
+    expect(isComputedStateVisible(lens, EndeavorComputedState.overdue)).toBe(true)
+  })
+})
+
+describe('doAutoAdvanceLaneOrder', () => {
+  it('is canon’s documented order, hero first', () => {
+    expect(doAutoAdvanceLaneOrder).toEqual([
+      DoLane.featured,
+      DoLane.now,
+      DoLane.overdue,
+      DoLane.expired,
+      DoLane.next,
+      DoLane.anytime,
+    ])
+  })
+
+  it('never includes Completed Today', () => {
+    expect(doAutoAdvanceLaneOrder).not.toContain(DoLane.completed)
+  })
+
+  it('keeps Expired next to its Overdue sibling', () => {
+    const overdueAt = doAutoAdvanceLaneOrder.indexOf(DoLane.overdue)
+    expect(doAutoAdvanceLaneOrder[overdueAt + 1]).toBe(DoLane.expired)
+  })
+})
+
+describe('laneCards', () => {
+  const lanes = {
+    ...emptyDoLanes,
+    overdue: [doEndeavorFixtures.overdueThisMorning],
+    completedToday: [doEndeavorFixtures.completedTodayTask],
+  }
+
+  it('reads the named lane', () => {
+    expect(laneCards(lanes, DoLane.overdue)).toEqual([
+      doEndeavorFixtures.overdueThisMorning,
+    ])
+  })
+
+  it('reads Completed Today, which auto-advance never walks', () => {
+    expect(laneCards(lanes, DoLane.completed)).toEqual([
+      doEndeavorFixtures.completedTodayTask,
+    ])
+  })
+
+  it('returns an empty lane rather than undefined', () => {
+    expect(laneCards(lanes, DoLane.anytime)).toEqual([])
+  })
+})

--- a/packages/app/src/features/do/__tests__/DoSelectors.test.ts
+++ b/packages/app/src/features/do/__tests__/DoSelectors.test.ts
@@ -1,0 +1,308 @@
+import { EndeavorKind } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { greetingStateMocks } from '../../greeting/GreetingMocks'
+import type { RootState } from '../../../library/store'
+import type { DoState } from '../DoFeature'
+import { DO_MOCK_NOW, doEndeavorFixtures, doStateMocks } from '../DoMocks'
+import { DoLane, doCardKey, initialDoVisibility } from '../DoRules'
+import {
+  selectAreDoRingsVisible,
+  selectAreDoSuggestionsVisible,
+  selectDoClearExpiredTargets,
+  selectDoException,
+  selectDoFeaturedNowLane,
+  selectDoHabitsRing,
+  selectDoLanes,
+  selectDoNextActionableCardKey,
+  selectDoNotificationBadgeCount,
+  selectDoRemainingTodayCount,
+  selectDoSuggestions,
+  selectDoTasksRing,
+  selectHasNoDoEndeavors,
+  selectIsDoLoading,
+} from '../DoSelectors'
+import { withVisibilityApplied } from '../DoShifters'
+
+/** Selectors run against a hand-built root state, never a live store. */
+const rootWith = (slice: DoState): RootState => ({
+  greeting: greetingStateMocks.idle,
+  do: slice,
+})
+
+const loaded = rootWith(doStateMocks.loadedTypicalDay)
+
+describe('selectIsDoLoading', () => {
+  it('is true while a read is in flight', () => {
+    expect(selectIsDoLoading(rootWith(doStateMocks.loading))).toBe(true)
+  })
+
+  it('is false before anything was asked for', () => {
+    expect(selectIsDoLoading(rootWith(doStateMocks.idle))).toBe(false)
+  })
+
+  it('is false once a refresh failed, so a spinner never sits on top of an error', () => {
+    expect(
+      selectIsDoLoading(rootWith(doStateMocks.failedRefreshKeepingTheDay)),
+    ).toBe(false)
+  })
+})
+
+describe('selectDoException', () => {
+  it('surfaces the typed exception after a failed refresh', () => {
+    expect(
+      selectDoException(rootWith(doStateMocks.failedRefreshKeepingTheDay))?.kind,
+    ).toBe('fetchFailed')
+  })
+
+  it('is null on the happy path', () => {
+    expect(selectDoException(loaded)).toBeNull()
+  })
+
+  it('is null while loading', () => {
+    expect(selectDoException(rootWith(doStateMocks.loading))).toBeNull()
+  })
+})
+
+describe('selectHasNoDoEndeavors', () => {
+  it('is true for a genuinely empty day', () => {
+    expect(selectHasNoDoEndeavors(rootWith(doStateMocks.loadedEmptyDay))).toBe(true)
+  })
+
+  it('is false for a populated day', () => {
+    expect(selectHasNoDoEndeavors(loaded)).toBe(false)
+  })
+
+  it('is false when only events remain — the day still holds something', () => {
+    const eventsOnly: DoState = {
+      ...doStateMocks.loadedEmptyDay,
+      events: [doEndeavorFixtures.eventToday],
+    }
+    expect(selectHasNoDoEndeavors(rootWith(eventsOnly))).toBe(false)
+  })
+})
+
+describe('selectDoNotificationBadgeCount', () => {
+  it('counts overdue plus expired — everything that missed its deadline', () => {
+    const lanes = selectDoLanes(loaded)
+    expect(selectDoNotificationBadgeCount(loaded)).toBe(
+      lanes.overdue.length + lanes.expired.length,
+    )
+    expect(selectDoNotificationBadgeCount(loaded)).toBe(6)
+  })
+
+  it('is zero on a day with nothing missed', () => {
+    expect(
+      selectDoNotificationBadgeCount(rootWith(doStateMocks.loadedEmptyDay)),
+    ).toBe(0)
+  })
+
+  it('drops to the overdue count alone when the user hides Expired', () => {
+    const hidden = withVisibilityApplied(
+      doStateMocks.loadedTypicalDay,
+      { ...initialDoVisibility, hiddenComputedStates: ['expired'] },
+      DO_MOCK_NOW,
+    )
+    expect(selectDoNotificationBadgeCount(rootWith(hidden))).toBe(4)
+  })
+})
+
+describe('selectDoRemainingTodayCount', () => {
+  it('counts every actionable lane and neither featured nor completed', () => {
+    const lanes = selectDoLanes(loaded)
+    expect(selectDoRemainingTodayCount(loaded)).toBe(
+      lanes.overdue.length +
+        lanes.expired.length +
+        lanes.now.length +
+        lanes.next.length +
+        lanes.anytime.length,
+    )
+  })
+
+  it('does not double-count the featured hero, which is already in another lane', () => {
+    const lanes = selectDoLanes(loaded)
+    expect(lanes.featuredNow.length).toBeGreaterThan(0)
+    expect(selectDoRemainingTodayCount(loaded)).toBeLessThan(
+      lanes.overdue.length +
+        lanes.expired.length +
+        lanes.now.length +
+        lanes.next.length +
+        lanes.anytime.length +
+        lanes.featuredNow.length,
+    )
+  })
+
+  it('is zero on an empty day', () => {
+    expect(
+      selectDoRemainingTodayCount(rootWith(doStateMocks.loadedEmptyDay)),
+    ).toBe(0)
+  })
+})
+
+describe('selectDoFeaturedNowLane', () => {
+  it('shows three cards at the compact capacity', () => {
+    expect(selectDoFeaturedNowLane(loaded)).toHaveLength(3)
+  })
+
+  it('widens to nine without displacing the hero', () => {
+    const narrow = selectDoFeaturedNowLane(loaded)
+    const wide = selectDoFeaturedNowLane(
+      rootWith({ ...doStateMocks.loadedTypicalDay, featuredCapacity: 9 }),
+    )
+    expect(wide.length).toBeGreaterThan(narrow.length)
+    expect(wide[Math.floor(wide.length / 2)]?.id).toBe(
+      narrow[Math.floor(narrow.length / 2)]?.id,
+    )
+  })
+
+  it('is empty when nothing scores', () => {
+    expect(selectDoFeaturedNowLane(rootWith(doStateMocks.loadedEmptyDay))).toEqual(
+      [],
+    )
+  })
+})
+
+describe('the ring selectors', () => {
+  it('report today’s standing from the parked clock reading', () => {
+    expect(selectDoTasksRing(loaded)).not.toBeNull()
+    expect(selectDoHabitsRing(loaded)).not.toBeNull()
+  })
+
+  it('are absent before the first regroup has stamped an instant', () => {
+    expect(selectDoTasksRing(rootWith(doStateMocks.idle))).toBeNull()
+    expect(selectDoHabitsRing(rootWith(doStateMocks.idle))).toBeNull()
+  })
+
+  it('do not move when the user hides a kind — the ring reports the day', () => {
+    const before = selectDoHabitsRing(loaded)
+    const hidingHabits = withVisibilityApplied(
+      doStateMocks.loadedTypicalDay,
+      { ...initialDoVisibility, hiddenKinds: [EndeavorKind.habit] },
+      DO_MOCK_NOW,
+    )
+    const after = rootWith(hidingHabits)
+    // The lanes lost every habit…
+    expect(
+      selectDoLanes(after).now.map((endeavor) => endeavor.id),
+    ).not.toContain(doEndeavorFixtures.habitDueSoon.id)
+    // …and the gold ring is byte-identical.
+    expect(selectDoHabitsRing(after)).toEqual(before)
+  })
+
+  it('do not move when the user hides the Completed Today state', () => {
+    const before = selectDoTasksRing(loaded)
+    const hidingCompleted = rootWith(
+      withVisibilityApplied(
+        doStateMocks.loadedTypicalDay,
+        { ...initialDoVisibility, hiddenComputedStates: ['completedToday'] },
+        DO_MOCK_NOW,
+      ),
+    )
+    expect(selectDoLanes(hidingCompleted).completedToday).toEqual([])
+    expect(selectDoTasksRing(hidingCompleted)).toEqual(before)
+  })
+})
+
+describe('selectAreDoRingsVisible', () => {
+  it('is true on the ordinary shipping configuration', () => {
+    expect(selectAreDoRingsVisible(rootWith(doStateMocks.ringsEnabled))).toBe(true)
+  })
+
+  it('is false while bulk mark-complete mode is on', () => {
+    expect(
+      selectAreDoRingsVisible(
+        rootWith({
+          ...doStateMocks.ringsEnabled,
+          isInMarkCompleteMode: true,
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('is false while the kill switch is off', () => {
+    expect(selectAreDoRingsVisible(loaded)).toBe(false)
+  })
+})
+
+describe('the suggestion selectors', () => {
+  it('surface the offered nudge', () => {
+    expect(
+      selectDoSuggestions(rootWith(doStateMocks.suggestionOffered)),
+    ).toHaveLength(1)
+    expect(
+      selectAreDoSuggestionsVisible(rootWith(doStateMocks.suggestionOffered)),
+    ).toBe(true)
+  })
+
+  it('hide the lane once every nudge is dismissed', () => {
+    expect(
+      selectAreDoSuggestionsVisible(rootWith(doStateMocks.suggestionDismissed)),
+    ).toBe(false)
+  })
+
+  it('hide the lane when the preference is off, even with a card to show', () => {
+    const preferenceOff = rootWith({
+      ...doStateMocks.suggestionOffered,
+      preferences: {
+        ...doStateMocks.suggestionOffered.preferences,
+        showSuggestions: false,
+      },
+    })
+    expect(selectAreDoSuggestionsVisible(preferenceOff)).toBe(false)
+  })
+})
+
+describe('selectDoNextActionableCardKey', () => {
+  it('names the featured hero on a populated day', () => {
+    const lanes = selectDoLanes(loaded)
+    const hero = lanes.featuredNow[Math.floor(lanes.featuredNow.length / 2)]
+    expect(selectDoNextActionableCardKey(loaded)).toBe(
+      doCardKey(DoLane.featured, hero?.id ?? ''),
+    )
+  })
+
+  it('is null on an empty day', () => {
+    expect(
+      selectDoNextActionableCardKey(rootWith(doStateMocks.loadedEmptyDay)),
+    ).toBeNull()
+  })
+
+  it('ignores Completed Today, which is not actionable', () => {
+    const onlyCompleted: DoState = {
+      ...doStateMocks.loadedEmptyDay,
+      lanes: {
+        ...doStateMocks.loadedEmptyDay.lanes,
+        completedToday: [doEndeavorFixtures.completedTodayTask],
+      },
+    }
+    expect(selectDoNextActionableCardKey(rootWith(onlyCompleted))).toBeNull()
+  })
+})
+
+describe('selectDoClearExpiredTargets', () => {
+  it('names every expired endeavor on the day', () => {
+    expect(
+      selectDoClearExpiredTargets(loaded).map((endeavor) => endeavor.id).sort(),
+    ).toEqual(
+      [
+        doEndeavorFixtures.expiredLastNight.id,
+        doEndeavorFixtures.expiredLastWeek.id,
+      ].sort(),
+    )
+  })
+
+  it('still names them when the user has hidden the Expired lane', () => {
+    const hidden = rootWith(
+      withVisibilityApplied(
+        doStateMocks.loadedTypicalDay,
+        { ...initialDoVisibility, hiddenComputedStates: ['expired'] },
+        DO_MOCK_NOW,
+      ),
+    )
+    expect(selectDoLanes(hidden).expired).toEqual([])
+    expect(selectDoClearExpiredTargets(hidden)).toHaveLength(2)
+  })
+
+  it('is empty before the first regroup', () => {
+    expect(selectDoClearExpiredTargets(rootWith(doStateMocks.idle))).toEqual([])
+  })
+})

--- a/packages/app/src/features/do/__tests__/DoShifters.test.ts
+++ b/packages/app/src/features/do/__tests__/DoShifters.test.ts
@@ -1,0 +1,476 @@
+import { EndeavorKind, EndeavorStatus, makeEndeavor } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { DoExceptions } from '../DoException'
+import { defaultDoPreferences, initialDoState } from '../DoFeature'
+import {
+  DO_MOCK_NOW,
+  doEndeavorFixtures,
+  doFixtureDay,
+  doMockAt,
+  doStateMocks,
+} from '../DoMocks'
+import { DoLane, doCardKey, initialDoVisibility } from '../DoRules'
+import {
+  withAutoAdvanced,
+  withBackdatingCancelled,
+  withBackdatingRequested,
+  withCardSelected,
+  withEndeavorsInstalled,
+  withException,
+  withFetchStarted,
+  withLoadedAt,
+  withMarkCompleteModeToggled,
+  withOptimisticallyCompleted,
+  withPreferencesApplied,
+  withScrollRequestHandled,
+  withSuggestionDismissed,
+  withSuggestionsRefreshed,
+  withVisibilityApplied,
+} from '../DoShifters'
+import { DoSuggestionSource } from '../DoSuggestions'
+
+const loaded = doStateMocks.loadedTypicalDay
+
+describe('withEndeavorsInstalled', () => {
+  it('splits one snapshot into the four channels, habits landing in tasks too', () => {
+    const next = withEndeavorsInstalled(initialDoState, doFixtureDay, DO_MOCK_NOW)
+    expect(next.habits.map((endeavor) => endeavor.id)).toContain(
+      doEndeavorFixtures.habitDueSoon.id,
+    )
+    expect(next.tasks.map((endeavor) => endeavor.id)).toContain(
+      doEndeavorFixtures.habitDueSoon.id,
+    )
+    expect(next.events.map((endeavor) => endeavor.id)).toEqual([
+      doEndeavorFixtures.eventToday.id,
+    ])
+    expect(next.reminders.map((endeavor) => endeavor.id)).toContain(
+      doEndeavorFixtures.reminderDueToday.id,
+    )
+  })
+
+  it('partitions and stamps the clock in the same pass', () => {
+    const next = withEndeavorsInstalled(initialDoState, doFixtureDay, DO_MOCK_NOW)
+    expect(next.clockAnchor).toEqual(DO_MOCK_NOW)
+    expect(next.load).toEqual({ kind: 'loaded' })
+    expect(next.lanes.overdue.length).toBeGreaterThan(0)
+  })
+
+  it('replaces the previous day wholesale rather than merging into it', () => {
+    const next = withEndeavorsInstalled(loaded, [], DO_MOCK_NOW)
+    expect(next.tasks).toEqual([])
+    expect(next.lanes.overdue).toEqual([])
+    expect(next.lanes.completedToday).toEqual([])
+  })
+
+  it('collapses a duplicate row so one endeavor is presented once', () => {
+    const twice = [
+      doEndeavorFixtures.overdueThisMorning,
+      { ...doEndeavorFixtures.overdueThisMorning, title: 'Send the invoice v2' },
+    ]
+    const next = withEndeavorsInstalled(initialDoState, twice, DO_MOCK_NOW)
+    expect(next.lanes.overdue).toHaveLength(1)
+  })
+})
+
+describe('withLoadedAt', () => {
+  it('classifies the retained day against the instant it is given', () => {
+    const seeded = { ...loaded, lanes: initialDoState.lanes, clockAnchor: null }
+    const next = withLoadedAt(seeded, DO_MOCK_NOW)
+    expect(next.clockAnchor).toEqual(DO_MOCK_NOW)
+    expect(next.lanes.overdue.length).toBeGreaterThan(0)
+  })
+
+  it('re-partitions the same day differently later in the day', () => {
+    // At 19:00 the 18:00 task is overdue rather than Next.
+    const evening = withLoadedAt(loaded, doMockAt(17, 19, 0))
+    expect(evening.lanes.overdue.map((endeavor) => endeavor.id)).toContain(
+      doEndeavorFixtures.dueLateToday.id,
+    )
+    expect(evening.lanes.next).toEqual([])
+  })
+
+  it('leaves an empty day empty', () => {
+    const next = withLoadedAt(doStateMocks.loadedEmptyDay, DO_MOCK_NOW)
+    expect(next.lanes.now).toEqual([])
+  })
+})
+
+describe('withFetchStarted / withException', () => {
+  it('clears a prior exception when a new read starts', () => {
+    const failed = withException(loaded, DoExceptions.fetchFailed('boom'))
+    expect(withFetchStarted(failed).load).toEqual({ kind: 'loading' })
+  })
+
+  it('keeps the retained day intact through a failure', () => {
+    const failed = withException(loaded, DoExceptions.fetchFailed('boom'))
+    expect(failed.lanes).toEqual(loaded.lanes)
+    expect(failed.tasks).toEqual(loaded.tasks)
+  })
+
+  it('carries the typed exception, not a bare message', () => {
+    const failed = withException(
+      initialDoState,
+      DoExceptions.clearExpiredRefreshFailed(),
+    )
+    expect(failed.load).toEqual({
+      kind: 'failed',
+      exception: DoExceptions.clearExpiredRefreshFailed(),
+    })
+  })
+})
+
+describe('withPreferencesApplied', () => {
+  it('re-partitions when the Due Soon window widens', () => {
+    const wider = withPreferencesApplied(loaded, {
+      ...defaultDoPreferences,
+      nowThresholdHours: 12,
+    })
+    // The 18:00 task was Next at a two-hour window; twelve hours takes it.
+    expect(wider.lanes.now.map((endeavor) => endeavor.id)).toContain(
+      doEndeavorFixtures.dueLateToday.id,
+    )
+    expect(wider.lanes.next).toEqual([])
+  })
+
+  it('regenerates the suggestions the new flags allow', () => {
+    const next = withPreferencesApplied(loaded, {
+      ...defaultDoPreferences,
+      googleCalendarEnabled: true,
+    })
+    expect(next.suggestions).toHaveLength(1)
+  })
+
+  it('skips the regroup before the first clock stamp — there is no instant yet', () => {
+    const next = withPreferencesApplied(initialDoState, defaultDoPreferences)
+    expect(next.clockAnchor).toBeNull()
+    expect(next.lanes).toEqual(initialDoState.lanes)
+  })
+})
+
+describe('withVisibilityApplied', () => {
+  it('empties the lane whose computed state the user hid', () => {
+    const next = withVisibilityApplied(
+      loaded,
+      { ...initialDoVisibility, hiddenComputedStates: ['expired'] },
+      DO_MOCK_NOW,
+    )
+    expect(next.lanes.expired).toEqual([])
+  })
+
+  it('leaves the raw channels untouched, so the rings cannot move', () => {
+    const next = withVisibilityApplied(
+      loaded,
+      { ...initialDoVisibility, hiddenKinds: [EndeavorKind.habit] },
+      DO_MOCK_NOW,
+    )
+    expect(next.habits).toEqual(loaded.habits)
+    expect(next.tasks).toEqual(loaded.tasks)
+  })
+
+  it('restores the hidden lane when the selection is cleared again', () => {
+    const hidden = withVisibilityApplied(
+      loaded,
+      { ...initialDoVisibility, hiddenComputedStates: ['expired'] },
+      DO_MOCK_NOW,
+    )
+    const shown = withVisibilityApplied(hidden, initialDoVisibility, DO_MOCK_NOW)
+    expect(shown.lanes.expired).toEqual(loaded.lanes.expired)
+  })
+})
+
+describe('withSuggestionsRefreshed / withSuggestionDismissed', () => {
+  const offering = {
+    ...loaded,
+    preferences: { ...loaded.preferences, googleCalendarEnabled: true },
+  }
+
+  it('offers the connect nudge once the flag turns on', () => {
+    expect(withSuggestionsRefreshed(offering).suggestions).toHaveLength(1)
+  })
+
+  it('drops the nudge for good once dismissed', () => {
+    const dismissed = withSuggestionDismissed(
+      withSuggestionsRefreshed(offering),
+      DoSuggestionSource.googleCalendar,
+    )
+    expect(dismissed.suggestions).toEqual([])
+    expect(dismissed.dismissedSuggestionSources).toEqual([
+      DoSuggestionSource.googleCalendar,
+    ])
+  })
+
+  it('is a no-op when the same source is dismissed twice', () => {
+    const once = withSuggestionDismissed(
+      offering,
+      DoSuggestionSource.googleCalendar,
+    )
+    const twice = withSuggestionDismissed(
+      once,
+      DoSuggestionSource.googleCalendar,
+    )
+    expect(twice).toBe(once)
+  })
+})
+
+describe('withCardSelected', () => {
+  it('prepares the tapped card', () => {
+    const next = withCardSelected(loaded, DoLane.overdue, 'abc')
+    expect(next.selectedCardKey).toBe(doCardKey(DoLane.overdue, 'abc'))
+  })
+
+  it('un-prepares it on a second tap', () => {
+    const once = withCardSelected(loaded, DoLane.overdue, 'abc')
+    expect(withCardSelected(once, DoLane.overdue, 'abc').selectedCardKey).toBeNull()
+  })
+
+  it('never arms the auto-advance scroll — a manual tap must not move the surface', () => {
+    const advanced = { ...loaded, shouldScrollToCurrentCard: true }
+    expect(
+      withCardSelected(advanced, DoLane.now, 'abc').shouldScrollToCurrentCard,
+    ).toBe(false)
+  })
+})
+
+describe('withMarkCompleteModeToggled', () => {
+  it('clears the preparation cursor on the way in', () => {
+    const prepared = withCardSelected(loaded, DoLane.now, 'abc')
+    const next = withMarkCompleteModeToggled(prepared)
+    expect(next.isInMarkCompleteMode).toBe(true)
+    expect(next.selectedCardKey).toBeNull()
+  })
+
+  it('closes a half-open completion popover on the way in', () => {
+    const opened = withBackdatingRequested(loaded, 'abc', DO_MOCK_NOW)
+    expect(withMarkCompleteModeToggled(opened).backdating).toBeNull()
+  })
+
+  it('leaves the cursor alone on the way out', () => {
+    const inMode = withMarkCompleteModeToggled(loaded)
+    const back = withMarkCompleteModeToggled({
+      ...inMode,
+      selectedCardKey: 'now:abc',
+    })
+    expect(back.isInMarkCompleteMode).toBe(false)
+    expect(back.selectedCardKey).toBe('now:abc')
+  })
+})
+
+describe('withScrollRequestHandled', () => {
+  it('spends the auto-advance one-shot', () => {
+    const armed = { ...loaded, shouldScrollToCurrentCard: true }
+    expect(withScrollRequestHandled(armed).shouldScrollToCurrentCard).toBe(false)
+  })
+
+  it('spends the overdue-jump one-shot', () => {
+    const armed = { ...loaded, shouldScrollToOverdue: true }
+    expect(withScrollRequestHandled(armed).shouldScrollToOverdue).toBe(false)
+  })
+
+  it('is harmless when neither is armed', () => {
+    const next = withScrollRequestHandled(loaded)
+    expect(next.shouldScrollToCurrentCard).toBe(false)
+    expect(next.shouldScrollToOverdue).toBe(false)
+  })
+})
+
+describe('withBackdatingRequested / withBackdatingCancelled', () => {
+  const yesterday = doMockAt(16, 18, 0)
+
+  it('opens the popover on a card at an instant', () => {
+    const next = withBackdatingRequested(loaded, 'abc', yesterday)
+    expect(next.backdating).toEqual({
+      endeavorId: 'abc',
+      completionDate: yesterday,
+    })
+  })
+
+  it('re-aims an already-open popover rather than opening a second', () => {
+    const once = withBackdatingRequested(loaded, 'abc', yesterday)
+    const again = withBackdatingRequested(once, 'abc', DO_MOCK_NOW)
+    expect(again.backdating).toEqual({
+      endeavorId: 'abc',
+      completionDate: DO_MOCK_NOW,
+    })
+  })
+
+  it('cancels to a no-op when nothing was open', () => {
+    expect(withBackdatingCancelled(loaded)).toBe(loaded)
+  })
+})
+
+describe('withOptimisticallyCompleted', () => {
+  const targetId = doEndeavorFixtures.overdueThisMorning.id
+
+  it('moves the card out of Overdue and into Completed Today at once', () => {
+    const next = withOptimisticallyCompleted(
+      loaded,
+      targetId,
+      DO_MOCK_NOW,
+      DO_MOCK_NOW,
+    )
+    expect(next.lanes.overdue.map((endeavor) => endeavor.id)).not.toContain(targetId)
+    expect(next.lanes.completedToday.map((endeavor) => endeavor.id)).toContain(
+      targetId,
+    )
+  })
+
+  it('advances the emerald ring on the same tap', () => {
+    const before = loaded.tasks.filter(
+      (endeavor) => endeavor.id === targetId,
+    )[0]
+    expect(before?.completed).toBeNull()
+    const next = withOptimisticallyCompleted(
+      loaded,
+      targetId,
+      DO_MOCK_NOW,
+      DO_MOCK_NOW,
+    )
+    const after = next.tasks.find((endeavor) => endeavor.id === targetId)
+    expect(after?.status).toBe(EndeavorStatus.closed)
+    expect(after?.completed).toEqual(DO_MOCK_NOW)
+  })
+
+  it('keeps a completion backdated to yesterday out of today’s record', () => {
+    const next = withOptimisticallyCompleted(
+      loaded,
+      targetId,
+      doMockAt(16, 18, 0),
+      DO_MOCK_NOW,
+    )
+    expect(next.lanes.completedToday.map((endeavor) => endeavor.id)).not.toContain(
+      targetId,
+    )
+    expect(next.lanes.overdue.map((endeavor) => endeavor.id)).not.toContain(targetId)
+  })
+
+  it('re-mirrors the habit channel when the completed card was a habit', () => {
+    const next = withOptimisticallyCompleted(
+      loaded,
+      doEndeavorFixtures.habitDueSoon.id,
+      DO_MOCK_NOW,
+      DO_MOCK_NOW,
+    )
+    const habit = next.habits.find(
+      (endeavor) => endeavor.id === doEndeavorFixtures.habitDueSoon.id,
+    )
+    expect(habit?.status).toBe(EndeavorStatus.closed)
+  })
+
+  it('is a no-op for an id the day does not hold', () => {
+    expect(
+      withOptimisticallyCompleted(loaded, 'no-such-card', DO_MOCK_NOW, DO_MOCK_NOW),
+    ).toBe(loaded)
+  })
+
+  it('closes the completion popover it was confirmed from', () => {
+    const opened = withBackdatingRequested(loaded, targetId, DO_MOCK_NOW)
+    const next = withOptimisticallyCompleted(
+      opened,
+      targetId,
+      DO_MOCK_NOW,
+      DO_MOCK_NOW,
+    )
+    expect(next.backdating).toBeNull()
+  })
+})
+
+describe('withAutoAdvanced', () => {
+  const enabled = doStateMocks.autoAdvanceEnabled
+
+  it('clears focus without jumping when the preference is off', () => {
+    const prepared = withCardSelected(loaded, DoLane.now, 'abc')
+    const next = withAutoAdvanced(prepared)
+    expect(next.selectedCardKey).toBeNull()
+    expect(next.shouldScrollToCurrentCard).toBe(false)
+  })
+
+  it('focuses the featured hero and arms the scroll when it is on', () => {
+    const next = withAutoAdvanced(enabled)
+    const hero = enabled.lanes.featuredNow[
+      Math.floor(enabled.lanes.featuredNow.length / 2)
+    ]
+    expect(next.selectedCardKey).toBe(doCardKey(DoLane.featured, hero?.id ?? ''))
+    expect(next.shouldScrollToCurrentCard).toBe(true)
+  })
+
+  it('clears focus in bulk mark-complete mode, which has no cursor to advance', () => {
+    const bulk = { ...enabled, isInMarkCompleteMode: true }
+    const next = withAutoAdvanced(bulk)
+    expect(next.selectedCardKey).toBeNull()
+    expect(next.shouldScrollToCurrentCard).toBe(false)
+  })
+
+  it('clears focus without jumping when nothing actionable is left', () => {
+    const emptied = {
+      ...doStateMocks.loadedEmptyDay,
+      preferences: {
+        ...doStateMocks.loadedEmptyDay.preferences,
+        autoAdvanceAfterComplete: true,
+      },
+    }
+    const next = withAutoAdvanced(emptied)
+    expect(next.selectedCardKey).toBeNull()
+    expect(next.shouldScrollToCurrentCard).toBe(false)
+  })
+
+  it('walks the documented order after each completion until the day is empty', () => {
+    // A three-card day: one overdue, one due soon, one anytime. Completing the
+    // focused card each time must land on the next card the order names.
+    const cards = [
+      makeEndeavor({
+        id: 'a-overdue',
+        title: 'a',
+        kind: EndeavorKind.task,
+        due: doMockAt(17, 8, 0),
+      }),
+      makeEndeavor({
+        id: 'b-due-soon',
+        title: 'b',
+        kind: EndeavorKind.task,
+        due: doMockAt(17, 11, 0),
+      }),
+      makeEndeavor({
+        id: 'c-anytime',
+        title: 'c',
+        kind: EndeavorKind.task,
+        status: EndeavorStatus.ongoing,
+      }),
+    ]
+    let state = withEndeavorsInstalled(
+      {
+        ...initialDoState,
+        preferences: {
+          ...defaultDoPreferences,
+          autoAdvanceAfterComplete: true,
+        },
+      },
+      cards,
+      DO_MOCK_NOW,
+    )
+
+    const walk: (string | null)[] = []
+    for (let step = 0; step < 4; step += 1) {
+      state = withAutoAdvanced(state)
+      walk.push(state.selectedCardKey)
+      const focusedId = state.selectedCardKey?.split(':')[1]
+      if (focusedId === undefined) break
+      state = withOptimisticallyCompleted(
+        state,
+        focusedId,
+        DO_MOCK_NOW,
+        DO_MOCK_NOW,
+      )
+    }
+
+    expect(walk).toEqual([
+      // The overdue card scores 110 and is the hero.
+      doCardKey(DoLane.featured, 'a-overdue'),
+      // Then the due-soon card, still via the featured lane.
+      doCardKey(DoLane.featured, 'b-due-soon'),
+      // Then the ongoing card, which the featured lane also ranks.
+      doCardKey(DoLane.featured, 'c-anytime'),
+      // Nothing left: focus clears rather than jumping.
+      null,
+    ])
+  })
+})

--- a/packages/app/src/features/do/__tests__/DoSuggestions.test.ts
+++ b/packages/app/src/features/do/__tests__/DoSuggestions.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DoSuggestionSource,
+  areDoSuggestionsVisible,
+  doSuggestionSources,
+  generateDoSuggestions,
+} from '../DoSuggestions'
+
+const offerable = {
+  googleCalendarEnabled: true,
+  googleCalendarConnected: false,
+}
+
+describe('generateDoSuggestions', () => {
+  it('offers the Google Calendar nudge when the flag is on and the account is unlinked', () => {
+    const suggestions = generateDoSuggestions({
+      integrations: offerable,
+      dismissedSources: [],
+    })
+    expect(suggestions.map((suggestion) => suggestion.source)).toEqual([
+      DoSuggestionSource.googleCalendar,
+    ])
+    expect(suggestions[0]?.actionTitle).toBe('Connect')
+  })
+
+  it('offers nothing once the account is linked — there is nothing left to nudge', () => {
+    expect(
+      generateDoSuggestions({
+        integrations: { ...offerable, googleCalendarConnected: true },
+        dismissedSources: [],
+      }),
+    ).toEqual([])
+  })
+
+  it('offers nothing while the flag is off, however unlinked the account is', () => {
+    expect(
+      generateDoSuggestions({
+        integrations: { ...offerable, googleCalendarEnabled: false },
+        dismissedSources: [],
+      }),
+    ).toEqual([])
+  })
+
+  it('suppresses a nudge the user already dismissed this session', () => {
+    expect(
+      generateDoSuggestions({
+        integrations: offerable,
+        dismissedSources: [DoSuggestionSource.googleCalendar],
+      }),
+    ).toEqual([])
+  })
+
+  it('dismisses per source, so an unrelated source is unaffected', () => {
+    // One source exists on web today; the shape is per-source so adding a
+    // second is a member plus a branch, never a change to this rule.
+    expect(doSuggestionSources).toEqual([DoSuggestionSource.googleCalendar])
+    expect(
+      generateDoSuggestions({
+        integrations: offerable,
+        dismissedSources: [],
+      }),
+    ).toHaveLength(1)
+  })
+})
+
+describe('areDoSuggestionsVisible', () => {
+  const suggestions = generateDoSuggestions({
+    integrations: offerable,
+    dismissedSources: [],
+  })
+
+  it('shows the lane when the preference is on and a card survived', () => {
+    expect(
+      areDoSuggestionsVisible({
+        showSuggestionsPreference: true,
+        suggestions,
+      }),
+    ).toBe(true)
+  })
+
+  it('hides the lane when the user turned suggestions off entirely', () => {
+    expect(
+      areDoSuggestionsVisible({
+        showSuggestionsPreference: false,
+        suggestions,
+      }),
+    ).toBe(false)
+  })
+
+  it('hides an empty lane rather than rendering an empty state', () => {
+    expect(
+      areDoSuggestionsVisible({
+        showSuggestionsPreference: true,
+        suggestions: [],
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
+++ b/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
@@ -1,5 +1,6 @@
 import { greetingMocks } from '@kro/core/mocks'
 import { describe, expect, it } from 'vitest'
+import { initialDoState } from '../../do/DoFeature'
 import type { RootState } from '../../../library/store'
 import type { GreetingState } from '../GreetingFeature'
 import { greetingStateMocks } from '../GreetingMocks'
@@ -12,7 +13,12 @@ import {
 } from '../GreetingSelectors'
 
 /** Selectors are exercised against a hand-built root state, never a live store. */
-const rootWith = (greeting: GreetingState): RootState => ({ greeting })
+// `do` is present only because `RootState` now has a second slice (#16); this
+// suite asserts nothing about it.
+const rootWith = (greeting: GreetingState): RootState => ({
+  greeting,
+  do: initialDoState,
+})
 
 describe('selectGreeting', () => {
   it('returns the greeting once it has loaded', () => {

--- a/packages/app/src/library/store.ts
+++ b/packages/app/src/library/store.ts
@@ -16,6 +16,7 @@
  */
 import type { LocalStore } from '@kro/core'
 import { configureStore, isPlain } from '@reduxjs/toolkit'
+import { doSlice } from '../features/do/DoFeature'
 import { greetingSlice } from '../features/greeting/GreetingFeature'
 import {
   type GreetingService,
@@ -64,6 +65,7 @@ export const makeStore = (extra: ThunkExtra = liveThunkExtra) =>
   configureStore({
     reducer: {
       greeting: greetingSlice.reducer,
+      do: doSlice.reducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({


### PR DESCRIPTION
> 🟥 **Ichigo · Substitute** — the local plane, entire · *local, on your creds · I open PRs for **you** to merge (I never merge `main`, never review my own work)*
> acting as **Shinigami** (product code) · authored locally in a Claude Code session on behalf of @zheref — no CI run

Closes #16 · Part of #1

# What this changes for you

The Do tab's business rules now exist. Nothing is on screen yet — #17 owns the rendering — but the whole daily-execution engine is here and under test: give it a day's endeavors and an instant, and it tells you exactly what belongs in every lane, which card is the hero, how far round the rings have gone, what "N left today" says, what **Clear Expired** would close, and where focus lands after you tick something off.

Concretely, `packages/app/src/features/do/**` adds:

| Piece | What it decides |
|---|---|
| `DoRules.ts` | the lane partition — Overdue / Due Soon / Expired / Next / Anytime / Completed Today — the visibility terms, the auto-advance order and Clear Expired's target set |
| `DoFeaturedNow.ts` | the featured-Now score, the odd-count hero-centred arrangement, and the 3/5/7/9 responsive window |
| `DoRings.ts` | the two day-progress rings, and the rule that visibility filters never move them |
| `DoSuggestions.ts` | the connect nudges, per-source dismissal and the `do.showSuggestions` gate |
| `DoFeature.ts` | the slice: one `load` lifecycle field, the reconciled channels, the lanes, the preparation cursor, bulk mark-complete mode and the backdated-completion popover intent |
| `DoShifters.ts` / `DoSelectors.ts` / `DoProducer.ts` | the pure state transitions, the derived reads, and four thunks over the local store |
| `DoMocks.ts` | one fixture day carrying every lane and every boundary, plus ten canned `DoState` variants |

**Do is one vista.** `EndeavorsVistas.doTab` is fetched once, reconciled once (`#12`'s reconcile-before-grouping contract), and partitioned in memory by Shifters. There is no per-lane query.

**The clock is injected, everywhere.** No reducer, Shifter or Selector in this feature reads `Date.now()` or builds a `Date`: every event carries `now` in its payload and every thunk takes it as an argument. A test in `DoFeature.test.ts` greps the feature's own sources and fails if that ever stops being true. It is what makes a midnight-boundary case a plain unit test, and it is why `clockAnchor` is parked in state for the pure ring Selectors to read.

**One line in `store.ts`**, directly after the greeting entry, plus one flagged test-literal fix-up (below). No new dependencies, no `ThunkExtra` port: preferences, feature flags and endeavors all arrive through the `localStore` bundle that is already in the manifest.

**295 tests** across ten suites, all clock-controlled, none touching the network.

## How to verify

```bash
git fetch origin && git checkout ichigo/16-do-logic
make setup
make typecheck && make test && make lint && make build
```

All four are green on this branch (`@kro/app`: 599 tests across 25 files).

### Acceptance criterion 1 — fixture days partition into lanes exactly per canon, including due-midnight boundaries and the ongoing + overdue overlap

```bash
pnpm --filter @kro/app exec vitest run src/features/do/__tests__/DoRules.test.ts
```

`DoRules.test.ts` opens with the table-driven suite from `DoLanes.md`: 25 rows, one per fixture, each naming the lanes it must land in and why. The boundaries it pins, in order of how easy they are to get wrong:

- **Due at exactly `now`** → Due Soon, never Overdue (`isDueNow` is `due >= now`; `isOverdue` is `due < now`).
- **Due in exactly two hours** → Due Soon; **one second later** → Next. The window is inclusive on the Now side and strict on the Next side.
- **Midnight edge** — `moves a task from Overdue to Expired the moment the calendar day turns` walks the 30 seconds either side of midnight for a task due 23:59: nothing about the task changes, only which day `now` is on.
- **Due at 00:00 today** → Overdue (it is due *today*); **due at 00:00 tomorrow** → no lane at all.
- **Ongoing + overdue overlap** → Overdue alone. Never both; a separate case asserts no fixture in the day is ever matched by both predicates.
- **Ongoing, undated or due tomorrow** → Due Soon's ongoing tail, never Anytime.
- **Skipped** → no lane at all (`hasBeenCompleted` counts it; Completed Today does not).

`lane ordering` pins the sorts, including the one the doc gets wrong (see Notes).

### Acceptance criterion 2 — featured selection is odd-count, centred, deterministic for ties; zero-score exclusion holds

```bash
pnpm --filter @kro/app exec vitest run src/features/do/__tests__/DoFeaturedNow.test.ts
```

- **Scoring** — each weight is asserted at its own boundary: overdue `+100`, ≤2h `+50`, ≤6h `+25` (inclusive, with the moment past it dropping to `+10`), any due date `+10`, ongoing `+30`, duration `+5`, `sessionPoints > 10` `+3` (at exactly 10 it does *not* fire). Completed and reminder-kind endeavors score 0; a habit scores exactly as a task.
- **Centring** — three cards read `[2nd, 1st, 3rd]`; at seven the hero is at index 3; `centredFeaturedWindow` narrows by dropping the lowest-ranked flankers from *both* ends, so `selectDoFeaturedNowLane` at capacity 3 and at capacity 9 return windows with the same hero (`DoSelectors.test.ts`).
- **Odd count** — an even count of three or more loses its weakest card; a two-card day keeps both; the ceiling is nine.
- **Ties** — `breaks a score tie on the earlier due date`, and `is deterministic on a full tie` runs the same input twice and asserts an identical order.
- **Zero-score exclusion** — `excludes every zero-scoring endeavor`, and `is empty when nothing scores`.

### Acceptance criterion 3 — auto-advance picks the documented next card after each completion; rings ignore lens filters

```bash
pnpm --filter @kro/app exec vitest run src/features/do/__tests__/DoShifters.test.ts src/features/do/__tests__/DoRings.test.ts src/features/do/__tests__/DoSelectors.test.ts
```

- **Auto-advance order walk** — `walks the documented order after each completion until the day is empty` builds a three-card day, then loops *complete → advance* and asserts the full sequence of focused keys, ending in `null` (focus clears without jumping). `heroFirstSearchOrder` is pinned at 3 and at 9; `doAutoAdvanceLaneOrder` is asserted to be hero → now → overdue → expired → next → anytime, to exclude Completed Today, and to keep Expired beside Overdue. Bulk mark-complete mode always falls into the clearing branch, and the preference being off clears focus without jumping.
- **Rings ignore filters** — the two ring functions take the raw channels and *accept no lens argument at all*, which is the guarantee made structural. On top of that, `DoSelectors.test.ts` hides the habit kind, asserts the lanes lost every habit, and asserts the gold ring is byte-identical; the same is done for the Completed Today state.
- **Rings truth table** — `DoRings.test.ts` walks the five states from `DayProgressRings.md` (nothing expected / habits only / tasks only / both partly done / both complete), plus: no denominator ⇒ **absent**, not an empty track; overdue counted; expired excluded outright; undated tasks excluded; a habit never counted twice as a task; bulk mode and the `doActivityRings` kill switch hiding the readout.

### Clear Expired atomicity

```bash
pnpm --filter @kro/app exec vitest run src/features/do/__tests__/DoProducer.test.ts
```

Three tests carry it, against a stubbed in-memory store with an instrumented endeavor store:

- `awaits every mutation before the single refetch` — asserts on the call log that both writes precede the one read that follows them.
- `installs nothing at all when a mutation fails halfway — no partial day is observable` — subscribes to the store, fails the second write, and asserts that **every** state the reducer produced during the operation carried the same lanes. There is no instant at which half the day is cleared.
- `reports the refresh failure separately once the mutations have landed` — the two failure modes stay distinct, because the user's next move differs.

A fourth asserts a cleared row is `closed` with `completed` still `null`: clearing is an acknowledgement, not an achievement, and stamping it would let expired work fill a ring.

### Try it yourself

```bash
pnpm --filter @kro/app exec vitest run src/features/do --reporter=verbose
```

295 assertions, each named as a scenario. Nothing reaches the network; every suite goes through `makeStore(extra)` with a stubbed `localStore`.

## Notes

### Canon

Re-fetched `zheref/KroApple` `origin/main` before starting: it is at **`2c1ee45`**, the same commit #1 pinned. **No canon divergence from the epic's pin.**

### Doc ↔ code divergences found in canon, and which one this follows

The epic's rule is that `docs/Features/*.md` binds and **code is the tie-breaker**. Three places where they disagree, all resolved toward the code, all worth a decision:

1. **Clear Expired's target set.** `DoLanes.md` § 6 says the action *"clears all `isOverdue` tasks (both today's Overdue and Expired)"*. The reducer arm says `isOverdue && !isDueToday` — the Expired lane **alone**. This port follows the code and leaves today's Overdue untouched. `doClearExpiredTargets` carries the reasoning and is the one line that changes if you rule for the doc.
2. **Completed Today's pre-sync clause.** `DoLanes.md` § 9 says rows *"marked complete in the current session but not yet synced (no `completed` date set yet) are also included"*. `EndeavorComputedState.completedToday` requires a completion date, and the Do shifter filters on nothing else — so on iOS a just-completed card leaves every lane until the refetch returns it stamped. This port makes the doc's promise true instead, by stamping the completion optimistically (deviation 4 below).
3. **Due Soon's sort.** `DoLanes.md` § 5 says the lane is *"sorted by due date ascending"*. The code sorts the due-window head and then **appends the ongoing tail unsorted**, so the lane is not globally due-ordered. Ported as the code has it, and pinned by a test.

### Boundary semantics the docs do not state, discovered in the Swift

Each is pinned by a test and documented at its definition:

- `isDueNow` is `due >= now` while `isOverdue` is `due < now`, so the instant a task falls due it is **Due Soon**, not Overdue.
- The Due Soon window is inclusive (`<= hours`) and Next is strictly `>`: exactly-two-hours-away is Due Soon.
- Overdue vs Expired splits on the **calendar day of the due date**, not a rolling 24h window — something due 23:59 yesterday is Expired at 00:01 today.
- `isDueNext` additionally requires `isDueToday`, so **a pending task due tomorrow appears in no lane at all** — not Next (not today), not Anytime (it has a due date). This is canon behaviour, not an omission here; it is the fixture `dueTomorrowMorning`.
- The ongoing tail admits an ongoing task *whatever* its due date, so an ongoing task due tomorrow does surface — in Due Soon.
- `hasBeenCompleted` also counts `skipped` / `reviewing` / `qa`, while Completed Today requires `status === closed`: a **skipped** endeavor therefore appears in **no** lane.
- The featured lane's 2h / 6h proximity bands are canon constants and are **not** wired to `do.nowThresholdHours`; the preference moves the lane boundary only.
- `selectFeaturedNowTasks` drops a card to keep the count odd only from three upward — a two-card day legitimately shows an even lane.

### Deliberate deviations from canon, and why

1. **The clock is a parameter.** Canon's `featuredNowScore` and `isOverdue` read `Date()` inside the property, so the same endeavor scores differently on consecutive reads and no test can pin a boundary. Every predicate here takes `now`, exactly as canon already does for `isDueNow(withinHours:now:)`. Weights, thresholds and ordering are unchanged.
2. **`resolvedKind`, not `kind`.** Canon guards every lane on the source-resolved kind. `packages/core/src/vistas` still reads plain `kind` with a doc note at each site saying adoption is a *vistas-lane* change — so this feature re-states the three computed-state guards locally against `resolvedKind` rather than editing files outside its lane. A daily reminder therefore participates here as a Habit, which is what `DayProgressRings.md` requires.
3. **Ties resolve stably.** Ranking is score-desc then due-asc; `Array.sort` is stable where Swift's `sorted` is not, so a full tie falls back to the reconciled pool's own first-appearance order instead of being arbitrary. Strictly more determinism, no change to the ordering canon specifies.
4. **The optimistic completion is stamped.** Canon sets only `status = .closed` and lets the host return the timestamp. Here the local store *is* the host and the persist writes exactly this instant, so stamping it keeps the optimistic and refetched states identical — and it is what makes both specs' promises true at the tap: the card enters Completed Today, and the arc sweeps forward. A completion backdated to an earlier day correctly does neither (tested).
5. **Visibility is stored as arrays, not an `EndeavorsLens`.** The lens carries five `Set`s and the store's `serializableCheck` admits `Date` and plain objects only. `DoState` holds the four toggles Do exposes as plain arrays and materialises the lens at the point of use (`doLensFor`), so the vista keeps owning `showArchived: true` and the exposed toggle set.
6. **Apple sources are absent, so Suggestions has one member.** The epic puts Apple Reminders and Apple Calendar permanently out of scope (no EventKit on web); Google Calendar is the flagship external host. `DoSuggestionSource` declares that one source, and dismissal is keyed on the **source** rather than on canon's copy-hash card id — so re-wording a nudge cannot resurrect one the user already turned down. Adding a source later is a member plus a branch.
7. **The Apple-Reminders relevance branch in the tasks ring is not ported.** It has no reachable input on web; the remaining `due`-is-today term is canon's own fallback for every other host.

### Scope

- **Events are installed, not laned.** The single fetch installs the calendar-event channel so nothing is discarded, but the all-day / timed grouping and the session-skip set from `DoLanes.md` § 2 are not among this issue's deliverables and are not built here.
- **No barrel export.** `packages/app/src/index.ts` is outside this issue's file lane, so the Do surface is not re-exported from `@kro/app` yet. #17 adds the exports it needs in its own lane.
- **No `use<F>` hook, no Page, no Fragment** — #17 owns the render layer.

### Flagged lane exceptions

- `packages/app/src/library/store.ts` — the one reducer entry, added **directly after** the greeting entry as the issue asked.
- `packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts` — a one-line test-literal fix-up. `RootState` now has a second slice, so that suite's hand-built root needs a `do:` field; it asserts nothing about it and says so in a comment. Same class as the #48 precedent, flagged here.

### Definition of Done — the items that are not fully satisfied

- **Coverage is argued, not measured.** `@kro/app` has no coverage provider installed (`@vitest/coverage-v8` is wired in `apps/web` only), and adding a dev dependency is outside this issue's lane and its "no new dependencies" constraint. Instead: every exported symbol in the feature is referenced by a test, every reducer arm / Shifter / Selector / Producer meets the ≥3 minimum, and the audit that found the four thinly-covered helpers (`isActionableDoKind`, `isComputedStateVisible`, `doAutoAdvanceLaneOrder`, `laneCards`) is reflected in the last three `describe` blocks of `DoRules.test.ts`. **Wiring coverage for `@kro/app` deserves its own change** — worth filing.
- **`UZF-26` visual evidence: exempt.** Logic-only session; no rendered UI surface changed.
- **`UZF-21` feature spec:** `docs/Features/Do.md` and `DayProgressRings.md` are canon in `zheref/KroApple`, not in this repo, and this change ports existing behaviour rather than adding any — so there is no spec here to update. Flag wrapping is `UZF-22`-clean: `doActivityRings` and `googleCalendar` are read through the flag registry and AND'd with their preferences where canon does.

---

Bankai-Agent: ichigo
