### PR TITLE
feat(find,detail): Find/Tasks vista logic and Endeavor Detail state

### DIFF
--- a/packages/app/src/features/capture/__tests__/CaptureSelectors.test.ts
+++ b/packages/app/src/features/capture/__tests__/CaptureSelectors.test.ts
@@ -2,6 +2,8 @@ import { EndeavorOperation, EndeavorsVistas } from '@kro/core'
 import { describe, expect, it } from 'vitest'
 import type { RootState } from '../../../library/store'
 import { initialDoState } from '../../do/DoFeature'
+import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
+import { initialFindState } from '../../find/FindState'
 import { greetingStateMocks } from '../../greeting/GreetingMocks'
 import { initialPlanState } from '../../plan/PlanState'
 import { CaptureExceptions } from '../CaptureException'
@@ -45,11 +47,13 @@ import {
 /** Selectors run against a hand-built root state, never a live store. */
 const rootWith = (slice: CaptureState): RootState => ({
   greeting: greetingStateMocks.idle,
-  // Present only because `RootState` names every registered slice (#16, #18);
-  // this suite asserts nothing about Do or Plan.
+  // Present only because `RootState` names every registered slice (#16, #18,
+  // #29); this suite asserts nothing about Do, Plan, Find or Detail.
   do: initialDoState,
   plan: initialPlanState,
   capture: slice,
+  find: initialFindState,
+  endeavorDetail: initialEndeavorDetailState,
 })
 
 const loaded = rootWith(captureStateMocks.loadedPool)

--- a/packages/app/src/features/do/__tests__/DoSelectors.test.ts
+++ b/packages/app/src/features/do/__tests__/DoSelectors.test.ts
@@ -23,16 +23,20 @@ import {
   selectIsDoLoading,
 } from '../DoSelectors'
 import { withVisibilityApplied } from '../DoShifters'
+import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
+import { initialFindState } from '../../find/FindState'
 import { initialPlanState } from '../../plan/PlanState'
 
 /** Selectors run against a hand-built root state, never a live store. */
 const rootWith = (slice: DoState): RootState => ({
   greeting: greetingStateMocks.idle,
   do: slice,
-  // Present only because `RootState` names every registered slice (#18, #23);
-  // this suite asserts nothing about Plan or Capture.
+  // Present only because `RootState` names every registered slice (#18, #23,
+  // #29); this suite asserts nothing about Plan, Capture, Find or Detail.
   plan: initialPlanState,
   capture: initialCaptureState,
+  find: initialFindState,
+  endeavorDetail: initialEndeavorDetailState,
 })
 
 const loaded = rootWith(doStateMocks.loadedTypicalDay)

--- a/packages/app/src/features/endeavorDetail/EndeavorDetailCards.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDetailCards.ts
@@ -1,0 +1,176 @@
+/**
+ * The Detail **read** surface's data — canon's `EndeavorDetailSelectors.swift`
+ * (`visibleFieldsBySectionSelector`, `visibleSectionsSelector`,
+ * `relationManageAvailabilitySelector`) and the header derivations in
+ * `KroUI/EndeavorDetail/EndeavorDetailView.swift`.
+ *
+ * Detail reads the matrix's **visibility** question; Edit reads its
+ * **editability** one. v1 has no visible-but-locked non-relation field, so the
+ * two happen to select the same fields today — they stay separate functions for
+ * canon's own reason: Detail and Edit are independent surfaces, and the day a
+ * field becomes visible-but-locked exactly one of them must change.
+ *
+ * Nothing here formats. A duration is seconds and a status is a status; turning
+ * either into a string is `#30`'s, because this tier has no locale.
+ */
+import {
+  type Endeavor,
+  type EndeavorKind,
+  type EndeavorRelation,
+  type EndeavorStatus,
+  type TimeIntervalSeconds,
+  endeavorKindDisplayName,
+  endeavorRelations,
+  endeavorStatusDisplayName,
+  isFieldVisible,
+  isRelationEditable,
+  isRelationVisible,
+} from '@kro/core'
+import type { EndeavorDetailSectionModel } from './EndeavorDetailEditing'
+import {
+  endeavorDetailSections,
+  fieldsOfSection,
+  sectionTitle,
+} from './EndeavorDetailEditing'
+
+/**
+ * Every section with the fields **visible** for this kind, in display order.
+ * Every section is present, with an empty array where nothing is relevant, so a
+ * caller can look one up without an optional.
+ */
+export const visibleFieldsBySection = (
+  kind: EndeavorKind,
+): readonly EndeavorDetailSectionModel[] =>
+  endeavorDetailSections.map((section) => ({
+    section,
+    title: sectionTitle(section),
+    fields: fieldsOfSection(section).filter((field) =>
+      isFieldVisible(field, kind),
+    ),
+  }))
+
+/**
+ * The sections worth a header — those with at least one visible field. A
+ * section with none is omitted rather than shown empty, which is canon's rule.
+ */
+export const visibleSections = (
+  kind: EndeavorKind,
+): readonly EndeavorDetailSectionModel[] =>
+  visibleFieldsBySection(kind).filter((model) => model.fields.length > 0)
+
+/** One relation card on the read surface. */
+export interface EndeavorRelationCard {
+  readonly relation: EndeavorRelation
+  /** Relations are always visible, whatever the kind (PO decision, 2026-07-10). */
+  readonly isVisible: boolean
+  /** Whether the manage affordance should be offered — per-kind, from the matrix. */
+  readonly isManageable: boolean
+  /** How many entries the endeavor currently holds for this relation. */
+  readonly count: number
+}
+
+const relationCount = (
+  endeavor: Endeavor,
+  relation: EndeavorRelation,
+): number => {
+  switch (relation) {
+    case 'performances':
+      return endeavor.performances.length
+    case 'defers':
+      return endeavor.defers.length
+    case 'hosts':
+      return endeavor.hostedBy.length
+    default:
+      return (endeavor.shadows ?? []).length
+  }
+}
+
+/**
+ * Every relation, in declaration order, with whether its manage affordance is
+ * live for this endeavor's kind.
+ *
+ * Visibility is unconditional and editability comes straight from
+ * `isRelationEditable`, so the read surface and the reducer's own guard cannot
+ * disagree about which relations are manageable.
+ */
+export const relationCards = (
+  endeavor: Endeavor,
+): readonly EndeavorRelationCard[] =>
+  endeavorRelations.map((relation) => ({
+    relation,
+    isVisible: isRelationVisible(relation, endeavor.kind),
+    isManageable: isRelationEditable(relation, endeavor.kind),
+    count: relationCount(endeavor, relation),
+  }))
+
+// ---------------------------------------------------------------------------
+// Header
+// ---------------------------------------------------------------------------
+
+/**
+ * One header chip. Canon's header leads with the **kind** — *"the endeavor's
+ * kind is its strongest identity signal"* — then the status, then the facts
+ * that are set: duration, reward points, whether it repeats.
+ *
+ * The union carries values, never strings-for-display beyond the enum's own
+ * canon label, so `#30` can render an icon and a tint per case without this
+ * tier knowing what a colour is.
+ */
+export type EndeavorDetailBadge =
+  | {
+      readonly kind: 'kind'
+      readonly value: EndeavorKind
+      readonly label: string
+    }
+  | {
+      readonly kind: 'status'
+      readonly value: EndeavorStatus
+      readonly label: string
+    }
+  | { readonly kind: 'duration'; readonly seconds: TimeIntervalSeconds }
+  | { readonly kind: 'rewardPoints'; readonly points: number }
+  | { readonly kind: 'repeats' }
+
+/**
+ * The header's badges, in canon's order.
+ *
+ * Kind and status are always present; the rest appear **only when set**, so a
+ * sparse endeavor gets a compact header rather than a row of placeholders —
+ * canon's own reasoning, preserved verbatim in behaviour.
+ */
+export const detailHeaderBadges = (
+  endeavor: Endeavor,
+): readonly EndeavorDetailBadge[] => {
+  const badges: EndeavorDetailBadge[] = [
+    {
+      kind: 'kind',
+      value: endeavor.kind,
+      label: endeavorKindDisplayName(endeavor.kind),
+    },
+    {
+      kind: 'status',
+      value: endeavor.status,
+      label: endeavorStatusDisplayName(endeavor.status),
+    },
+  ]
+  if (endeavor.duration !== null) {
+    badges.push({ kind: 'duration', seconds: endeavor.duration })
+  }
+  if (endeavor.sessionPoints !== null && endeavor.sessionPoints > 0) {
+    badges.push({ kind: 'rewardPoints', points: endeavor.sessionPoints })
+  }
+  if (endeavor.repeatConfig !== null) {
+    badges.push({ kind: 'repeats' })
+  }
+  return badges
+}
+
+/**
+ * Canon's `displayTitle`: the trimmed title, or **"Untitled"** when it is blank.
+ * A whitespace-only title is blank — otherwise the header would render an
+ * invisible heading.
+ */
+export const detailDisplayTitle = (endeavor: Endeavor): string => {
+  const trimmed = endeavor.title.trim()
+  return trimmed.length === 0 ? 'Untitled' : trimmed
+}

--- a/packages/app/src/features/endeavorDetail/EndeavorDetailEditing.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDetailEditing.ts
@@ -1,0 +1,375 @@
+/**
+ * The Edit surface's field vocabulary and its matrix enforcement — the port of
+ * canon's `EndeavorEditFieldChange` (`Endeavor+EditDisplay.swift`) and
+ * `EndeavorEditShifters.applyFieldChanged`.
+ *
+ * ## Acceptance criterion 3, structurally
+ *
+ * *"Edit refuses kind-irrelevant fields identically to the domain matrix (no
+ * UI-side divergence possible)."* Two halves, both here:
+ *
+ * 1. **A forbidden edit cannot be expressed.** `applyFieldChange` routes every
+ *    change through the domain's own guarded `with…` helper, and those no-op by
+ *    **returning the same object reference** when
+ *    `EndeavorFieldRelevance.isFieldEditable` says no. This file therefore
+ *    contains no per-kind `if` of its own — there is nothing here that could
+ *    drift from the matrix, because the matrix is the only thing consulted.
+ * 2. **The surface can tell in advance.** `editableFieldsBySection` /
+ *    `editableSections` derive the per-kind field set from the same matrix, so
+ *    `#30` renders a field disabled or absent rather than offering a control
+ *    whose edit would be silently dropped.
+ *
+ * The truth table the suite asserts is generated from `endeavorFields ×
+ * endeavorKinds` against `isFieldEditable` — so a change to the **domain**
+ * matrix breaks exactly one test, and a change here that disagreed with the
+ * matrix would break it too.
+ */
+import {
+  type AnyEndeavorList,
+  type Endeavor,
+  EndeavorField,
+  type EndeavorKind,
+  type EndeavorStatus,
+  type EndeavorTag,
+  type RepeatConfig,
+  type TimeIntervalSeconds,
+  assertNever,
+  endeavorFields,
+  isFieldEditable,
+  withAssociatedColor,
+  withDue,
+  withDuration,
+  withDurationProfile,
+  withEffort,
+  withExpiry,
+  withProject,
+  withRepeatConfig,
+  withSessionPoints,
+  withStart,
+  withStatus,
+  withTags,
+  withTitle,
+  withValue,
+} from '@kro/core'
+
+/**
+ * One reported field edit. Canon's `EndeavorEditFieldChange`, case for case —
+ * including `durationProfile`, which the Duration surface reports as one change
+ * because its three bounds are one invariant.
+ */
+export type EndeavorFieldChange =
+  | { readonly field: 'title'; readonly value: string }
+  | { readonly field: 'status'; readonly value: EndeavorStatus }
+  | { readonly field: 'due'; readonly value: Date | null }
+  | { readonly field: 'start'; readonly value: Date | null }
+  | {
+      readonly field: 'duration'
+      readonly value: TimeIntervalSeconds | null
+    }
+  | {
+      readonly field: 'durationProfile'
+      readonly preferred: TimeIntervalSeconds | null
+      readonly minimum: TimeIntervalSeconds | null
+      readonly maximum: TimeIntervalSeconds | null
+    }
+  | { readonly field: 'sessionPoints'; readonly value: number | null }
+  | { readonly field: 'value'; readonly value: number | null }
+  | { readonly field: 'effort'; readonly value: number | null }
+  | { readonly field: 'expiry'; readonly value: Date | null }
+  /** Add the tag if absent, remove it if present — canon's `applyTagToggled`. */
+  | { readonly field: 'tagToggled'; readonly value: EndeavorTag }
+  | { readonly field: 'associatedColor'; readonly value: string | null }
+  | {
+      readonly field: 'project'
+      readonly value: AnyEndeavorList | null
+    }
+  | { readonly field: 'repeatConfig'; readonly value: RepeatConfig | null }
+
+/**
+ * The matrix field a change is governed by.
+ *
+ * `durationProfile` maps to `duration` (it writes the same three columns), and
+ * `tagToggled` to `tags` — so the editability question and the change use one
+ * vocabulary and cannot answer differently.
+ */
+export const fieldOfChange = (change: EndeavorFieldChange): EndeavorField => {
+  switch (change.field) {
+    case 'title':
+      return EndeavorField.title
+    case 'status':
+      return EndeavorField.status
+    case 'due':
+      return EndeavorField.due
+    case 'start':
+      return EndeavorField.start
+    case 'duration':
+    case 'durationProfile':
+      return EndeavorField.duration
+    case 'sessionPoints':
+      return EndeavorField.sessionPoints
+    case 'value':
+      return EndeavorField.value
+    case 'effort':
+      return EndeavorField.effort
+    case 'expiry':
+      return EndeavorField.expiry
+    case 'tagToggled':
+      return EndeavorField.tags
+    case 'associatedColor':
+      return EndeavorField.associatedColor
+    case 'project':
+      return EndeavorField.project
+    case 'repeatConfig':
+      return EndeavorField.repeatConfig
+    default:
+      return assertNever(change)
+  }
+}
+
+/**
+ * Whether the surface may offer this change at all — the *same* question the
+ * domain helper will ask, asked early so a control can be disabled rather than
+ * silently ignored.
+ */
+export const isChangeExpressible = (
+  change: EndeavorFieldChange,
+  kind: EndeavorKind,
+): boolean => isFieldEditable(fieldOfChange(change), kind)
+
+/**
+ * Canon's `applyTagToggled`: flip membership, then normalise an empty result
+ * back to `null`.
+ *
+ * The normalisation is load-bearing and canon spells out why — a cleared
+ * optional serialises as explicit `null`, so *"leaving `[]` instead would
+ * rewrite the server's `tags` column from `NULL` to `'{}'` on save"*.
+ */
+const tagsAfterToggle = (
+  endeavor: Endeavor,
+  tag: EndeavorTag,
+): readonly EndeavorTag[] | null => {
+  const current = endeavor.tags ?? []
+  const next = current.includes(tag)
+    ? current.filter((existing) => existing !== tag)
+    : [...current, tag]
+  return next.length === 0 ? null : next
+}
+
+/**
+ * Apply one change to a working copy.
+ *
+ * Every branch delegates to the domain's guarded helper, so a change the matrix
+ * forbids comes back as **the identical object** — which is exactly what
+ * `isDirty` then reads as "nothing happened". There is no per-kind test in this
+ * function, deliberately: adding one would create the second source of truth
+ * the acceptance criterion forbids.
+ */
+export const applyFieldChange = (
+  endeavor: Endeavor,
+  change: EndeavorFieldChange,
+): Endeavor => {
+  switch (change.field) {
+    case 'title':
+      return withTitle(endeavor, change.value)
+    case 'status':
+      return withStatus(endeavor, change.value)
+    case 'due':
+      return withDue(endeavor, change.value)
+    case 'start':
+      return withStart(endeavor, change.value)
+    case 'duration':
+      return withDuration(endeavor, change.value)
+    case 'durationProfile':
+      return withDurationProfile(endeavor, {
+        preferred: change.preferred,
+        minimum: change.minimum,
+        maximum: change.maximum,
+      })
+    case 'sessionPoints':
+      return withSessionPoints(endeavor, change.value)
+    case 'value':
+      return withValue(endeavor, change.value)
+    case 'effort':
+      return withEffort(endeavor, change.value)
+    case 'expiry':
+      return withExpiry(endeavor, change.value)
+    case 'tagToggled':
+      return withTags(endeavor, tagsAfterToggle(endeavor, change.value))
+    case 'associatedColor':
+      return withAssociatedColor(endeavor, change.value)
+    case 'project':
+      // Canon's two-field invariant: `list` and `projectId` move together, so
+      // `EndeavorUpdatePayload`'s `list?.id ?? projectId` derivation stays
+      // consistent with what the user picked.
+      return withProject(endeavor, {
+        projectId: change.value?.id ?? null,
+        list: change.value,
+      })
+    case 'repeatConfig':
+      return withRepeatConfig(endeavor, change.value)
+    default:
+      return assertNever(change)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dirty tracking
+// ---------------------------------------------------------------------------
+
+/**
+ * A stable, order-independent normalisation of any domain value, for comparison
+ * only. `Date` collapses to its epoch (no ISO string, no locale), object keys
+ * are sorted (so insertion order cannot fake a difference), and arrays keep
+ * their order (because `defers` and `performances` are ordered by meaning).
+ */
+const comparable = (value: unknown): unknown => {
+  if (value instanceof Date) return value.getTime()
+  if (Array.isArray(value)) return value.map(comparable)
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, entry]) => [key, comparable(entry)]),
+    )
+  }
+  return value
+}
+
+/**
+ * Value equality for two endeavors — canon's `endeavor == saved`, which is
+ * Swift struct equality.
+ *
+ * A **reference** comparison would be wrong in both directions: two structurally
+ * identical copies would read as different (leaving a saved form permanently
+ * dirty), and it would make dirty tracking depend on whether a Producer happened
+ * to echo the same object back rather than on whether anything actually changed.
+ * The reference check stays as the fast path.
+ */
+export const endeavorsEqual = (left: Endeavor, right: Endeavor): boolean =>
+  left === right ||
+  JSON.stringify(comparable(left)) === JSON.stringify(comparable(right))
+
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+/**
+ * Canon's `EndeavorDetailSection` / `EndeavorEditSection` — the three display
+ * groups, and the fields each holds in display order.
+ *
+ * The grouping lives here rather than in `@kro/core` for canon's own stated
+ * reason: `EndeavorFieldRelevance` stays per-field and has no notion of a
+ * "section"; grouping fields into display sections is a Detail/Edit concern.
+ */
+export const EndeavorDetailSection = {
+  core: 'core',
+  enrichment: 'enrichment',
+  recurrence: 'recurrence',
+} as const
+
+export type EndeavorDetailSection =
+  (typeof EndeavorDetailSection)[keyof typeof EndeavorDetailSection]
+
+/** Every section, in display order. */
+export const endeavorDetailSections: readonly EndeavorDetailSection[] = [
+  EndeavorDetailSection.core,
+  EndeavorDetailSection.enrichment,
+  EndeavorDetailSection.recurrence,
+]
+
+/** The fields a section holds, in display order. Canon's `section.fields`. */
+export const fieldsOfSection = (
+  section: EndeavorDetailSection,
+): readonly EndeavorField[] => {
+  switch (section) {
+    case EndeavorDetailSection.core:
+      return [
+        EndeavorField.title,
+        EndeavorField.status,
+        EndeavorField.due,
+        EndeavorField.start,
+        EndeavorField.duration,
+        EndeavorField.sessionPoints,
+      ]
+    case EndeavorDetailSection.enrichment:
+      return [
+        EndeavorField.value,
+        EndeavorField.effort,
+        EndeavorField.expiry,
+        EndeavorField.tags,
+        EndeavorField.associatedColor,
+        EndeavorField.project,
+      ]
+    case EndeavorDetailSection.recurrence:
+      return [EndeavorField.repeatConfig]
+    default:
+      return assertNever(section)
+  }
+}
+
+/** `EndeavorDetailSection.displayTitle`. */
+export const sectionTitle = (section: EndeavorDetailSection): string => {
+  switch (section) {
+    case EndeavorDetailSection.core:
+      return 'Core'
+    case EndeavorDetailSection.enrichment:
+      return 'Enrichment'
+    case EndeavorDetailSection.recurrence:
+      return 'Recurrence'
+    default:
+      return assertNever(section)
+  }
+}
+
+/** One section as the surface renders it. */
+export interface EndeavorDetailSectionModel {
+  readonly section: EndeavorDetailSection
+  readonly title: string
+  readonly fields: readonly EndeavorField[]
+}
+
+/**
+ * Every section with the fields **editable** for this kind, in display order,
+ * derived from the domain matrix.
+ *
+ * Sections with no editable field are still present with an empty array, so a
+ * caller can look any section up without an optional — canon's own reason. Use
+ * `editableSections` for the ones worth a header.
+ */
+export const editableFieldsBySection = (
+  kind: EndeavorKind,
+  focusedField: EndeavorField | null = null,
+): readonly EndeavorDetailSectionModel[] =>
+  endeavorDetailSections.map((section) => {
+    const relevant = fieldsOfSection(section).filter((field) =>
+      isFieldEditable(field, kind),
+    )
+    return {
+      section,
+      title: sectionTitle(section),
+      // Canon's focused-field editor exposes exactly one row: opened from a
+      // Detail row, Edit shows that field and nothing else.
+      fields:
+        focusedField === null
+          ? relevant
+          : relevant.filter((field) => field === focusedField),
+    }
+  })
+
+/** The sections with at least one editable field — the ones worth a header. */
+export const editableSections = (
+  kind: EndeavorKind,
+  focusedField: EndeavorField | null = null,
+): readonly EndeavorDetailSectionModel[] =>
+  editableFieldsBySection(kind, focusedField).filter(
+    (model) => model.fields.length > 0,
+  )
+
+/**
+ * Every field this kind can edit, flat and in display order — the row the
+ * truth-table test walks, and the set `#30` renders controls for.
+ */
+export const editableFieldsFor = (
+  kind: EndeavorKind,
+): readonly EndeavorField[] =>
+  endeavorFields.filter((field) => isFieldEditable(field, kind))

--- a/packages/app/src/features/endeavorDetail/EndeavorDetailException.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDetailException.ts
@@ -1,0 +1,62 @@
+/**
+ * The Detail/Edit/Duration/relations failure union (`RC-8`, `UZF-8`).
+ *
+ * Canon splits these across `EndeavorEditException` (local / remote / host
+ * write-back), `EndeavorRelationSyncException` and `EndeavorDefersException`.
+ * They fold into **one** union here for `RC-24`'s reason: the slice carries a
+ * single `save` lifecycle field, and a field typed as a union of unions would
+ * let a reader believe an edit failure and a relation failure can coexist.
+ *
+ * ## Two canon cases have no counterpart yet, deliberately
+ *
+ * `remoteSyncFailed` and `hostWriteBackFailed` describe a save that landed
+ * locally but not on Kro Cloud / not on a provider. This build has **no** cloud
+ * client (`#31`) and **no** provider adapter (`#33`), so a case for either would
+ * be unreachable — and an unreachable case is worse than an absent one, because
+ * a `switch` over it implies coverage nothing can produce. `hostAdapterUnavailable`
+ * below is the honest stand-in: it says the mirror could not be changed *because
+ * this build cannot change mirrors*, which is a different statement from "the
+ * write-back failed".
+ */
+import { type Exception, exception } from '@kro/core'
+
+export type EndeavorDetailException =
+  /** The local upsert failed — nothing was persisted, so the edit stays dirty. */
+  | Exception<'localPersistenceFailed'>
+  /** A child-table relation write (a performance, a defer) failed. */
+  | Exception<'relationSyncFailed'>
+  /** Attaching or detaching a provider is not possible in this build. */
+  | Exception<'hostAdapterUnavailable'>
+  /** The endeavor being edited is no longer in the store. */
+  | Exception<'endeavorNotFound'>
+  /** The defensive `.rejected` fallback's landing shape (`RC-26`). */
+  | Exception<'unknown'>
+
+export const EndeavorDetailExceptions = {
+  localPersistenceFailed: (reason: string): EndeavorDetailException =>
+    exception(
+      'localPersistenceFailed',
+      `Couldn't save your changes: ${reason}`,
+      true,
+    ),
+
+  relationSyncFailed: (reason: string): EndeavorDetailException =>
+    exception('relationSyncFailed', `Couldn't save that entry: ${reason}`, true),
+
+  hostAdapterUnavailable: (reason: string): EndeavorDetailException =>
+    exception('hostAdapterUnavailable', reason, false),
+
+  endeavorNotFound: (id: string): EndeavorDetailException =>
+    exception(
+      'endeavorNotFound',
+      `No endeavor with id '${id}' is stored on this device.`,
+      false,
+    ),
+
+  unknown: (message: string): EndeavorDetailException =>
+    exception('unknown', message, true),
+} as const
+
+/** Narrows an unknown thrown value into this feature's `message` shape. */
+export const detailExceptionMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)

--- a/packages/app/src/features/endeavorDetail/EndeavorDetailFeature.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDetailFeature.ts
@@ -1,0 +1,295 @@
+/**
+ * The Endeavor Detail slice (`RC-1`, `RC-2`, `RC-23`, `RC-36`) — the port of
+ * `EndeavorDetailFeature` and the five children it presents
+ * (`EndeavorEditFeature`, `EndeavorDurationFeature` and the four relation
+ * features), folded into one slice because RTK has no store composition.
+ *
+ * `State` lives in the sibling `EndeavorDetailState.ts`; the matrix-driven
+ * editing vocabulary, the read-surface cards, the duration profile and the
+ * relation forms each own their own file.
+ *
+ * ## Entry points
+ *
+ * Another surface asks for Detail by dispatching `onDetailRequested` (or
+ * `onEditRequested`) with the endeavor it already holds. That is the consumer
+ * side of Find's `viewDetail` / `edit` intents: a slice never imports a sibling
+ * slice (`RC-20`), so the hand-off is one event with a domain value in it, and
+ * the container that sees both is the one that wires them.
+ *
+ * ## Where this reducer deliberately differs from canon's
+ *
+ * - **No `ownerUserId`.** Canon threads it into every local upsert for
+ *   attribution. There is no auth session in this build (`#31`), and inventing a
+ *   field nothing can fill would be a lie in `State`.
+ * - **No host write-back fan-out.** Canon's Edit save fans out one effect per
+ *   external host and aggregates them. There is no provider adapter here, so the
+ *   save ends at the local upsert and the two host operations refuse explicitly.
+ * - **Relations do not have a save button.** That is canon's shape, not a
+ *   simplification: each add/remove commits on its own, so only Edit and
+ *   Duration have a dirty baseline.
+ */
+import type { Endeavor, EndeavorField, EndeavorRelation } from '@kro/core'
+import { isRelationEditable } from '@kro/core'
+import { type PayloadAction, createSlice, isAnyOf } from '@reduxjs/toolkit'
+import type { EndeavorFieldChange } from './EndeavorDetailEditing'
+import { EndeavorDetailExceptions } from './EndeavorDetailException'
+import {
+  addDeferThunk,
+  addPerformanceThunk,
+  addShadowThunk,
+  attachHostThunk,
+  detachHostThunk,
+  removeDeferThunk,
+  removePerformanceThunk,
+  removeShadowThunk,
+  saveEndeavorThunk,
+} from './EndeavorDetailProducer'
+import {
+  withDestinationDismissed,
+  withDetailDismissed,
+  withDetailPresented,
+  withDurationBoundAdjusted,
+  withDurationBoundToggled,
+  withEditRequested,
+  withFieldChanged,
+  withFieldEditRequested,
+  withRelationDraft,
+  withRelationManagementRequested,
+  withRelationUpdated,
+  withSaveFailed,
+  withSaveStarted,
+  withSaveSucceeded,
+} from './EndeavorDetailShifters'
+import type { EndeavorDetailState } from './EndeavorDetailState'
+import { initialEndeavorDetailState } from './EndeavorDetailState'
+import type { DurationBound } from './EndeavorDuration'
+import type { RelationDraft } from './EndeavorRelations'
+
+export type { EndeavorDetailState } from './EndeavorDetailState'
+export { initialEndeavorDetailState } from './EndeavorDetailState'
+
+/** Every relation write resolves the same way, so one arm pair handles them all. */
+const relationThunks = [
+  addPerformanceThunk,
+  removePerformanceThunk,
+  addDeferThunk,
+  removeDeferThunk,
+  addShadowThunk,
+  removeShadowThunk,
+  attachHostThunk,
+  detachHostThunk,
+] as const
+
+export const endeavorDetailSlice = createSlice({
+  name: 'endeavorDetail',
+  initialState: initialEndeavorDetailState,
+  reducers: {
+    /** Lifecycle: another surface asked for Detail on an endeavor it holds. */
+    onDetailRequested(state, action: PayloadAction<{ endeavor: Endeavor }>) {
+      Object.assign(
+        state,
+        withDetailPresented(state as EndeavorDetailState, action.payload),
+      )
+    },
+
+    /** Lifecycle: another surface asked for the full editor directly. */
+    onEditRequested(
+      state,
+      action: PayloadAction<{ endeavor?: Endeavor }>,
+    ) {
+      Object.assign(
+        state,
+        withEditRequested(state as EndeavorDetailState, action.payload),
+      )
+    },
+
+    /** User intent: the Done affordance. Detail closes; nothing survives it. */
+    userDidTapDismiss(state) {
+      Object.assign(state, withDetailDismissed(state as EndeavorDetailState))
+    },
+
+    /**
+     * User intent: one Detail row was tapped to edit it. Refused for a field
+     * the matrix marks non-editable for this kind — the defensive backstop
+     * behind an affordance the read surface should already have rendered inert.
+     */
+    userDidTapField(state, action: PayloadAction<{ field: EndeavorField }>) {
+      Object.assign(
+        state,
+        withFieldEditRequested(state as EndeavorDetailState, action.payload),
+      )
+    },
+
+    /** User intent: a relation's manage affordance. Same matrix gate. */
+    userDidTapManageRelation(
+      state,
+      action: PayloadAction<{ relation: EndeavorRelation }>,
+    ) {
+      Object.assign(
+        state,
+        withRelationManagementRequested(
+          state as EndeavorDetailState,
+          action.payload,
+        ),
+      )
+    },
+
+    /** User intent: the presented editor was closed without saving. */
+    userDidDismissDestination(state) {
+      Object.assign(
+        state,
+        withDestinationDismissed(state as EndeavorDetailState),
+      )
+    },
+
+    /**
+     * User intent: one field edit. Applied through the domain's guarded helper,
+     * so a kind-irrelevant edit leaves the working copy identical and the draft
+     * clean — the refusal is the matrix's.
+     */
+    userDidChangeField(
+      state,
+      action: PayloadAction<{ change: EndeavorFieldChange }>,
+    ) {
+      Object.assign(
+        state,
+        withFieldChanged(state as EndeavorDetailState, action.payload),
+      )
+    },
+
+    /** User intent: a duration bound's switch flipped. */
+    userDidToggleDurationBound(
+      state,
+      action: PayloadAction<{ bound: DurationBound; isEnabled: boolean }>,
+    ) {
+      Object.assign(
+        state,
+        withDurationBoundToggled(state as EndeavorDetailState, action.payload),
+      )
+    },
+
+    /** User intent: a duration bound's number dialled. */
+    userDidAdjustDurationBound(
+      state,
+      action: PayloadAction<{ bound: DurationBound; seconds: number }>,
+    ) {
+      Object.assign(
+        state,
+        withDurationBoundAdjusted(state as EndeavorDetailState, action.payload),
+      )
+    },
+
+    /**
+     * User intent: an add form opened, changed, or was cancelled (`null`).
+     *
+     * Refused where the relation is not editable for this kind, so a form the
+     * matrix forbids cannot even be composed — the same gate the reducer's
+     * manage-relation arm applies, and the same one the domain would apply at
+     * the write.
+     */
+    userDidChangeRelationDraft(
+      state,
+      action: PayloadAction<{ draft: RelationDraft | null }>,
+    ) {
+      const endeavor = state.endeavor
+      const draft = action.payload.draft
+      if (
+        draft !== null &&
+        (endeavor === null ||
+          !isRelationEditable(draft.relation, endeavor.kind))
+      ) {
+        return
+      }
+      Object.assign(
+        state,
+        withRelationDraft(state as EndeavorDetailState, action.payload),
+      )
+    },
+  },
+
+  extraReducers: (builder) => {
+    builder
+      // ------------------------------------------------------- the save
+      .addCase(saveEndeavorThunk.pending, (state) => {
+        Object.assign(state, withSaveStarted(state as EndeavorDetailState))
+      })
+      .addCase(saveEndeavorThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        Object.assign(
+          state,
+          result.ok
+            ? withSaveSucceeded(state as EndeavorDetailState, {
+                saved: result.value,
+              })
+            : withSaveFailed(state as EndeavorDetailState, {
+                exception: result.error,
+              }),
+        )
+      })
+      .addCase(saveEndeavorThunk.rejected, (state, action) => {
+        // Cancellation is the only silent exit (`UZF-14`).
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withSaveFailed(state as EndeavorDetailState, {
+            exception: EndeavorDetailExceptions.unknown(
+              action.error.message ?? 'Unknown error',
+            ),
+          }),
+        )
+      })
+
+      // ------------------------------------------------- relation writes
+      //
+      // Eight thunks, one set of matchers: every relation mutation commits on
+      // its own and reports the refreshed endeavor, so a per-thunk arm set
+      // would be eight copies of the same three lines. The failures differ
+      // only in their exception, which the Producer has already typed.
+      .addMatcher(isAnyOf(...relationThunks.map((thunk) => thunk.pending)), (state) => {
+        Object.assign(state, withSaveStarted(state as EndeavorDetailState))
+      })
+      .addMatcher(
+        isAnyOf(...relationThunks.map((thunk) => thunk.fulfilled)),
+        (state, action) => {
+          const result = action.payload
+          Object.assign(
+            state,
+            result.ok
+              ? withRelationUpdated(state as EndeavorDetailState, {
+                  updated: result.value,
+                })
+              : withSaveFailed(state as EndeavorDetailState, {
+                  exception: result.error,
+                }),
+          )
+        },
+      )
+      .addMatcher(
+        isAnyOf(...relationThunks.map((thunk) => thunk.rejected)),
+        (state, action) => {
+          if (action.meta.aborted) return
+          Object.assign(
+            state,
+            withSaveFailed(state as EndeavorDetailState, {
+              exception: EndeavorDetailExceptions.unknown(
+                action.error.message ?? 'Unknown error',
+              ),
+            }),
+          )
+        },
+      )
+  },
+})
+
+export const {
+  onDetailRequested,
+  onEditRequested,
+  userDidAdjustDurationBound,
+  userDidChangeField,
+  userDidChangeRelationDraft,
+  userDidDismissDestination,
+  userDidTapDismiss,
+  userDidTapField,
+  userDidTapManageRelation,
+  userDidToggleDurationBound,
+} = endeavorDetailSlice.actions

--- a/packages/app/src/features/endeavorDetail/EndeavorDetailMocks.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDetailMocks.ts
@@ -1,0 +1,263 @@
+/**
+ * Canned `EndeavorDetailState` variants and the endeavors behind them
+ * (`RC-31`, `UZF-18`).
+ *
+ * Every test in this feature reads its state from here — a `State` is never
+ * constructed inline — and `#30`'s stories will consume the same variants.
+ *
+ * The fixture set is chosen so the **matrix** is exercised, not just the happy
+ * path: a task (every field and relation editable), a calendar event (no `due`,
+ * no `sessionPoints`, no `performances`), a habit (no `due`, no `hosts`) and a
+ * blueprint (no `start`, `duration`, `sessionPoints`, and no relations at all
+ * beyond `defers`' own rule). A truth table built from any one of those alone
+ * would pass while the matrix was wrong.
+ */
+import type { Endeavor } from '@kro/core'
+import {
+  EndeavorHost,
+  EndeavorKind,
+  EndeavorStatus,
+  PerformResolution,
+  makeEndeavor,
+  makePerform,
+  makeShadow,
+} from '@kro/core'
+import { EndeavorDetailExceptions } from './EndeavorDetailException'
+import type { EndeavorDetailState } from './EndeavorDetailState'
+import { initialEndeavorDetailState } from './EndeavorDetailState'
+import { durationDraftFor } from './EndeavorDuration'
+
+/** A fixed instant. Every fixture below is relative to it. */
+export const DETAIL_REFERENCE_NOW = new Date(2026, 5, 18, 9, 40, 0, 0)
+
+const at = (hour: number, minute = 0): Date =>
+  new Date(2026, 5, 18, hour, minute, 0, 0)
+
+/** Three qualifying sessions — exactly the empirical sample minimum. */
+const qualifyingPerformances = [
+  makePerform({
+    date: at(8, 0),
+    duration: 1500,
+    resolution: PerformResolution.finished,
+    wasCompletedInSession: true,
+    rewardPoints: 5,
+  }),
+  makePerform({
+    date: at(9, 0),
+    duration: 1800,
+    resolution: PerformResolution.complete,
+    wasCompletedInSession: true,
+    rewardPoints: 4,
+  }),
+  makePerform({
+    date: at(10, 0),
+    duration: 2100,
+    resolution: PerformResolution.finished,
+    wasCompletedInSession: true,
+    rewardPoints: 6,
+  }),
+]
+
+export const detailEndeavorMocks = {
+  /** A task: every field and every relation is editable for this kind. */
+  task: makeEndeavor({
+    id: 'detail-task',
+    title: 'Prepare quarterly slides',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.pending,
+    due: at(17, 0),
+    start: at(15, 0),
+    duration: 1800,
+    sessionPoints: 8,
+    createdAt: at(7, 0),
+    hostedBy: [EndeavorHost.local],
+  }),
+
+  /** The same task with three qualifying sessions — the observed-time case. */
+  taskWithSessions: makeEndeavor({
+    id: 'detail-task-sessions',
+    title: 'Write the release notes',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.ongoing,
+    due: at(18, 0),
+    createdAt: at(6, 0),
+    hostedBy: [EndeavorHost.local],
+    performances: qualifyingPerformances,
+  }),
+
+  /** One session short of the minimum — the recommendation stays locked. */
+  taskWithOneSession: makeEndeavor({
+    id: 'detail-task-one-session',
+    title: 'Sketch the onboarding',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.pending,
+    createdAt: at(6, 0),
+    hostedBy: [EndeavorHost.local],
+    performances: [qualifyingPerformances[0] as ReturnType<typeof makePerform>],
+  }),
+
+  /** A calendar event: no `due`, no `sessionPoints`, no `performances`. */
+  event: makeEndeavor({
+    id: 'detail-event',
+    title: 'Team sync',
+    kind: EndeavorKind.calendarEvent,
+    status: EndeavorStatus.planned,
+    start: at(11, 0),
+    duration: 3600,
+    createdAt: at(5, 0),
+    hostedBy: [EndeavorHost.googleCalendar],
+    shadows: [
+      makeShadow({
+        originalTitle: 'Team sync',
+        sourceIdentifier: 'gcal-1',
+        kind: EndeavorKind.calendarEvent,
+        source: EndeavorHost.googleCalendar,
+      }),
+    ],
+  }),
+
+  /** A habit: no `due`, no `hosts`, but sessions and points are its own. */
+  habit: makeEndeavor({
+    id: 'detail-habit',
+    title: 'Stretch',
+    kind: EndeavorKind.habit,
+    status: EndeavorStatus.pending,
+    sessionPoints: 2,
+    createdAt: at(4, 0),
+    hostedBy: [EndeavorHost.local],
+  }),
+
+  /** A blueprint: one of the three meta kinds — no `start`, no `duration`. */
+  blueprint: makeEndeavor({
+    id: 'detail-blueprint',
+    title: 'Quarterly review template',
+    kind: EndeavorKind.blueprint,
+    status: EndeavorStatus.pending,
+    createdAt: at(3, 0),
+    hostedBy: [EndeavorHost.local],
+  }),
+
+  /** A blank title — the one validation rule's failing case. */
+  untitled: makeEndeavor({
+    id: 'detail-untitled',
+    title: '   ',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.pending,
+    createdAt: at(3, 0),
+    hostedBy: [EndeavorHost.local],
+  }),
+} as const
+
+/** Every fixture, in declaration order. */
+export const allDetailEndeavorMocks: readonly Endeavor[] = Object.values(
+  detailEndeavorMocks,
+)
+
+const presented = (endeavor: Endeavor): EndeavorDetailState => ({
+  ...initialEndeavorDetailState,
+  endeavor,
+})
+
+const editing = (endeavor: Endeavor): EndeavorDetailState => ({
+  ...presented(endeavor),
+  destination: { kind: 'edit', focusedField: null },
+  edit: { working: endeavor, original: endeavor, focusedField: null },
+})
+
+export const detailStateMocks = {
+  /** Closed — nothing is presented. */
+  closed: initialEndeavorDetailState,
+
+  /** Detail open on a task, no editor presented. */
+  presentedTask: presented(detailEndeavorMocks.task),
+
+  /** Detail open on a calendar event — the matrix hides three fields. */
+  presentedEvent: presented(detailEndeavorMocks.event),
+
+  /** Detail open on a habit — no due date, no host management. */
+  presentedHabit: presented(detailEndeavorMocks.habit),
+
+  /** The full editor open over a task, nothing changed yet. */
+  editingTask: editing(detailEndeavorMocks.task),
+
+  /** The editor open with one field in focus, as a Detail row tap opens it. */
+  editingTitleOnly: {
+    ...presented(detailEndeavorMocks.task),
+    destination: { kind: 'edit', focusedField: 'title' },
+    edit: {
+      working: detailEndeavorMocks.task,
+      original: detailEndeavorMocks.task,
+      focusedField: 'title',
+    },
+  } satisfies EndeavorDetailState as EndeavorDetailState,
+
+  /** The editor open with an unsaved change — the dirty case. */
+  editingDirty: {
+    ...editing(detailEndeavorMocks.task),
+    edit: {
+      working: { ...detailEndeavorMocks.task, title: 'Prepare the deck' },
+      original: detailEndeavorMocks.task,
+      focusedField: null,
+    },
+  } satisfies EndeavorDetailState as EndeavorDetailState,
+
+  /** The editor open over a blank title — dirty but invalid. */
+  editingInvalid: {
+    ...editing(detailEndeavorMocks.untitled),
+    edit: {
+      working: { ...detailEndeavorMocks.untitled, title: '' },
+      original: detailEndeavorMocks.untitled,
+      focusedField: null,
+    },
+  } satisfies EndeavorDetailState as EndeavorDetailState,
+
+  /** The Duration profile open over a task with three sessions. */
+  durationOpen: {
+    ...presented(detailEndeavorMocks.taskWithSessions),
+    destination: { kind: 'duration' },
+    edit: {
+      working: detailEndeavorMocks.taskWithSessions,
+      original: detailEndeavorMocks.taskWithSessions,
+      focusedField: 'duration',
+    },
+    duration: durationDraftFor(detailEndeavorMocks.taskWithSessions),
+  } satisfies EndeavorDetailState as EndeavorDetailState,
+
+  /** The Performances relation open over a task — editable. */
+  performancesOpen: {
+    ...presented(detailEndeavorMocks.taskWithSessions),
+    destination: { kind: 'relation', relation: 'performances' },
+  } satisfies EndeavorDetailState as EndeavorDetailState,
+
+  /** The Performances relation open over an event — read-only, with a reason. */
+  performancesReadOnly: {
+    ...presented(detailEndeavorMocks.event),
+    destination: { kind: 'relation', relation: 'performances' },
+  } satisfies EndeavorDetailState as EndeavorDetailState,
+
+  /** The Hosts relation open over a task — nothing attachable in this build. */
+  hostsOpen: {
+    ...presented(detailEndeavorMocks.task),
+    destination: { kind: 'relation', relation: 'hosts' },
+  } satisfies EndeavorDetailState as EndeavorDetailState,
+
+  /** A save that failed — the working copy is untouched, still dirty. */
+  saveFailed: {
+    ...editing(detailEndeavorMocks.task),
+    edit: {
+      working: { ...detailEndeavorMocks.task, title: 'Prepare the deck' },
+      original: detailEndeavorMocks.task,
+      focusedField: null,
+    },
+    save: {
+      kind: 'failed',
+      exception: EndeavorDetailExceptions.localPersistenceFailed('disk full'),
+    },
+  } satisfies EndeavorDetailState as EndeavorDetailState,
+
+  /** A save in flight. */
+  saving: {
+    ...editing(detailEndeavorMocks.task),
+    save: { kind: 'saving' },
+  } satisfies EndeavorDetailState as EndeavorDetailState,
+} as const

--- a/packages/app/src/features/endeavorDetail/EndeavorDetailProducer.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDetailProducer.ts
@@ -1,0 +1,461 @@
+/**
+ * Endeavor Detail Producers (`RC-3`, `RC-6`, `RC-7`, `RC-25`) — canon's
+ * `EndeavorEditProducer.produceSaveEndeavorEffect` and the four relation
+ * features' add/remove effects.
+ *
+ * Every thunk reads its services from `extra`, takes `now` as an argument, and
+ * **never throws**: each resolves `Result<Endeavor, EndeavorDetailException>`,
+ * so the slice's `.rejected` arms are defensive fallbacks rather than the error
+ * path.
+ *
+ * ## Offline-first, minus a remote that does not exist yet
+ *
+ * Canon saves locally, then pushes to Kro Cloud, then fans out one write-back
+ * per external host. This build has the first step only — `#31` brings the
+ * cloud client and `#33` the first provider adapter — so a save here is the
+ * local upsert, and the two host operations refuse with a typed exception
+ * rather than reporting a success they cannot deliver. Named, not dropped.
+ *
+ * ## The matrix refuses before persistence, not after
+ *
+ * Every relation mutation goes through the domain's guarded `with…` helper. A
+ * refusal returns **the same object**, and this file then writes nothing and
+ * resolves the unchanged endeavor — so a kind-irrelevant relation edit cannot
+ * reach disk even if a caller dispatched it directly.
+ */
+import {
+  type Defer,
+  type Endeavor,
+  type EndeavorHost,
+  type EndeavorRecord,
+  type LocalStore,
+  type Perform,
+  type ReconciliationContext,
+  type Result,
+  type Shadow,
+  deferFromRecord,
+  deferRecordFromDefer,
+  endeavorFromRecord,
+  endeavorRecordFromEndeavor,
+  epochMillisFromDate,
+  err,
+  livingChildRecords,
+  makeReconciliationContext,
+  ok,
+  performFromRecord,
+  performanceRecordFromPerform,
+  resolvedKind,
+  withAddedDefer,
+  withAddedPerformance,
+  withAddedShadow,
+  withRemovedDefer,
+  withRemovedPerformance,
+  withRemovedShadow,
+} from '@kro/core'
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import type { ThunkExtra } from '../../library/store'
+import type { EndeavorDetailException } from './EndeavorDetailException'
+import {
+  EndeavorDetailExceptions,
+  detailExceptionMessage,
+} from './EndeavorDetailException'
+import { hostAdapterUnavailableReason } from './EndeavorRelations'
+
+type DetailResult = Result<Endeavor, EndeavorDetailException>
+
+/** Hydrates one stored endeavor with its two child relations. */
+const readEndeavor = async (
+  localStore: LocalStore,
+  endeavorId: string,
+): Promise<Endeavor | null> => {
+  const record = await localStore.endeavors.get(endeavorId)
+  if (record === null) return null
+  const [deferRecords, performanceRecords] = await Promise.all([
+    localStore.defers.forEndeavor(endeavorId),
+    localStore.performances.forEndeavor(endeavorId),
+  ])
+  const hydrated = endeavorFromRecord(record, {
+    defers: livingChildRecords(deferRecords).map(deferFromRecord),
+    performances: livingChildRecords(performanceRecords).map(performFromRecord),
+  })
+  return hydrated.ok ? hydrated.value : null
+}
+
+/**
+ * Rewrites one stored endeavor, preserving its sync watermark — dropping
+ * `lastSyncedAtEpochMillis` would present an already-synced row to the next push
+ * sweep as if it had never left the device.
+ */
+const persistEndeavor = async (
+  localStore: LocalStore,
+  endeavor: Endeavor,
+  now: Date,
+  context: ReconciliationContext,
+): Promise<void> => {
+  const existing: EndeavorRecord | null = await localStore.endeavors.get(
+    endeavor.id,
+  )
+  await localStore.endeavors.put(
+    endeavorRecordFromEndeavor(endeavor, {
+      now,
+      lastSyncedAtEpochMillis: existing?.lastSyncedAtEpochMillis ?? null,
+      resolvedKind: resolvedKind(endeavor, context),
+    }),
+  )
+}
+
+/**
+ * The offline-first save — canon's `produceSaveEndeavorEffect`, local half.
+ *
+ * The working copy is persisted exactly as given; the reducer resets its dirty
+ * baseline to the snapshot that landed, not to whatever the user has typed
+ * since.
+ */
+export const saveEndeavorThunk = createAsyncThunk<
+  DetailResult,
+  { readonly endeavor: Endeavor; readonly now: Date },
+  { extra: ThunkExtra }
+>('endeavorDetail/onSaveCompleted', async ({ endeavor, now }, { extra }) => {
+  try {
+    await persistEndeavor(
+      extra.localStore,
+      endeavor,
+      now,
+      makeReconciliationContext({ now }),
+    )
+    return ok(endeavor)
+  } catch (error) {
+    return err(
+      EndeavorDetailExceptions.localPersistenceFailed(
+        detailExceptionMessage(error),
+      ),
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Performances — a child table
+// ---------------------------------------------------------------------------
+
+/**
+ * Log one performance by hand.
+ *
+ * Two writes: the child row, and the endeavor itself (whose `performances`
+ * array the surface reads). The domain helper decides whether there is anything
+ * to write at all — a kind the matrix excludes from `performances` returns the
+ * same endeavor, and nothing is persisted.
+ */
+export const addPerformanceThunk = createAsyncThunk<
+  DetailResult,
+  {
+    readonly endeavorId: string
+    readonly performance: Perform
+    readonly now: Date
+  },
+  { extra: ThunkExtra }
+>(
+  'endeavorDetail/onPerformanceAddCompleted',
+  async ({ endeavorId, performance, now }, { extra }) => {
+    try {
+      const target = await readEndeavor(extra.localStore, endeavorId)
+      if (target === null) {
+        return err(EndeavorDetailExceptions.endeavorNotFound(endeavorId))
+      }
+      const updated = withAddedPerformance(target, performance)
+      if (updated === target) return ok(target)
+
+      await extra.localStore.performances.put(
+        performanceRecordFromPerform(performance, {
+          endeavorId,
+          nowMillis: epochMillisFromDate(now),
+        }),
+      )
+      await persistEndeavor(
+        extra.localStore,
+        updated,
+        now,
+        makeReconciliationContext({ now }),
+      )
+      return ok(updated)
+    } catch (error) {
+      return err(
+        EndeavorDetailExceptions.relationSyncFailed(
+          detailExceptionMessage(error),
+        ),
+      )
+    }
+  },
+)
+
+/**
+ * Remove one performance.
+ *
+ * The index addresses the **living** child rows for this endeavor — the same
+ * order the hydrated `performances` array was built from, which is why the
+ * surface's index and the store's agree. An out-of-range index is the domain's
+ * no-op, so nothing is written.
+ */
+export const removePerformanceThunk = createAsyncThunk<
+  DetailResult,
+  { readonly endeavorId: string; readonly index: number; readonly now: Date },
+  { extra: ThunkExtra }
+>(
+  'endeavorDetail/onPerformanceRemoveCompleted',
+  async ({ endeavorId, index, now }, { extra }) => {
+    try {
+      const target = await readEndeavor(extra.localStore, endeavorId)
+      if (target === null) {
+        return err(EndeavorDetailExceptions.endeavorNotFound(endeavorId))
+      }
+      const updated = withRemovedPerformance(target, index)
+      if (updated === target) return ok(target)
+
+      const rows = livingChildRecords(
+        await extra.localStore.performances.forEndeavor(endeavorId),
+      )
+      const row = rows[index]
+      if (row !== undefined) {
+        await extra.localStore.performances.removeLocal(
+          row,
+          epochMillisFromDate(now),
+        )
+      }
+      await persistEndeavor(
+        extra.localStore,
+        updated,
+        now,
+        makeReconciliationContext({ now }),
+      )
+      return ok(updated)
+    } catch (error) {
+      return err(
+        EndeavorDetailExceptions.relationSyncFailed(
+          detailExceptionMessage(error),
+        ),
+      )
+    }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Defers — a child table, plus the endeavor's own `due`
+// ---------------------------------------------------------------------------
+
+/**
+ * Append one defer.
+ *
+ * `withAddedDefer` records the audit entry **without** moving `due` — canon
+ * keeps that split, and the due move belongs to the deferral *operation* (the
+ * Find surface's `defer`), not to editing the history. Removing an entry
+ * likewise does not undo the due move it recorded.
+ */
+export const addDeferThunk = createAsyncThunk<
+  DetailResult,
+  {
+    readonly endeavorId: string
+    readonly entry: Defer
+    readonly now: Date
+  },
+  { extra: ThunkExtra }
+>(
+  'endeavorDetail/onDeferAddCompleted',
+  async ({ endeavorId, entry, now }, { extra }) => {
+    try {
+      const target = await readEndeavor(extra.localStore, endeavorId)
+      if (target === null) {
+        return err(EndeavorDetailExceptions.endeavorNotFound(endeavorId))
+      }
+      const updated = withAddedDefer(target, entry)
+      if (updated === target) return ok(target)
+
+      await extra.localStore.defers.put(
+        deferRecordFromDefer(entry, {
+          endeavorId,
+          now,
+          nowMillis: epochMillisFromDate(now),
+        }),
+      )
+      await persistEndeavor(
+        extra.localStore,
+        updated,
+        now,
+        makeReconciliationContext({ now }),
+      )
+      return ok(updated)
+    } catch (error) {
+      return err(
+        EndeavorDetailExceptions.relationSyncFailed(
+          detailExceptionMessage(error),
+        ),
+      )
+    }
+  },
+)
+
+/** Remove one defer audit entry. `due` is deliberately left where it is. */
+export const removeDeferThunk = createAsyncThunk<
+  DetailResult,
+  { readonly endeavorId: string; readonly index: number; readonly now: Date },
+  { extra: ThunkExtra }
+>(
+  'endeavorDetail/onDeferRemoveCompleted',
+  async ({ endeavorId, index, now }, { extra }) => {
+    try {
+      const target = await readEndeavor(extra.localStore, endeavorId)
+      if (target === null) {
+        return err(EndeavorDetailExceptions.endeavorNotFound(endeavorId))
+      }
+      const updated = withRemovedDefer(target, index)
+      if (updated === target) return ok(target)
+
+      const rows = livingChildRecords(
+        await extra.localStore.defers.forEndeavor(endeavorId),
+      )
+      const row = rows[index]
+      if (row !== undefined) {
+        await extra.localStore.defers.removeLocal(
+          row,
+          epochMillisFromDate(now),
+        )
+      }
+      await persistEndeavor(
+        extra.localStore,
+        updated,
+        now,
+        makeReconciliationContext({ now }),
+      )
+      return ok(updated)
+    } catch (error) {
+      return err(
+        EndeavorDetailExceptions.relationSyncFailed(
+          detailExceptionMessage(error),
+        ),
+      )
+    }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Shadows — embedded on the endeavor record
+// ---------------------------------------------------------------------------
+
+/**
+ * Add one shadow.
+ *
+ * Shadows embed on the endeavor row, so there is one write. `withAddedShadow`
+ * is one of canon's **unguarded** ingestion helpers — a provider describing its
+ * own item — so the kind gate is the reducer's here, not the domain's, and the
+ * reducer applies exactly the same `isRelationEditable(.shadows, …)` call.
+ */
+export const addShadowThunk = createAsyncThunk<
+  DetailResult,
+  {
+    readonly endeavorId: string
+    readonly shadow: Shadow
+    readonly now: Date
+  },
+  { extra: ThunkExtra }
+>(
+  'endeavorDetail/onShadowAddCompleted',
+  async ({ endeavorId, shadow, now }, { extra }) => {
+    try {
+      const target = await readEndeavor(extra.localStore, endeavorId)
+      if (target === null) {
+        return err(EndeavorDetailExceptions.endeavorNotFound(endeavorId))
+      }
+      const updated = withAddedShadow(target, shadow)
+      await persistEndeavor(
+        extra.localStore,
+        updated,
+        now,
+        makeReconciliationContext({ now }),
+      )
+      return ok(updated)
+    } catch (error) {
+      return err(
+        EndeavorDetailExceptions.relationSyncFailed(
+          detailExceptionMessage(error),
+        ),
+      )
+    }
+  },
+)
+
+/** Remove one shadow. Guarded by the matrix inside `withRemovedShadow`. */
+export const removeShadowThunk = createAsyncThunk<
+  DetailResult,
+  { readonly endeavorId: string; readonly index: number; readonly now: Date },
+  { extra: ThunkExtra }
+>(
+  'endeavorDetail/onShadowRemoveCompleted',
+  async ({ endeavorId, index, now }, { extra }) => {
+    try {
+      const target = await readEndeavor(extra.localStore, endeavorId)
+      if (target === null) {
+        return err(EndeavorDetailExceptions.endeavorNotFound(endeavorId))
+      }
+      const updated = withRemovedShadow(target, index)
+      if (updated === target) return ok(target)
+      await persistEndeavor(
+        extra.localStore,
+        updated,
+        now,
+        makeReconciliationContext({ now }),
+      )
+      return ok(updated)
+    } catch (error) {
+      return err(
+        EndeavorDetailExceptions.relationSyncFailed(
+          detailExceptionMessage(error),
+        ),
+      )
+    }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Hosts — declared by canon, unbindable on this build
+// ---------------------------------------------------------------------------
+
+/**
+ * Attach a provider.
+ *
+ * Canon creates the endeavor's copy **on the provider** and only then records
+ * the host and the shadow it returned. There is no provider adapter in this
+ * build, so recording the host locally would claim a mirror that does not
+ * exist — every later write-back would then aim at a record no provider has.
+ * The operation therefore refuses, with the reason the surface already shows
+ * beside the candidate.
+ */
+export const attachHostThunk = createAsyncThunk<
+  DetailResult,
+  { readonly endeavorId: string; readonly host: EndeavorHost },
+  { extra: ThunkExtra }
+>('endeavorDetail/onHostAttachCompleted', async ({ host }) =>
+  err(
+    EndeavorDetailExceptions.hostAdapterUnavailable(
+      hostAdapterUnavailableReason(host) ??
+        'This provider has no web adapter yet.',
+    ),
+  ),
+)
+
+/**
+ * Detach a provider.
+ *
+ * Symmetrically refused: canon deletes the provider-side copy first, and
+ * dropping the host locally without that call would orphan the provider record
+ * — the endeavor would look un-mirrored while the copy lived on.
+ */
+export const detachHostThunk = createAsyncThunk<
+  DetailResult,
+  { readonly endeavorId: string; readonly host: EndeavorHost },
+  { extra: ThunkExtra }
+>('endeavorDetail/onHostDetachCompleted', async ({ host }) =>
+  err(
+    EndeavorDetailExceptions.hostAdapterUnavailable(
+      hostAdapterUnavailableReason(host) ??
+        'This provider has no web adapter yet.',
+    ),
+  ),
+)

--- a/packages/app/src/features/endeavorDetail/EndeavorDetailSelectors.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDetailSelectors.ts
@@ -1,0 +1,327 @@
+/**
+ * Endeavor Detail Selectors (`RC-5`, `RC-20`) — canon's
+ * `EndeavorDetailSelectors`, `EndeavorEditSelectors`,
+ * `EndeavorDurationSelectors` and the four relation features' Selectors.
+ *
+ * Built with `createSelector` over `RootState` alone, and pure throughout: no
+ * clock, no service. Every per-kind answer comes from the domain matrix through
+ * `EndeavorDetailCards` / `EndeavorDetailEditing`, so a Selector here and the
+ * reducer's own guard cannot disagree about what is editable.
+ */
+import {
+  type Endeavor,
+  type EndeavorField,
+  type EndeavorRelation,
+  type Perform,
+  type Defer,
+  type Shadow,
+} from '@kro/core'
+import { createSelector } from '@reduxjs/toolkit'
+import type { RootState } from '../../library/store'
+import type {
+  EndeavorDetailBadge,
+  EndeavorRelationCard,
+} from './EndeavorDetailCards'
+import {
+  detailDisplayTitle,
+  detailHeaderBadges,
+  relationCards,
+  visibleFieldsBySection,
+  visibleSections,
+} from './EndeavorDetailCards'
+import type { EndeavorDetailSectionModel } from './EndeavorDetailEditing'
+import {
+  editableFieldsBySection,
+  editableSections,
+  endeavorsEqual,
+} from './EndeavorDetailEditing'
+import type { EndeavorDetailException } from './EndeavorDetailException'
+import type {
+  EndeavorDetailDestination,
+  EndeavorDetailState,
+  EndeavorEditDraft,
+} from './EndeavorDetailState'
+import type {
+  EndeavorDurationDraft,
+  ObservedFocusTime,
+} from './EndeavorDuration'
+import { durationValidationMessage, observedFocusTime } from './EndeavorDuration'
+import type {
+  HostAttachCandidate,
+  RelationDraft,
+  RelationEmptyState,
+} from './EndeavorRelations'
+import {
+  attachedHostsOf,
+  defersOf,
+  hostAttachCandidatesOf,
+  isRelationDraftCommittable,
+  performancesOf,
+  relationEmptyState,
+  relationReadOnlyReason,
+  shadowsOf,
+} from './EndeavorRelations'
+
+const selectDetailSlice = (state: RootState): EndeavorDetailState =>
+  state.endeavorDetail
+
+// ---------------------------------------------------------------------------
+// Presentation
+// ---------------------------------------------------------------------------
+
+/** The endeavor Detail is presenting, or `null` when the surface is closed. */
+export const selectDetailEndeavor = createSelector(
+  [selectDetailSlice],
+  (slice): Endeavor | null => slice.endeavor,
+)
+
+export const selectIsDetailPresented = createSelector(
+  [selectDetailSlice],
+  (slice) => slice.endeavor !== null,
+)
+
+export const selectDetailDestination = createSelector(
+  [selectDetailSlice],
+  (slice): EndeavorDetailDestination | null => slice.destination,
+)
+
+/** Canon's `displayTitle` — the trimmed title, or "Untitled" when blank. */
+export const selectDetailTitle = createSelector(
+  [selectDetailEndeavor],
+  (endeavor): string => (endeavor === null ? '' : detailDisplayTitle(endeavor)),
+)
+
+/** The header's kind + state badges, in canon's order. */
+export const selectDetailBadges = createSelector(
+  [selectDetailEndeavor],
+  (endeavor): readonly EndeavorDetailBadge[] =>
+    endeavor === null ? [] : detailHeaderBadges(endeavor),
+)
+
+// ---------------------------------------------------------------------------
+// The read surface's grouped cards
+// ---------------------------------------------------------------------------
+
+/** Every section with its per-kind visible fields — empty arrays included. */
+export const selectDetailFieldsBySection = createSelector(
+  [selectDetailEndeavor],
+  (endeavor): readonly EndeavorDetailSectionModel[] =>
+    endeavor === null ? [] : visibleFieldsBySection(endeavor.kind),
+)
+
+/** Only the sections worth a header — those with at least one visible field. */
+export const selectDetailVisibleSections = createSelector(
+  [selectDetailEndeavor],
+  (endeavor): readonly EndeavorDetailSectionModel[] =>
+    endeavor === null ? [] : visibleSections(endeavor.kind),
+)
+
+/** The four relation cards, with per-kind manageability and their counts. */
+export const selectDetailRelationCards = createSelector(
+  [selectDetailEndeavor],
+  (endeavor): readonly EndeavorRelationCard[] =>
+    endeavor === null ? [] : relationCards(endeavor),
+)
+
+// ---------------------------------------------------------------------------
+// Edit
+// ---------------------------------------------------------------------------
+
+export const selectEditDraft = createSelector(
+  [selectDetailSlice],
+  (slice): EndeavorEditDraft | null => slice.edit,
+)
+
+/** The working copy the editor is presenting, or `null` when none is open. */
+export const selectEditWorkingCopy = createSelector(
+  [selectEditDraft],
+  (draft): Endeavor | null => draft?.working ?? null,
+)
+
+/** The sections and fields Edit may render for this kind — the matrix's answer. */
+export const selectEditableSections = createSelector(
+  [selectEditDraft],
+  (draft): readonly EndeavorDetailSectionModel[] =>
+    draft === null
+      ? []
+      : editableSections(draft.working.kind, draft.focusedField),
+)
+
+/** Every section, including the empty ones — for a caller that indexes them. */
+export const selectEditableFieldsBySection = createSelector(
+  [selectEditDraft],
+  (draft): readonly EndeavorDetailSectionModel[] =>
+    draft === null
+      ? []
+      : editableFieldsBySection(draft.working.kind, draft.focusedField),
+)
+
+/**
+ * Canon's `isDirtySelector`: the working copy differs from the saved baseline.
+ *
+ * By **value**, not by reference — canon compares two Swift structs, and a
+ * reference comparison would leave a just-saved form permanently dirty the
+ * moment a Producer echoed back a structurally identical copy.
+ */
+export const selectIsEditDirty = createSelector(
+  [selectEditDraft],
+  (draft): boolean =>
+    draft !== null && !endeavorsEqual(draft.working, draft.original),
+)
+
+/**
+ * Canon's `isTitleValidSelector` — v1's one validation rule. `title` is the
+ * only field rendered unconditionally, so it is the only one required.
+ */
+export const selectIsEditValid = createSelector(
+  [selectEditDraft],
+  (draft): boolean => draft !== null && draft.working.title.trim().length > 0,
+)
+
+export const selectIsDetailSaving = createSelector(
+  [selectDetailSlice],
+  (slice) => slice.save.kind === 'saving',
+)
+
+export const selectDetailException = createSelector(
+  [selectDetailSlice],
+  (slice): EndeavorDetailException | null =>
+    slice.save.kind === 'failed' ? slice.save.exception : null,
+)
+
+/**
+ * Canon's `isSaveEnabledSelector`, plus the Duration screen's extra term:
+ * there is something to save, it is valid, the duration profile is coherent,
+ * and no save is already in flight.
+ */
+export const selectIsSaveEnabled = createSelector(
+  [
+    selectIsEditDirty,
+    selectIsEditValid,
+    selectIsDetailSaving,
+    selectDetailSlice,
+  ],
+  (isDirty, isValid, isSaving, slice): boolean => {
+    if (!isDirty || !isValid || isSaving) return false
+    if (slice.duration === null) return true
+    return durationValidationMessage(slice.duration) === null
+  },
+)
+
+/** Canon's `editNavigationTitleSelector` — "Edit" or "Edit <field>". */
+export const selectEditNavigationTitle = createSelector(
+  [selectEditDraft],
+  (draft): string => {
+    const focused: EndeavorField | null = draft?.focusedField ?? null
+    return focused === null ? 'Edit' : `Edit ${focused}`
+  },
+)
+
+/** Canon's `showsIdentityHeaderSelector` — the full form shows the header. */
+export const selectEditShowsIdentityHeader = createSelector(
+  [selectEditDraft],
+  (draft): boolean => draft !== null && draft.focusedField === null,
+)
+
+// ---------------------------------------------------------------------------
+// Duration
+// ---------------------------------------------------------------------------
+
+export const selectDurationDraft = createSelector(
+  [selectDetailSlice],
+  (slice): EndeavorDurationDraft | null => slice.duration,
+)
+
+/** The read-only "Observed focus time" card, computed from performances. */
+export const selectObservedFocusTime = createSelector(
+  [selectDetailEndeavor],
+  (endeavor): ObservedFocusTime | null =>
+    endeavor === null ? null : observedFocusTime(endeavor),
+)
+
+/** Canon's `validationMessageSelector`. `null` when the profile is coherent. */
+export const selectDurationValidationMessage = createSelector(
+  [selectDurationDraft],
+  (draft): string | null =>
+    draft === null ? null : durationValidationMessage(draft),
+)
+
+// ---------------------------------------------------------------------------
+// Relations
+// ---------------------------------------------------------------------------
+
+export const selectDetailPerformances = createSelector(
+  [selectDetailEndeavor],
+  (endeavor): readonly Perform[] =>
+    endeavor === null ? [] : performancesOf(endeavor),
+)
+
+export const selectDetailDefers = createSelector(
+  [selectDetailEndeavor],
+  (endeavor): readonly Defer[] => (endeavor === null ? [] : defersOf(endeavor)),
+)
+
+export const selectDetailShadows = createSelector(
+  [selectDetailEndeavor],
+  (endeavor): readonly Shadow[] =>
+    endeavor === null ? [] : shadowsOf(endeavor),
+)
+
+/** Canon's `attachedHostsSelector` — the external providers in `hostedBy`. */
+export const selectDetailAttachedHosts = createSelector(
+  [selectDetailEndeavor],
+  (endeavor) => (endeavor === null ? [] : attachedHostsOf(endeavor)),
+)
+
+/**
+ * Canon's `availableHostsToAttachSelector`, each candidate carrying whether
+ * this build can actually attach it — today none can, and each says why.
+ */
+export const selectDetailHostCandidates = createSelector(
+  [selectDetailEndeavor],
+  (endeavor): readonly HostAttachCandidate[] =>
+    endeavor === null ? [] : hostAttachCandidatesOf(endeavor),
+)
+
+/**
+ * Why the presented relation is read-only for this kind, or `null` when it is
+ * editable. This is the string the surface shows **instead of** the add form.
+ */
+export const selectRelationReadOnlyReason = createSelector(
+  [selectDetailEndeavor, selectDetailDestination],
+  (endeavor, destination): string | null => {
+    if (endeavor === null) return null
+    if (destination === null || destination.kind !== 'relation') return null
+    return relationReadOnlyReason(destination.relation, endeavor.kind)
+  },
+)
+
+/** The presented relation's empty-state copy, keyed on its editability. */
+export const selectRelationEmptyState = createSelector(
+  [selectDetailEndeavor, selectDetailDestination],
+  (endeavor, destination): RelationEmptyState | null => {
+    if (endeavor === null) return null
+    if (destination === null || destination.kind !== 'relation') return null
+    return relationEmptyState(destination.relation, endeavor.kind)
+  },
+)
+
+/** The relation the surface is managing, or `null`. */
+export const selectManagedRelation = createSelector(
+  [selectDetailDestination],
+  (destination): EndeavorRelation | null =>
+    destination !== null && destination.kind === 'relation'
+      ? destination.relation
+      : null,
+)
+
+export const selectRelationDraft = createSelector(
+  [selectDetailSlice],
+  (slice): RelationDraft | null => slice.relationDraft,
+)
+
+/** Whether the open add form has enough in it to commit. */
+export const selectIsRelationDraftCommittable = createSelector(
+  [selectRelationDraft],
+  (draft): boolean => draft !== null && isRelationDraftCommittable(draft),
+)

--- a/packages/app/src/features/endeavorDetail/EndeavorDetailShifters.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDetailShifters.ts
@@ -1,0 +1,344 @@
+/**
+ * Endeavor Detail Shifters (`RC-4`, `RC-19`) — canon's
+ * `EndeavorDetailShifters` (`applyFieldEditRequested`,
+ * `applyRelationManagementRequested`, `applyRelationUpdated`) and
+ * `EndeavorEditShifters` (the save lifecycle) in one file, because they are one
+ * slice here.
+ *
+ * Pure throughout: no clock, no store. Where a transition needs an instant — a
+ * fresh defer's `made`, a hand-logged performance's date — it is an argument.
+ *
+ * ## The matrix guards are defensive backstops, not the rule
+ *
+ * `withFieldEditRequested` and `withRelationManagementRequested` both refuse a
+ * field or relation the matrix marks non-editable. The read surface should not
+ * have offered a tappable affordance in the first place — the same
+ * `isFieldEditable` / `isRelationEditable` calls drive
+ * `visibleFieldsBySection` and `relationCards` — so these guards exist for the
+ * case canon names: *"this is the defensive backstop"*.
+ */
+import {
+  type Endeavor,
+  type EndeavorField,
+  EndeavorField as Field,
+  type EndeavorRelation,
+  isFieldEditable,
+  isRelationEditable,
+} from '@kro/core'
+import type { EndeavorFieldChange } from './EndeavorDetailEditing'
+import { applyFieldChange, endeavorsEqual } from './EndeavorDetailEditing'
+import type { EndeavorDetailException } from './EndeavorDetailException'
+import type { EndeavorDetailState } from './EndeavorDetailState'
+import { initialEndeavorDetailState } from './EndeavorDetailState'
+import type {
+  DurationBound,
+  EndeavorDurationDraft,
+} from './EndeavorDuration'
+import {
+  draftWithBoundAdjusted,
+  draftWithBoundToggled,
+  durationDraftFor,
+  durationProfileOf,
+} from './EndeavorDuration'
+import type { RelationDraft } from './EndeavorRelations'
+
+// ---------------------------------------------------------------------------
+// Presentation
+// ---------------------------------------------------------------------------
+
+/**
+ * One concern: Detail opened on an endeavor.
+ *
+ * Every draft is cleared with it — a destination left over from the previous
+ * endeavor would edit the wrong row, which is precisely the invariant canon
+ * gets for free from `@Presents`.
+ */
+export function withDetailPresented(
+  _state: EndeavorDetailState,
+  args: { readonly endeavor: Endeavor },
+): EndeavorDetailState {
+  return { ...initialEndeavorDetailState, endeavor: args.endeavor }
+}
+
+/** One concern: Detail closed. Nothing survives it. */
+export function withDetailDismissed(
+  _state: EndeavorDetailState,
+): EndeavorDetailState {
+  return initialEndeavorDetailState
+}
+
+/** A fresh edit draft over an endeavor. The baseline starts equal to it. */
+const draftFor = (
+  endeavor: Endeavor,
+  focusedField: EndeavorField | null,
+): EndeavorDetailState['edit'] => ({
+  working: endeavor,
+  original: endeavor,
+  focusedField,
+})
+
+/**
+ * One concern: a Detail row was tapped to edit it.
+ *
+ * `duration` opens the Duration profile — canon routes that one field to its own
+ * screen — and every other field opens Edit focused on it. A field the matrix
+ * refuses opens nothing.
+ */
+export function withFieldEditRequested(
+  state: EndeavorDetailState,
+  args: { readonly field: EndeavorField },
+): EndeavorDetailState {
+  const endeavor = state.endeavor
+  if (endeavor === null) return state
+  if (!isFieldEditable(args.field, endeavor.kind)) return state
+
+  if (args.field === Field.duration) {
+    return {
+      ...state,
+      destination: { kind: 'duration' },
+      edit: draftFor(endeavor, Field.duration),
+      duration: durationDraftFor(endeavor),
+      relationDraft: null,
+    }
+  }
+  return {
+    ...state,
+    destination: { kind: 'edit', focusedField: args.field },
+    edit: draftFor(endeavor, args.field),
+    duration: null,
+    relationDraft: null,
+  }
+}
+
+/**
+ * One concern: the full editor was opened (no single field in focus) — the
+ * entry point another surface's `edit` operation lands on.
+ */
+export function withEditRequested(
+  state: EndeavorDetailState,
+  args: { readonly endeavor?: Endeavor },
+): EndeavorDetailState {
+  const endeavor = args.endeavor ?? state.endeavor
+  if (endeavor === null) return state
+  return {
+    ...state,
+    endeavor,
+    destination: { kind: 'edit', focusedField: null },
+    edit: draftFor(endeavor, null),
+    duration: null,
+    relationDraft: null,
+  }
+}
+
+/**
+ * One concern: a relation's manage affordance was tapped.
+ *
+ * Refused where the matrix marks the relation non-editable for this kind — the
+ * defensive backstop behind an affordance `relationCards` should already have
+ * rendered inert.
+ */
+export function withRelationManagementRequested(
+  state: EndeavorDetailState,
+  args: { readonly relation: EndeavorRelation },
+): EndeavorDetailState {
+  const endeavor = state.endeavor
+  if (endeavor === null) return state
+  if (!isRelationEditable(args.relation, endeavor.kind)) return state
+  return {
+    ...state,
+    destination: { kind: 'relation', relation: args.relation },
+    edit: null,
+    duration: null,
+    relationDraft: null,
+  }
+}
+
+/**
+ * One concern: the presented editor closed without saving.
+ *
+ * Discarding is implicit — the working copy simply never reaches `endeavor`,
+ * which is canon's own wording: *"the caller never receives the unsaved working
+ * copy"*. A failed save is cleared with it, so reopening starts clean.
+ */
+export function withDestinationDismissed(
+  state: EndeavorDetailState,
+): EndeavorDetailState {
+  return {
+    ...state,
+    destination: null,
+    edit: null,
+    duration: null,
+    relationDraft: null,
+    save: { kind: 'idle' },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Editing
+// ---------------------------------------------------------------------------
+
+/**
+ * One concern: one field edit landed on the working copy.
+ *
+ * The change goes through the domain's guarded helper, so a kind-irrelevant
+ * edit returns the identical object and the draft stays clean — the refusal is
+ * the matrix's, not a check restated here.
+ *
+ * Any further edit also supersedes a stale save failure, so the error banner
+ * does not linger once the user has acted on it (canon's invariant).
+ */
+export function withFieldChanged(
+  state: EndeavorDetailState,
+  args: { readonly change: EndeavorFieldChange },
+): EndeavorDetailState {
+  const edit = state.edit
+  if (edit === null) return state
+  return {
+    ...state,
+    edit: { ...edit, working: applyFieldChange(edit.working, args.change) },
+    save: { kind: 'idle' },
+  }
+}
+
+/**
+ * One concern: the three duration bounds and the working copy move together.
+ *
+ * Canon's `applyDurationProfileChanged` — the draft is the user-facing shape and
+ * the working copy is what saves, so writing one without the other would let the
+ * dials and the row disagree.
+ */
+const withDurationProfileApplied = (
+  state: EndeavorDetailState,
+  draft: EndeavorDurationDraft,
+): EndeavorDetailState => {
+  const edit = state.edit
+  if (edit === null) return { ...state, duration: draft }
+  const profile = durationProfileOf(draft)
+  return {
+    ...state,
+    duration: draft,
+    edit: {
+      ...edit,
+      working: applyFieldChange(edit.working, {
+        field: 'durationProfile',
+        preferred: profile.preferred,
+        minimum: profile.minimum,
+        maximum: profile.maximum,
+      }),
+    },
+    save: { kind: 'idle' },
+  }
+}
+
+/** One concern: a bound's switch flipped, and the working copy followed. */
+export function withDurationBoundToggled(
+  state: EndeavorDetailState,
+  args: { readonly bound: DurationBound; readonly isEnabled: boolean },
+): EndeavorDetailState {
+  const draft = state.duration
+  if (draft === null) return state
+  return withDurationProfileApplied(
+    state,
+    draftWithBoundToggled(draft, args.bound, args.isEnabled),
+  )
+}
+
+/** One concern: a bound's number dialled, and the working copy followed. */
+export function withDurationBoundAdjusted(
+  state: EndeavorDetailState,
+  args: { readonly bound: DurationBound; readonly seconds: number },
+): EndeavorDetailState {
+  const draft = state.duration
+  if (draft === null) return state
+  return withDurationProfileApplied(
+    state,
+    draftWithBoundAdjusted(draft, args.bound, args.seconds),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Save lifecycle
+// ---------------------------------------------------------------------------
+
+/** One concern: a save started, so a stale failure banner goes with it. */
+export function withSaveStarted(
+  state: EndeavorDetailState,
+): EndeavorDetailState {
+  return { ...state, save: { kind: 'saving' } }
+}
+
+/**
+ * One concern: the save landed.
+ *
+ * `saved` is the exact snapshot that was persisted — **not** necessarily the
+ * working copy at completion time, because a field edit has no in-flight guard
+ * and the user can keep typing. So the working copy is only adopted when
+ * nothing raced ahead of it; otherwise the newer edit stays live and correctly
+ * re-reads as dirty against the new baseline, instead of being silently
+ * discarded. Canon's `applySaveSucceeded`, reasoning included.
+ */
+export function withSaveSucceeded(
+  state: EndeavorDetailState,
+  args: { readonly saved: Endeavor },
+): EndeavorDetailState {
+  const edit = state.edit
+  const raced = edit !== null && !endeavorsEqual(edit.working, args.saved)
+  return {
+    ...state,
+    endeavor: args.saved,
+    edit:
+      edit === null
+        ? null
+        : {
+            ...edit,
+            working: raced ? edit.working : args.saved,
+            original: args.saved,
+          },
+    save: { kind: 'idle' },
+  }
+}
+
+/**
+ * One concern: the save failed.
+ *
+ * The working copy is left exactly as the user left it — a `localPersistenceFailed`
+ * means nothing was written, so the edit must stay dirty for a retry.
+ */
+export function withSaveFailed(
+  state: EndeavorDetailState,
+  args: { readonly exception: EndeavorDetailException },
+): EndeavorDetailState {
+  return { ...state, save: { kind: 'failed', exception: args.exception } }
+}
+
+/**
+ * One concern: a relation write landed.
+ *
+ * Detail's own copy refreshes so the read surface reflects it immediately on
+ * return. The editor drafts are untouched: a relation screen has no dirty/save
+ * lifecycle of its own — every add and remove commits on its own, which is
+ * canon's shape for all four of them.
+ */
+export function withRelationUpdated(
+  state: EndeavorDetailState,
+  args: { readonly updated: Endeavor },
+): EndeavorDetailState {
+  return {
+    ...state,
+    endeavor: args.updated,
+    relationDraft: null,
+    save: { kind: 'idle' },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Relation add forms
+// ---------------------------------------------------------------------------
+
+/** One concern: an add form opened (or its fields changed). */
+export function withRelationDraft(
+  state: EndeavorDetailState,
+  args: { readonly draft: RelationDraft | null },
+): EndeavorDetailState {
+  return { ...state, relationDraft: args.draft, save: { kind: 'idle' } }
+}

--- a/packages/app/src/features/endeavorDetail/EndeavorDetailShifters.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDetailShifters.ts
@@ -23,7 +23,6 @@ import {
   EndeavorField as Field,
   type EndeavorRelation,
   isFieldEditable,
-  isRelationEditable,
 } from '@kro/core'
 import type { EndeavorFieldChange } from './EndeavorDetailEditing'
 import { applyFieldChange, endeavorsEqual } from './EndeavorDetailEditing'
@@ -143,7 +142,9 @@ export function withRelationManagementRequested(
 ): EndeavorDetailState {
   const endeavor = state.endeavor
   if (endeavor === null) return state
-  if (!isRelationEditable(args.relation, endeavor.kind)) return state
+  // Read-only relations still OPEN — canon renders their screens with the
+  // "why" copy and disabled affordances. Only the mutation path refuses
+  // (the draft guard in the Feature and `isManageable` on the cards).
   return {
     ...state,
     destination: { kind: 'relation', relation: args.relation },

--- a/packages/app/src/features/endeavorDetail/EndeavorDetailState.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDetailState.ts
@@ -1,0 +1,87 @@
+/**
+ * `EndeavorDetailState` — the shape behind the Detail read surface and the
+ * three editors it presents (Edit, Duration, and the four relation screens).
+ *
+ * Split out of `EndeavorDetailFeature.ts` under `RC-1`'s size clause.
+ *
+ * ## One slice, canon's six children
+ *
+ * Canon composes `EndeavorDetailFeature` with a `Destination` enum over six
+ * child reducers, each with its own store. RTK has no store composition of that
+ * kind, so the destination becomes **one discriminated field** and each child's
+ * working state becomes one nullable field beside it. The invariant canon gets
+ * from `@Presents` — a child's state exists exactly while it is presented — is
+ * kept by the Shifters: opening a destination seeds its draft, closing one
+ * clears every draft.
+ *
+ * ## Duration edits *through* the edit draft, as canon does
+ *
+ * Canon's `EndeavorDurationFeature` embeds an `EndeavorEditFeature.State` and
+ * reports its three bounds as one `durationProfile` field change. The same shape
+ * holds here: opening Duration seeds **both** the edit draft and the duration
+ * draft, and every bound change writes through `applyFieldChange`. That is what
+ * makes dirty tracking and the save path identical for the two editors, and it
+ * is why a kind whose matrix forbids `duration` cannot save one from either.
+ */
+import type { Endeavor, EndeavorField, EndeavorRelation } from '@kro/core'
+import type { EndeavorDetailException } from './EndeavorDetailException'
+import type { EndeavorDurationDraft } from './EndeavorDuration'
+import type { RelationDraft } from './EndeavorRelations'
+
+/** Which editor is presented over Detail, if any. */
+export type EndeavorDetailDestination =
+  /** The field editor. `focusedField` narrows it to one row, as canon does. */
+  | { readonly kind: 'edit'; readonly focusedField: EndeavorField | null }
+  /** The duration profile. */
+  | { readonly kind: 'duration' }
+  /** One of the four relation management screens. */
+  | { readonly kind: 'relation'; readonly relation: EndeavorRelation }
+
+/**
+ * The one lifecycle field (`RC-24`, `UZF-9`) — a save or a relation write is in
+ * flight, or the last one failed. Never `isSaving` + `exception` in parallel.
+ */
+export type EndeavorDetailSaveState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'saving' }
+  | { readonly kind: 'failed'; readonly exception: EndeavorDetailException }
+
+/**
+ * The editor's working copy and its dirty baseline.
+ *
+ * `original` is the last **durably saved** value — not the value the editor
+ * opened with, once a save has landed — so `isDirty` answers "is there anything
+ * still to save", which is the question the Save affordance asks.
+ */
+export interface EndeavorEditDraft {
+  readonly working: Endeavor
+  readonly original: Endeavor
+  /** Non-null when Edit was opened from one Detail row and shows only it. */
+  readonly focusedField: EndeavorField | null
+}
+
+export interface EndeavorDetailState {
+  /**
+   * The endeavor Detail presents, or `null` when the surface is closed. The
+   * caller already holds the full domain model (a list selection), so it is
+   * passed in rather than re-fetched — canon's own note.
+   */
+  readonly endeavor: Endeavor | null
+  readonly destination: EndeavorDetailDestination | null
+  /** Present while Edit **or** Duration is open. */
+  readonly edit: EndeavorEditDraft | null
+  /** Present while Duration is open. */
+  readonly duration: EndeavorDurationDraft | null
+  /** The open relation add-form, if any. */
+  readonly relationDraft: RelationDraft | null
+  readonly save: EndeavorDetailSaveState
+}
+
+export const initialEndeavorDetailState: EndeavorDetailState = {
+  endeavor: null,
+  destination: null,
+  edit: null,
+  duration: null,
+  relationDraft: null,
+  save: { kind: 'idle' },
+}

--- a/packages/app/src/features/endeavorDetail/EndeavorDuration.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorDuration.ts
@@ -1,0 +1,179 @@
+/**
+ * The Duration profile — the port of canon's `EndeavorDurationFeature`,
+ * `EndeavorDurationSelectors` and `EndeavorDurationShifters`.
+ *
+ * Three optional bounds the user authors — preferred, minimum, maximum — over
+ * one number the app **observes**: the empirical duration, computed from the
+ * endeavor's completed focus sessions.
+ *
+ * ## Observed focus time is read-only, and that is the point
+ *
+ * `empiricalDuration` (#8, `@kro/core`) is the mean of the qualifying
+ * performances. It seeds the drafts so a user who has never authored a
+ * preference still sees a sensible number, but **enabling** a bound is an
+ * explicit act — canon's own note: *"Empirical history prefills the draft
+ * without silently turning the learned value into an authored preference. The
+ * user must explicitly enable Preferred to freeze that recommendation."* So the
+ * observation is never written back, and nothing here can write it.
+ *
+ * Everything in this file is pure. Nothing formats — the surface turns seconds
+ * into "25 min", because this tier has no locale.
+ */
+import {
+  EMPIRICAL_SAMPLE_MINIMUM,
+  type Endeavor,
+  type TimeIntervalSeconds,
+  empiricalDuration,
+  empiricalDurationPerformances,
+  minutesInSeconds,
+} from '@kro/core'
+
+/** Canon's fallback seed when nothing is authored and nothing is observed. */
+export const DEFAULT_DURATION_SEED: TimeIntervalSeconds = minutesInSeconds(25)
+
+/** Which of the three bounds a toggle or an adjustment is about. */
+export const DurationBound = {
+  preferred: 'preferred',
+  minimum: 'minimum',
+  maximum: 'maximum',
+} as const
+
+export type DurationBound = (typeof DurationBound)[keyof typeof DurationBound]
+
+/** Every bound, in canon's display order. */
+export const durationBounds: readonly DurationBound[] = [
+  DurationBound.preferred,
+  DurationBound.minimum,
+  DurationBound.maximum,
+]
+
+/**
+ * The three drafts and their switches.
+ *
+ * A draft survives its switch being turned off, so toggling a bound off and
+ * back on restores the number the user had dialled rather than resetting it —
+ * canon keeps the draft and the switch as separate fields for exactly that.
+ */
+export interface EndeavorDurationDraft {
+  readonly preferredSeconds: TimeIntervalSeconds
+  readonly minimumSeconds: TimeIntervalSeconds
+  readonly maximumSeconds: TimeIntervalSeconds
+  readonly isPreferredEnabled: boolean
+  readonly isMinimumEnabled: boolean
+  readonly isMaximumEnabled: boolean
+}
+
+/**
+ * Canon's `EndeavorDurationFeature.State.init`, value for value.
+ *
+ * The seed ladder is `duration ?? empirical ?? 25 min` for preferred, and
+ * `<own bound> ?? duration ?? empirical ?? seed` for the two others — so a
+ * profile with only a preferred value opens with all three dials agreeing
+ * instead of two of them sitting at zero.
+ */
+export const durationDraftFor = (
+  endeavor: Endeavor,
+): EndeavorDurationDraft => {
+  const observed = empiricalDuration(endeavor)
+  const seed = endeavor.duration ?? observed ?? DEFAULT_DURATION_SEED
+  return {
+    preferredSeconds: seed,
+    minimumSeconds:
+      endeavor.minimumDuration ?? endeavor.duration ?? observed ?? seed,
+    maximumSeconds:
+      endeavor.maximumDuration ?? endeavor.duration ?? observed ?? seed,
+    isPreferredEnabled: endeavor.duration !== null,
+    isMinimumEnabled: endeavor.minimumDuration !== null,
+    isMaximumEnabled: endeavor.maximumDuration !== null,
+  }
+}
+
+/** One bound's switch flipped. The draft number is untouched. */
+export const draftWithBoundToggled = (
+  draft: EndeavorDurationDraft,
+  bound: DurationBound,
+  isEnabled: boolean,
+): EndeavorDurationDraft => {
+  switch (bound) {
+    case DurationBound.minimum:
+      return { ...draft, isMinimumEnabled: isEnabled }
+    case DurationBound.maximum:
+      return { ...draft, isMaximumEnabled: isEnabled }
+    default:
+      return { ...draft, isPreferredEnabled: isEnabled }
+  }
+}
+
+/** One bound's number dialled. Its switch is untouched. */
+export const draftWithBoundAdjusted = (
+  draft: EndeavorDurationDraft,
+  bound: DurationBound,
+  seconds: TimeIntervalSeconds,
+): EndeavorDurationDraft => {
+  switch (bound) {
+    case DurationBound.minimum:
+      return { ...draft, minimumSeconds: seconds }
+    case DurationBound.maximum:
+      return { ...draft, maximumSeconds: seconds }
+    default:
+      return { ...draft, preferredSeconds: seconds }
+  }
+}
+
+/**
+ * The draft as the three nullable columns the domain stores: a disabled bound
+ * writes `null`, which is what "the user has authored no preference" means.
+ */
+export const durationProfileOf = (
+  draft: EndeavorDurationDraft,
+): {
+  readonly preferred: TimeIntervalSeconds | null
+  readonly minimum: TimeIntervalSeconds | null
+  readonly maximum: TimeIntervalSeconds | null
+} => ({
+  preferred: draft.isPreferredEnabled ? draft.preferredSeconds : null,
+  minimum: draft.isMinimumEnabled ? draft.minimumSeconds : null,
+  maximum: draft.isMaximumEnabled ? draft.maximumSeconds : null,
+})
+
+/**
+ * Canon's one validation rule: an enabled minimum above an enabled maximum.
+ * `null` when the profile is fine.
+ */
+export const durationValidationMessage = (
+  draft: EndeavorDurationDraft,
+): string | null =>
+  draft.isMinimumEnabled &&
+  draft.isMaximumEnabled &&
+  draft.minimumSeconds > draft.maximumSeconds
+    ? 'Minimum duration must not exceed maximum duration.'
+    : null
+
+/**
+ * The read-only "Observed focus time" card.
+ *
+ * `seconds` is `null` below the sample minimum — the card then says how many
+ * sessions are still needed rather than showing an average of one data point.
+ */
+export interface ObservedFocusTime {
+  /** The empirical average, or `null` while the sample is too small. */
+  readonly seconds: TimeIntervalSeconds | null
+  /** How many performances qualified — canon's `empiricalSampleCount`. */
+  readonly sampleCount: number
+  /** The minimum sample the recommendation unlocks at. */
+  readonly requiredSampleCount: number
+}
+
+/**
+ * Compute the observed focus time from the endeavor's performances.
+ *
+ * Both halves come from `@kro/core`: which performances qualify (whole
+ * sessions, non-zero, completed or finished — never an aborted attempt) and how
+ * they average. Recomputing either here would let the Duration surface and the
+ * session recommendation disagree about the same endeavor.
+ */
+export const observedFocusTime = (endeavor: Endeavor): ObservedFocusTime => ({
+  seconds: empiricalDuration(endeavor),
+  sampleCount: empiricalDurationPerformances(endeavor).length,
+  requiredSampleCount: EMPIRICAL_SAMPLE_MINIMUM,
+})

--- a/packages/app/src/features/endeavorDetail/EndeavorRelations.ts
+++ b/packages/app/src/features/endeavorDetail/EndeavorRelations.ts
@@ -1,0 +1,273 @@
+/**
+ * The four relation surfaces' data — the port of
+ * `EndeavorPerformancesFeature` / `EndeavorDefersFeature` /
+ * `EndeavorHostsFeature` / `EndeavorShadowsFeature` (their Selectors and their
+ * add-form state), plus the empty/read-only **copy discipline** their Views
+ * carry.
+ *
+ * ## The read-only rule states WHY, per relation
+ *
+ * Canon never disables an affordance silently. When a relation is not editable
+ * for the endeavor's kind, its screen replaces the add form with an info banner
+ * naming the reason — *"This endeavor's kind can't record sessions."* — and the
+ * empty state's message changes with it, because "log one below by hand" is a
+ * lie on a surface that has no form. Both strings live here, keyed by relation
+ * and by editability, so `#30` cannot invent a different reason and cannot omit
+ * one.
+ *
+ * The editability answer itself is never restated: it is
+ * `EndeavorFieldRelevance.isRelationEditable`, the same call the domain's
+ * guarded `with…` helpers make before refusing a mutation.
+ *
+ * ## Hosts have no web binding yet, and that is said out loud
+ *
+ * Attaching or detaching a host is a **provider** lifecycle call — canon routes
+ * it through `EndeavorMutationHostClient.attach`/`.detach`. This repo has no
+ * provider adapter (Apple Calendar and Apple Reminders are impossible on the
+ * web at all; Google Calendar arrives with `#33`), so every candidate reports
+ * `isAttachable: false` with a reason, and the reducer refuses the mutation with
+ * a typed exception instead of pretending it worked. Named here and in the PR
+ * body rather than quietly dropped.
+ */
+import {
+  type Defer,
+  type Endeavor,
+  type EndeavorHost,
+  type EndeavorKind,
+  EndeavorRelation,
+  type EndeavorTag,
+  type Perform,
+  type PerformResolution,
+  type Shadow,
+  type TimeIntervalSeconds,
+  assertNever,
+  endeavorHostDisplayName,
+  endeavorHosts,
+  isKroOwnedHost,
+  isRelationEditable,
+} from '@kro/core'
+
+/**
+ * Why a relation is read-only for this kind, or `null` when it is editable.
+ *
+ * Verbatim from each relation screen's info banner. The strings are canon's
+ * user-facing copy, so a reviewer can diff them against the Swift.
+ */
+export const relationReadOnlyReason = (
+  relation: EndeavorRelation,
+  kind: EndeavorKind,
+): string | null => {
+  if (isRelationEditable(relation, kind)) return null
+  switch (relation) {
+    case EndeavorRelation.performances:
+      return "This endeavor's kind can't record sessions."
+    case EndeavorRelation.defers:
+      return "This endeavor's kind can't record defers."
+    case EndeavorRelation.hosts:
+      return "This endeavor's kind can't change where it's mirrored."
+    case EndeavorRelation.shadows:
+      return "This endeavor's kind can't change its external mirrors."
+    default:
+      return assertNever(relation)
+  }
+}
+
+/** A relation list with nothing in it — canon's `EmptyStateCard` content. */
+export interface RelationEmptyState {
+  readonly title: string
+  readonly message: string
+}
+
+/**
+ * The empty state for one relation.
+ *
+ * The message depends on editability wherever canon's does: a read-only
+ * Performances list says sessions *will appear here*, an editable one invites
+ * the user to log one.
+ */
+export const relationEmptyState = (
+  relation: EndeavorRelation,
+  kind: EndeavorKind,
+): RelationEmptyState => {
+  const isEditable = isRelationEditable(relation, kind)
+  switch (relation) {
+    case EndeavorRelation.performances:
+      return {
+        title: 'No sessions yet',
+        message: isEditable
+          ? 'Start a session on this endeavor, or log one below by hand.'
+          : 'Sessions logged against this endeavor will appear here.',
+      }
+    case EndeavorRelation.defers:
+      return {
+        title: 'Never deferred',
+        message: 'This endeavor has kept every due date it was given.',
+      }
+    case EndeavorRelation.hosts:
+      return {
+        title: 'Not mirrored anywhere',
+        message: isEditable
+          ? 'Attach a provider below to keep this endeavor in sync outside Kro.'
+          : 'This endeavor lives only in Kro.',
+      }
+    case EndeavorRelation.shadows:
+      return {
+        title: 'No shadows yet',
+        message:
+          'A shadow appears when this endeavor is mirrored from a calendar, reminders list, or another source.',
+      }
+    default:
+      return assertNever(relation)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lists
+// ---------------------------------------------------------------------------
+
+/** Canon's `performancesSelector` — already a non-optional array. */
+export const performancesOf = (endeavor: Endeavor): readonly Perform[] =>
+  endeavor.performances
+
+/** Canon's `defersSelector`, in `defers` order — the audit history. */
+export const defersOf = (endeavor: Endeavor): readonly Defer[] =>
+  endeavor.defers
+
+/** Canon's `shadowsSelector` — `shadows` normalised to a non-optional array. */
+export const shadowsOf = (endeavor: Endeavor): readonly Shadow[] =>
+  endeavor.shadows ?? []
+
+/**
+ * Whether a host is an external provider. Kro's own two stores (`supabase`,
+ * `local`) have nothing to attach to, which is canon's `isExternal` inverted
+ * through the host taxonomy this repo already ships.
+ */
+export const isExternalHost = (host: EndeavorHost): boolean =>
+  !isKroOwnedHost(host)
+
+/** Canon's `attachedHostsSelector` — the external hosts this endeavor is on. */
+export const attachedHostsOf = (
+  endeavor: Endeavor,
+): readonly EndeavorHost[] => endeavor.hostedBy.filter(isExternalHost)
+
+/**
+ * One attach candidate, and whether this build can actually attach it.
+ *
+ * `isAttachable` is **false for every host today** — see the module note. The
+ * candidate is still listed, with its reason, because hiding it would make the
+ * gap invisible to the user and to the next reader.
+ */
+export interface HostAttachCandidate {
+  readonly host: EndeavorHost
+  readonly label: string
+  readonly isAttachable: boolean
+  /** Why not, when `isAttachable` is false. */
+  readonly unavailableReason: string | null
+}
+
+/** Why this build cannot attach a given provider. `null` once one is wired. */
+export const hostAdapterUnavailableReason = (
+  host: EndeavorHost,
+): string | null => {
+  switch (host) {
+    case 'appleCalendar':
+    case 'appleReminders':
+      return 'Apple Calendar and Reminders have no web equivalent.'
+    case 'googleCalendar':
+      return 'Google Calendar mirroring is not connected yet.'
+    case 'outlookCalendar':
+      return 'Outlook mirroring is off in this build.'
+    default:
+      return 'This provider has no web adapter yet.'
+  }
+}
+
+/** Canon's `availableHostsToAttachSelector`, each with its web availability. */
+export const hostAttachCandidatesOf = (
+  endeavor: Endeavor,
+): readonly HostAttachCandidate[] =>
+  endeavorHosts
+    .filter(
+      (host) => isExternalHost(host) && !endeavor.hostedBy.includes(host),
+    )
+    .map((host) => ({
+      host,
+      label: endeavorHostDisplayName(host),
+      isAttachable: false,
+      unavailableReason: hostAdapterUnavailableReason(host),
+    }))
+
+// ---------------------------------------------------------------------------
+// Add forms
+// ---------------------------------------------------------------------------
+
+/**
+ * The hand-logged performance form. Canon's `EndeavorPerformancesView` keeps
+ * these as view `@State`; `RC-4` forbids the `useState` equivalent, and the
+ * confirm has to read them from somewhere the Producer can also see, so they
+ * are feature state here.
+ */
+export interface PerformanceDraft {
+  readonly date: Date
+  readonly durationSeconds: TimeIntervalSeconds
+  readonly resolution: PerformResolution
+  readonly notes: string
+  readonly rewardPoints: number
+  /**
+   * Whether this was a whole focus session. A hand-logged entry says **true**
+   * only when the user says so: `empiricalDuration` counts only whole sessions,
+   * so defaulting it to `true` would let a typo teach the recommendation.
+   */
+  readonly wasCompletedInSession: boolean
+  /** The row being edited in place, or `null` when this is a new entry. */
+  readonly editingIndex: number | null
+}
+
+/** The defer form: where the endeavor is pushed to, and optionally why. */
+export interface DeferDraft {
+  readonly target: Date
+  readonly reason: string
+}
+
+/** The shadow form — the four identity columns a mirror is matched on. */
+export interface ShadowDraft {
+  readonly originalTitle: string
+  readonly sourceIdentifier: string
+  readonly source: string
+  readonly kind: EndeavorKind
+  readonly group: string
+}
+
+/** Whichever add form is open, or `null` when none is. */
+export type RelationDraft =
+  | { readonly relation: 'performances'; readonly draft: PerformanceDraft }
+  | { readonly relation: 'defers'; readonly draft: DeferDraft }
+  | { readonly relation: 'shadows'; readonly draft: ShadowDraft }
+  | { readonly relation: 'hosts'; readonly host: EndeavorHost | null }
+
+/**
+ * Whether the open form can be committed.
+ *
+ * Every relation has one rule, and each is the smallest thing that makes the
+ * row meaningful: a performance needs a positive duration, a shadow needs both
+ * halves of its identity, a host needs a selection. A defer always can — its
+ * target defaults to a real moment and its reason is optional by design.
+ */
+export const isRelationDraftCommittable = (draft: RelationDraft): boolean => {
+  switch (draft.relation) {
+    case 'performances':
+      return draft.draft.durationSeconds > 0
+    case 'defers':
+      return true
+    case 'shadows':
+      return (
+        draft.draft.originalTitle.trim().length > 0 &&
+        draft.draft.sourceIdentifier.trim().length > 0
+      )
+    default:
+      return draft.host !== null
+  }
+}
+
+/** The tags a `tagToggled` change can name — re-exported for the add forms. */
+export type { EndeavorTag }

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailCards.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailCards.test.ts
@@ -1,0 +1,194 @@
+/**
+ * The Detail read surface's grouped cards and its header derivations.
+ *
+ * Detail asks the matrix's **visibility** question where Edit asks its
+ * **editability** one; the two happen to agree in v1, and the cases below assert
+ * that Detail is asking its own question rather than borrowing Edit's answer.
+ */
+import {
+  EndeavorField,
+  EndeavorKind,
+  EndeavorRelation,
+  endeavorRelations,
+  isFieldVisible,
+  isRelationEditable,
+  makeEndeavor,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  detailDisplayTitle,
+  detailHeaderBadges,
+  relationCards,
+  visibleFieldsBySection,
+  visibleSections,
+} from '../EndeavorDetailCards'
+import { EndeavorDetailSection } from '../EndeavorDetailEditing'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+
+describe('the grouped cards follow the matrix’s visibility answer', () => {
+  it('shows every section for a task', () => {
+    expect(visibleSections(EndeavorKind.task).map((model) => model.section)).toEqual(
+      [
+        EndeavorDetailSection.core,
+        EndeavorDetailSection.enrichment,
+        EndeavorDetailSection.recurrence,
+      ],
+    )
+  })
+
+  it('hides `due` on a calendar event and keeps `start`', () => {
+    const core = visibleFieldsBySection(EndeavorKind.calendarEvent).find(
+      (model) => model.section === EndeavorDetailSection.core,
+    )
+    expect(core?.fields).not.toContain(EndeavorField.due)
+    expect(core?.fields).toContain(EndeavorField.start)
+  })
+
+  it('hides `start` and `duration` on a blueprint', () => {
+    const core = visibleFieldsBySection(EndeavorKind.blueprint).find(
+      (model) => model.section === EndeavorDetailSection.core,
+    )
+    expect(core?.fields).not.toContain(EndeavorField.start)
+    expect(core?.fields).not.toContain(EndeavorField.duration)
+  })
+
+  it('lists every section, empty ones included, so a caller can index them', () => {
+    expect(visibleFieldsBySection(EndeavorKind.habit)).toHaveLength(3)
+  })
+
+  it('never shows a field the domain says is invisible for the kind', () => {
+    for (const model of visibleFieldsBySection(EndeavorKind.habit)) {
+      for (const field of model.fields) {
+        expect(isFieldVisible(field, EndeavorKind.habit)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('the relation cards are always visible, and manageable per kind', () => {
+  it('shows all four relations for every kind', () => {
+    for (const endeavor of [
+      detailEndeavorMocks.task,
+      detailEndeavorMocks.event,
+      detailEndeavorMocks.blueprint,
+    ]) {
+      expect(relationCards(endeavor)).toHaveLength(endeavorRelations.length)
+      expect(relationCards(endeavor).every((card) => card.isVisible)).toBe(true)
+    }
+  })
+
+  it('marks performances unmanageable on a calendar event', () => {
+    const card = relationCards(detailEndeavorMocks.event).find(
+      (candidate) => candidate.relation === EndeavorRelation.performances,
+    )
+    expect(card?.isManageable).toBe(false)
+  })
+
+  it('marks hosts unmanageable on a habit', () => {
+    const card = relationCards(detailEndeavorMocks.habit).find(
+      (candidate) => candidate.relation === EndeavorRelation.hosts,
+    )
+    expect(card?.isManageable).toBe(false)
+  })
+
+  it('answers manageability from the domain matrix, never a local rule', () => {
+    for (const card of relationCards(detailEndeavorMocks.event)) {
+      expect(card.isManageable).toBe(
+        isRelationEditable(card.relation, detailEndeavorMocks.event.kind),
+      )
+    }
+  })
+
+  it('counts the entries each relation currently holds', () => {
+    const cards = relationCards(detailEndeavorMocks.taskWithSessions)
+    expect(
+      cards.find((card) => card.relation === EndeavorRelation.performances)
+        ?.count,
+    ).toBe(3)
+    expect(
+      cards.find((card) => card.relation === EndeavorRelation.defers)?.count,
+    ).toBe(0)
+  })
+
+  it('counts shadows and hosts on a mirrored endeavor', () => {
+    const cards = relationCards(detailEndeavorMocks.event)
+    expect(
+      cards.find((card) => card.relation === EndeavorRelation.shadows)?.count,
+    ).toBe(1)
+    expect(
+      cards.find((card) => card.relation === EndeavorRelation.hosts)?.count,
+    ).toBe(1)
+  })
+})
+
+describe('the header badges lead with kind, then status, then what is set', () => {
+  it('always leads with the kind chip', () => {
+    const [first] = detailHeaderBadges(detailEndeavorMocks.task)
+    expect(first?.kind).toBe('kind')
+  })
+
+  it('always carries the status chip second', () => {
+    const badges = detailHeaderBadges(detailEndeavorMocks.task)
+    expect(badges[1]?.kind).toBe('status')
+  })
+
+  it('adds a duration chip only when a duration is set', () => {
+    expect(
+      detailHeaderBadges(detailEndeavorMocks.task).some(
+        (badge) => badge.kind === 'duration',
+      ),
+    ).toBe(true)
+    expect(
+      detailHeaderBadges(detailEndeavorMocks.habit).some(
+        (badge) => badge.kind === 'duration',
+      ),
+    ).toBe(false)
+  })
+
+  it('adds a reward chip only for a positive point value', () => {
+    const zeroPoints = makeEndeavor({
+      id: 'zero',
+      title: 'zero',
+      kind: EndeavorKind.task,
+      sessionPoints: 0,
+    })
+    expect(
+      detailHeaderBadges(zeroPoints).some(
+        (badge) => badge.kind === 'rewardPoints',
+      ),
+    ).toBe(false)
+    expect(
+      detailHeaderBadges(detailEndeavorMocks.task).some(
+        (badge) => badge.kind === 'rewardPoints',
+      ),
+    ).toBe(true)
+  })
+
+  it('adds a repeats chip only for a recurring endeavor', () => {
+    expect(
+      detailHeaderBadges(detailEndeavorMocks.task).some(
+        (badge) => badge.kind === 'repeats',
+      ),
+    ).toBe(false)
+  })
+
+  it('keeps a sparse endeavor’s header to the two mandatory chips', () => {
+    expect(detailHeaderBadges(detailEndeavorMocks.blueprint)).toHaveLength(2)
+  })
+})
+
+describe('the display title never renders blank', () => {
+  it('trims a padded title', () => {
+    expect(
+      detailDisplayTitle({ ...detailEndeavorMocks.task, title: '  Slides  ' }),
+    ).toBe('Slides')
+  })
+
+  it('falls back to "Untitled" for a whitespace-only title', () => {
+    expect(detailDisplayTitle(detailEndeavorMocks.untitled)).toBe('Untitled')
+  })
+
+  it('passes a normal title straight through', () => {
+    expect(detailDisplayTitle(detailEndeavorMocks.event)).toBe('Team sync')
+  })
+})

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailEditing.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailEditing.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Acceptance criterion 3 — *"Edit refuses kind-irrelevant fields identically to
+ * the domain matrix (no UI-side divergence possible)."*
+ *
+ * Two kinds of case here, and the split is deliberate:
+ *
+ * 1. **One truth table**, written out per kind as literal expectations. It is
+ *    the only place canon's matrix is restated, so a change to
+ *    `EndeavorFieldRelevance` in `@kro/core` breaks **exactly this test** and
+ *    nothing else — which is what makes it a canon regression alarm rather than
+ *    noise.
+ * 2. **Everything else derives** from `isFieldEditable`, so no other assertion
+ *    can drift from the domain. The expressibility cases prove the stronger
+ *    half: a forbidden change is not merely rejected, it produces the identical
+ *    object — there is nothing for a UI to persist.
+ */
+import type { EndeavorKind } from '@kro/core'
+import {
+  EndeavorField,
+  EndeavorKind as Kind,
+  EndeavorStatus,
+  EndeavorTag,
+  endeavorFields,
+  endeavorKinds,
+  isFieldEditable,
+  makeProject,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  EndeavorDetailSection,
+  applyFieldChange,
+  editableFieldsBySection,
+  editableFieldsFor,
+  editableSections,
+  endeavorDetailSections,
+  endeavorsEqual,
+  fieldOfChange,
+  fieldsOfSection,
+  isChangeExpressible,
+  sectionTitle,
+} from '../EndeavorDetailEditing'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+
+/**
+ * Canon's table, per kind — the ONLY restatement of the matrix in this repo's
+ * app tier. Every other assertion below derives from `isFieldEditable`.
+ */
+const CANON_EDITABLE_FIELDS: Record<EndeavorKind, readonly string[]> = {
+  // No `start`, no `duration`, no `sessionPoints`: the three meta kinds are not
+  // pinned to a time block and earn no session points.
+  background: [
+    'title',
+    'status',
+    'due',
+    'value',
+    'effort',
+    'expiry',
+    'tags',
+    'associatedColor',
+    'project',
+    'repeatConfig',
+  ],
+  behavior: [
+    'title',
+    'status',
+    'due',
+    'value',
+    'effort',
+    'expiry',
+    'tags',
+    'associatedColor',
+    'project',
+    'repeatConfig',
+  ],
+  blueprint: [
+    'title',
+    'status',
+    'due',
+    'value',
+    'effort',
+    'expiry',
+    'tags',
+    'associatedColor',
+    'project',
+    'repeatConfig',
+  ],
+  // A calendar event is driven by start/duration and has no `due` at all, and
+  // no session points.
+  calendarEvent: [
+    'title',
+    'status',
+    'start',
+    'duration',
+    'value',
+    'effort',
+    'expiry',
+    'tags',
+    'associatedColor',
+    'project',
+    'repeatConfig',
+  ],
+  // A habit always applies "today", so it has no `due` either — but it is
+  // session-trackable.
+  habit: [
+    'title',
+    'status',
+    'start',
+    'duration',
+    'sessionPoints',
+    'value',
+    'effort',
+    'expiry',
+    'tags',
+    'associatedColor',
+    'project',
+    'repeatConfig',
+  ],
+  reminder: [
+    'title',
+    'status',
+    'due',
+    'start',
+    'duration',
+    'sessionPoints',
+    'value',
+    'effort',
+    'expiry',
+    'tags',
+    'associatedColor',
+    'project',
+    'repeatConfig',
+  ],
+  task: [
+    'title',
+    'status',
+    'due',
+    'start',
+    'duration',
+    'sessionPoints',
+    'value',
+    'effort',
+    'expiry',
+    'tags',
+    'associatedColor',
+    'project',
+    'repeatConfig',
+  ],
+}
+
+describe('the kind × field editability truth table matches canon', () => {
+  for (const kind of endeavorKinds) {
+    it(`offers exactly canon's editable field set for a ${kind}`, () => {
+      expect(editableFieldsFor(kind)).toEqual(CANON_EDITABLE_FIELDS[kind])
+    })
+  }
+
+  it('never offers a field the domain matrix refuses, for any kind', () => {
+    for (const kind of endeavorKinds) {
+      for (const field of editableFieldsFor(kind)) {
+        expect(isFieldEditable(field, kind)).toBe(true)
+      }
+    }
+  })
+
+  it('never omits a field the domain matrix allows, for any kind', () => {
+    for (const kind of endeavorKinds) {
+      const offered = new Set(editableFieldsFor(kind))
+      for (const field of endeavorFields) {
+        if (isFieldEditable(field, kind)) expect(offered.has(field)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('a forbidden edit cannot be EXPRESSED, not merely rejected', () => {
+  const event = detailEndeavorMocks.event
+  const habit = detailEndeavorMocks.habit
+  const blueprint = detailEndeavorMocks.blueprint
+
+  it('returns the identical object when a calendar event is given a due date', () => {
+    const attempted = applyFieldChange(event, {
+      field: 'due',
+      value: new Date(2026, 5, 20, 9, 0, 0),
+    })
+    expect(attempted).toBe(event)
+  })
+
+  it('returns the identical object when a habit is given a due date', () => {
+    expect(
+      applyFieldChange(habit, { field: 'due', value: new Date() }),
+    ).toBe(habit)
+  })
+
+  it('returns the identical object when a blueprint is given a duration', () => {
+    expect(applyFieldChange(blueprint, { field: 'duration', value: 1800 })).toBe(
+      blueprint,
+    )
+  })
+
+  it('refuses session points on a calendar event', () => {
+    expect(
+      applyFieldChange(event, { field: 'sessionPoints', value: 5 }),
+    ).toBe(event)
+  })
+
+  it('refuses the whole duration profile on a blueprint', () => {
+    expect(
+      applyFieldChange(blueprint, {
+        field: 'durationProfile',
+        preferred: 1500,
+        minimum: 600,
+        maximum: 3600,
+      }),
+    ).toBe(blueprint)
+  })
+
+  it('answers the same question ahead of time, so a control can be disabled', () => {
+    expect(isChangeExpressible({ field: 'due', value: null }, Kind.habit)).toBe(
+      false,
+    )
+    expect(isChangeExpressible({ field: 'due', value: null }, Kind.task)).toBe(
+      true,
+    )
+  })
+})
+
+describe('an allowed edit lands on the working copy', () => {
+  const task = detailEndeavorMocks.task
+
+  it('renames a task', () => {
+    expect(
+      applyFieldChange(task, { field: 'title', value: 'Prepare the deck' }).title,
+    ).toBe('Prepare the deck')
+  })
+
+  it('moves a task’s status', () => {
+    expect(
+      applyFieldChange(task, { field: 'status', value: EndeavorStatus.blocked })
+        .status,
+    ).toBe(EndeavorStatus.blocked)
+  })
+
+  it('writes the three duration bounds together', () => {
+    const updated = applyFieldChange(task, {
+      field: 'durationProfile',
+      preferred: 1500,
+      minimum: 600,
+      maximum: 3600,
+    })
+    expect(updated.duration).toBe(1500)
+    expect(updated.minimumDuration).toBe(600)
+    expect(updated.maximumDuration).toBe(3600)
+  })
+
+  it('adds a tag, then removes it — normalising the empty result back to null', () => {
+    const tagged = applyFieldChange(task, {
+      field: 'tagToggled',
+      value: EndeavorTag.session,
+    })
+    expect(tagged.tags).toEqual([EndeavorTag.session])
+    const untagged = applyFieldChange(tagged, {
+      field: 'tagToggled',
+      value: EndeavorTag.session,
+    })
+    // `[]` would rewrite the server's NULL column to '{}' — canon normalises.
+    expect(untagged.tags).toBeNull()
+  })
+
+  it('moves `list` and `projectId` together, as one user-facing assignment', () => {
+    const project = makeProject({ id: 'p-1', title: 'Launch' })
+    const assigned = applyFieldChange(task, { field: 'project', value: project })
+    expect(assigned.projectId).toBe('p-1')
+    expect(assigned.list?.id).toBe('p-1')
+
+    const cleared = applyFieldChange(assigned, { field: 'project', value: null })
+    expect(cleared.projectId).toBeNull()
+    expect(cleared.list).toBeNull()
+  })
+
+  it('clears an optional enrichment field', () => {
+    expect(applyFieldChange(task, { field: 'value', value: null }).value).toBeNull()
+  })
+})
+
+describe('endeavorsEqual compares by value, as canon’s struct equality does', () => {
+  const task = detailEndeavorMocks.task
+
+  it('treats a structurally identical copy as equal', () => {
+    expect(endeavorsEqual(task, { ...task })).toBe(true)
+  })
+
+  it('sees through a Date rebuilt from the same instant', () => {
+    const rebuilt = {
+      ...task,
+      due: task.due === null ? null : new Date(task.due.getTime()),
+    }
+    expect(endeavorsEqual(task, rebuilt)).toBe(true)
+  })
+
+  it('reports a real edit as different', () => {
+    expect(
+      endeavorsEqual(task, applyFieldChange(task, { field: 'title', value: 'x' })),
+    ).toBe(false)
+  })
+
+  it('reports a changed relation array as different', () => {
+    expect(endeavorsEqual(task, detailEndeavorMocks.taskWithSessions)).toBe(false)
+  })
+})
+
+describe('fieldOfChange keeps one vocabulary for the question and the change', () => {
+  it('maps the duration profile onto the `duration` matrix field', () => {
+    expect(
+      fieldOfChange({
+        field: 'durationProfile',
+        preferred: null,
+        minimum: null,
+        maximum: null,
+      }),
+    ).toBe(EndeavorField.duration)
+  })
+
+  it('maps a tag toggle onto the `tags` matrix field', () => {
+    expect(fieldOfChange({ field: 'tagToggled', value: EndeavorTag.session })).toBe(
+      EndeavorField.tags,
+    )
+  })
+
+  it('maps every other change onto its own field', () => {
+    expect(fieldOfChange({ field: 'title', value: 'x' })).toBe(
+      EndeavorField.title,
+    )
+    expect(fieldOfChange({ field: 'expiry', value: null })).toBe(
+      EndeavorField.expiry,
+    )
+  })
+})
+
+describe('sections group the editable fields for rendering', () => {
+  it('keeps canon’s three sections in display order', () => {
+    expect(endeavorDetailSections).toEqual([
+      EndeavorDetailSection.core,
+      EndeavorDetailSection.enrichment,
+      EndeavorDetailSection.recurrence,
+    ])
+    expect(sectionTitle(EndeavorDetailSection.enrichment)).toBe('Enrichment')
+  })
+
+  it('lists every section, empty ones included, so a caller can index them', () => {
+    const models = editableFieldsBySection(Kind.blueprint)
+    expect(models).toHaveLength(3)
+    expect(models.map((model) => model.section)).toEqual(endeavorDetailSections)
+  })
+
+  it('omits an empty section from the ones worth a header', () => {
+    const sections = editableSections(Kind.task).map((model) => model.section)
+    expect(sections).toEqual(endeavorDetailSections)
+  })
+
+  it('drops a matrix-refused field out of its section', () => {
+    const core = editableFieldsBySection(Kind.calendarEvent).find(
+      (model) => model.section === EndeavorDetailSection.core,
+    )
+    expect(core?.fields).not.toContain(EndeavorField.due)
+    expect(core?.fields).toContain(EndeavorField.start)
+  })
+
+  it('narrows to a single row when Edit was opened from one Detail field', () => {
+    const sections = editableSections(Kind.task, EndeavorField.title)
+    expect(sections).toHaveLength(1)
+    expect(sections[0]?.fields).toEqual([EndeavorField.title])
+  })
+
+  it('keeps every field of a section in canon’s declared display order', () => {
+    expect(fieldsOfSection(EndeavorDetailSection.core)).toEqual([
+      EndeavorField.title,
+      EndeavorField.status,
+      EndeavorField.due,
+      EndeavorField.start,
+      EndeavorField.duration,
+      EndeavorField.sessionPoints,
+    ])
+  })
+})

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailException.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailException.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The typed failure union. Each case is asserted on its `kind` and its
+ * `recoverable` flag — the two a surface branches on (`RC-8`).
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  EndeavorDetailExceptions,
+  detailExceptionMessage,
+} from '../EndeavorDetailException'
+
+describe('EndeavorDetailExceptions says whether a retry can help', () => {
+  it('marks a failed local save retryable — nothing was written', () => {
+    const exception = EndeavorDetailExceptions.localPersistenceFailed('disk full')
+    expect(exception.kind).toBe('localPersistenceFailed')
+    expect(exception.recoverable).toBe(true)
+    expect(exception.message).toContain('disk full')
+  })
+
+  it('marks a failed relation write retryable', () => {
+    expect(
+      EndeavorDetailExceptions.relationSyncFailed('quota').recoverable,
+    ).toBe(true)
+  })
+
+  it('marks a missing provider adapter NOT retryable — the build cannot do it', () => {
+    const exception = EndeavorDetailExceptions.hostAdapterUnavailable(
+      'Google Calendar mirroring is not connected yet.',
+    )
+    expect(exception.kind).toBe('hostAdapterUnavailable')
+    expect(exception.recoverable).toBe(false)
+  })
+
+  it('marks a vanished endeavor NOT retryable — the lookup would miss again', () => {
+    const exception = EndeavorDetailExceptions.endeavorNotFound('ghost')
+    expect(exception.recoverable).toBe(false)
+    expect(exception.message).toContain('ghost')
+  })
+
+  it('carries the defensive fallback for a thunk that genuinely threw', () => {
+    expect(EndeavorDetailExceptions.unknown('boom').kind).toBe('unknown')
+  })
+})
+
+describe('detailExceptionMessage narrows whatever was thrown', () => {
+  it('uses an Error’s own message', () => {
+    expect(detailExceptionMessage(new Error('disk full'))).toBe('disk full')
+  })
+
+  it('stringifies a thrown non-Error', () => {
+    expect(detailExceptionMessage(42)).toBe('42')
+  })
+
+  it('survives a thrown undefined without crashing the failure path', () => {
+    expect(detailExceptionMessage(undefined)).toBe('undefined')
+  })
+})

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailFeature.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailFeature.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Reducer arms: the sync ones called directly against the slice's reducer
+ * (`RC-12`), the thunk lifecycles driven through the real thunks against a
+ * stubbed `LocalStore` (`RC-54`).
+ *
+ * The save/dismiss dirty-tracking cases are the ones the issue names: a save
+ * resets the baseline, a dismiss discards the working copy without touching the
+ * presented endeavor, and a failed save leaves the edit dirty for a retry.
+ */
+import type { Endeavor, EndeavorRecord } from '@kro/core'
+import {
+  EndeavorField,
+  EndeavorHost,
+  EndeavorRelation,
+  EndeavorStatus,
+  PerformResolution,
+  endeavorRecordFromEndeavor,
+  makePerform,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { makeStore } from '../../../library/store'
+import { stubbedGreetingService } from '../../../services/greeting/GreetingService'
+import { makeInMemoryLocalStore } from '../../../services/localStore/InMemoryLocalStore'
+import {
+  endeavorDetailSlice,
+  initialEndeavorDetailState,
+  onDetailRequested,
+  onEditRequested,
+  userDidAdjustDurationBound,
+  userDidChangeField,
+  userDidChangeRelationDraft,
+  userDidDismissDestination,
+  userDidTapDismiss,
+  userDidTapField,
+  userDidTapManageRelation,
+  userDidToggleDurationBound,
+} from '../EndeavorDetailFeature'
+import {
+  DETAIL_REFERENCE_NOW,
+  allDetailEndeavorMocks,
+  detailEndeavorMocks,
+  detailStateMocks,
+} from '../EndeavorDetailMocks'
+import {
+  addPerformanceThunk,
+  attachHostThunk,
+  saveEndeavorThunk,
+} from '../EndeavorDetailProducer'
+import { DurationBound } from '../EndeavorDuration'
+import { selectIsEditDirty, selectIsSaveEnabled } from '../EndeavorDetailSelectors'
+
+const reducer = endeavorDetailSlice.reducer
+
+const recordsOf = (
+  endeavors: readonly Endeavor[] = allDetailEndeavorMocks,
+): readonly EndeavorRecord[] =>
+  endeavors.map((endeavor) =>
+    endeavorRecordFromEndeavor(endeavor, { now: DETAIL_REFERENCE_NOW }),
+  )
+
+const storeWith = (records: readonly EndeavorRecord[] = recordsOf()) =>
+  makeStore({
+    greetingService: stubbedGreetingService,
+    localStore: makeInMemoryLocalStore({ endeavors: records }),
+  })
+
+describe('onDetailRequested — another surface hands an endeavor over', () => {
+  it('presents it, with no editor open', () => {
+    const next = reducer(
+      initialEndeavorDetailState,
+      onDetailRequested({ endeavor: detailEndeavorMocks.task }),
+    )
+    expect(next.endeavor).toBe(detailEndeavorMocks.task)
+    expect(next.destination).toBeNull()
+  })
+
+  it('replaces a previous endeavor rather than layering on it', () => {
+    const next = reducer(
+      detailStateMocks.editingDirty,
+      onDetailRequested({ endeavor: detailEndeavorMocks.event }),
+    )
+    expect(next.endeavor).toBe(detailEndeavorMocks.event)
+    expect(next.edit).toBeNull()
+  })
+
+  it('opens the editor directly when that is what was asked for', () => {
+    const next = reducer(
+      initialEndeavorDetailState,
+      onEditRequested({ endeavor: detailEndeavorMocks.task }),
+    )
+    expect(next.destination).toEqual({ kind: 'edit', focusedField: null })
+  })
+})
+
+describe('userDidTapField routes by field, and refuses what the matrix does', () => {
+  it('opens Edit focused on the tapped row', () => {
+    const next = reducer(
+      detailStateMocks.presentedTask,
+      userDidTapField({ field: EndeavorField.status }),
+    )
+    expect(next.destination).toEqual({ kind: 'edit', focusedField: 'status' })
+  })
+
+  it('routes `duration` to the Duration profile', () => {
+    const next = reducer(
+      detailStateMocks.presentedTask,
+      userDidTapField({ field: EndeavorField.duration }),
+    )
+    expect(next.destination).toEqual({ kind: 'duration' })
+  })
+
+  it('opens nothing for a field the kind cannot have', () => {
+    const next = reducer(
+      detailStateMocks.presentedEvent,
+      userDidTapField({ field: EndeavorField.due }),
+    )
+    expect(next.destination).toBeNull()
+  })
+})
+
+describe('userDidTapManageRelation obeys the same matrix', () => {
+  it('opens a relation a task can manage', () => {
+    const next = reducer(
+      detailStateMocks.presentedTask,
+      userDidTapManageRelation({ relation: EndeavorRelation.defers }),
+    )
+    expect(next.destination).toEqual({
+      kind: 'relation',
+      relation: EndeavorRelation.defers,
+    })
+  })
+
+  it('refuses one a calendar event cannot', () => {
+    const next = reducer(
+      detailStateMocks.presentedEvent,
+      userDidTapManageRelation({ relation: EndeavorRelation.performances }),
+    )
+    expect(next.destination).toBeNull()
+  })
+
+  it('refuses hosts on a habit', () => {
+    const next = reducer(
+      detailStateMocks.presentedHabit,
+      userDidTapManageRelation({ relation: EndeavorRelation.hosts }),
+    )
+    expect(next.destination).toBeNull()
+  })
+})
+
+describe('dirty tracking, save and dismiss', () => {
+  const rootOf = (state: ReturnType<typeof reducer>) =>
+    ({
+      ...storeWith().getState(),
+      endeavorDetail: state,
+    }) as ReturnType<ReturnType<typeof storeWith>['getState']>
+
+  it('reads clean the moment the editor opens', () => {
+    expect(selectIsEditDirty(rootOf(detailStateMocks.editingTask))).toBe(false)
+    expect(selectIsSaveEnabled(rootOf(detailStateMocks.editingTask))).toBe(false)
+  })
+
+  it('reads dirty after a real edit, and enables Save', () => {
+    const edited = reducer(
+      detailStateMocks.editingTask,
+      userDidChangeField({
+        change: { field: 'title', value: 'Prepare the deck' },
+      }),
+    )
+    expect(selectIsEditDirty(rootOf(edited))).toBe(true)
+    expect(selectIsSaveEnabled(rootOf(edited))).toBe(true)
+  })
+
+  it('stays CLEAN after an edit the matrix refused — nothing changed', () => {
+    const editingEvent = reducer(
+      detailStateMocks.presentedEvent,
+      onEditRequested({}),
+    )
+    const attempted = reducer(
+      editingEvent,
+      userDidChangeField({ change: { field: 'due', value: new Date() } }),
+    )
+    expect(selectIsEditDirty(rootOf(attempted))).toBe(false)
+    expect(selectIsSaveEnabled(rootOf(attempted))).toBe(false)
+  })
+
+  it('refuses Save on a blank title, however dirty the form is', () => {
+    expect(selectIsSaveEnabled(rootOf(detailStateMocks.editingInvalid))).toBe(
+      false,
+    )
+  })
+
+  it('resets the baseline once the save lands, so Save goes quiet again', async () => {
+    const store = storeWith()
+    store.dispatch(onEditRequested({ endeavor: detailEndeavorMocks.task }))
+    store.dispatch(
+      userDidChangeField({
+        change: { field: 'title', value: 'Prepare the deck' },
+      }),
+    )
+    expect(selectIsEditDirty(store.getState())).toBe(true)
+
+    const working = store.getState().endeavorDetail.edit?.working
+    if (working === undefined) throw new Error('expected an open editor')
+    await store.dispatch(
+      saveEndeavorThunk({ endeavor: working, now: DETAIL_REFERENCE_NOW }),
+    )
+
+    expect(selectIsEditDirty(store.getState())).toBe(false)
+    expect(store.getState().endeavorDetail.endeavor?.title).toBe(
+      'Prepare the deck',
+    )
+  })
+
+  it('leaves the edit dirty when the save failed — nothing was persisted', async () => {
+    const base = makeInMemoryLocalStore({ endeavors: recordsOf() })
+    const store = makeStore({
+      greetingService: stubbedGreetingService,
+      localStore: {
+        ...base,
+        endeavors: {
+          ...base.endeavors,
+          put: async () => {
+            throw new Error('disk full')
+          },
+        },
+      },
+    })
+    store.dispatch(onEditRequested({ endeavor: detailEndeavorMocks.task }))
+    store.dispatch(
+      userDidChangeField({ change: { field: 'title', value: 'Renamed' } }),
+    )
+    const working = store.getState().endeavorDetail.edit?.working
+    if (working === undefined) throw new Error('expected an open editor')
+    await store.dispatch(
+      saveEndeavorThunk({ endeavor: working, now: DETAIL_REFERENCE_NOW }),
+    )
+
+    expect(selectIsEditDirty(store.getState())).toBe(true)
+    expect(store.getState().endeavorDetail.save.kind).toBe('failed')
+  })
+
+  it('discards the working copy on dismiss, leaving the presented row alone', () => {
+    const edited = reducer(
+      detailStateMocks.editingTask,
+      userDidChangeField({ change: { field: 'title', value: 'Discarded' } }),
+    )
+    const dismissed = reducer(edited, userDidDismissDestination())
+    expect(dismissed.edit).toBeNull()
+    expect(dismissed.endeavor?.title).toBe(detailEndeavorMocks.task.title)
+  })
+
+  it('closes the whole surface on the Done affordance', () => {
+    expect(reducer(detailStateMocks.editingDirty, userDidTapDismiss())).toEqual(
+      initialEndeavorDetailState,
+    )
+  })
+})
+
+describe('the duration bounds edit through the same working copy', () => {
+  it('writes an enabled bound onto the working copy', () => {
+    const next = reducer(
+      detailStateMocks.durationOpen,
+      userDidToggleDurationBound({
+        bound: DurationBound.preferred,
+        isEnabled: true,
+      }),
+    )
+    expect(next.edit?.working.duration).toBe(next.duration?.preferredSeconds)
+  })
+
+  it('carries a dialled number through', () => {
+    const enabled = reducer(
+      detailStateMocks.durationOpen,
+      userDidToggleDurationBound({
+        bound: DurationBound.maximum,
+        isEnabled: true,
+      }),
+    )
+    const dialled = reducer(
+      enabled,
+      userDidAdjustDurationBound({
+        bound: DurationBound.maximum,
+        seconds: 3600,
+      }),
+    )
+    expect(dialled.edit?.working.maximumDuration).toBe(3600)
+  })
+
+  it('is a no-op when the Duration profile is not open', () => {
+    const next = reducer(
+      detailStateMocks.editingTask,
+      userDidAdjustDurationBound({
+        bound: DurationBound.preferred,
+        seconds: 900,
+      }),
+    )
+    expect(next.edit?.working.duration).toBe(detailEndeavorMocks.task.duration)
+  })
+})
+
+describe('the relation add form is gated by the same matrix', () => {
+  it('opens a form for a relation this kind can manage', () => {
+    const next = reducer(
+      detailStateMocks.performancesOpen,
+      userDidChangeRelationDraft({
+        draft: {
+          relation: 'performances',
+          draft: {
+            date: DETAIL_REFERENCE_NOW,
+            durationSeconds: 1500,
+            resolution: PerformResolution.finished,
+            notes: '',
+            rewardPoints: 0,
+            wasCompletedInSession: true,
+            editingIndex: null,
+          },
+        },
+      }),
+    )
+    expect(next.relationDraft?.relation).toBe('performances')
+  })
+
+  it('refuses to open one the kind cannot manage', () => {
+    const next = reducer(
+      detailStateMocks.performancesReadOnly,
+      userDidChangeRelationDraft({
+        draft: {
+          relation: 'performances',
+          draft: {
+            date: DETAIL_REFERENCE_NOW,
+            durationSeconds: 1500,
+            resolution: PerformResolution.finished,
+            notes: '',
+            rewardPoints: 0,
+            wasCompletedInSession: true,
+            editingIndex: null,
+          },
+        },
+      }),
+    )
+    expect(next.relationDraft).toBeNull()
+  })
+
+  it('always allows cancelling, whatever the kind', () => {
+    const next = reducer(
+      detailStateMocks.performancesReadOnly,
+      userDidChangeRelationDraft({ draft: null }),
+    )
+    expect(next.relationDraft).toBeNull()
+  })
+})
+
+describe('the relation write lifecycle', () => {
+  it('refreshes Detail’s own copy on success', async () => {
+    const store = storeWith()
+    store.dispatch(onDetailRequested({ endeavor: detailEndeavorMocks.task }))
+    await store.dispatch(
+      addPerformanceThunk({
+        endeavorId: detailEndeavorMocks.task.id,
+        performance: makePerform({
+          date: DETAIL_REFERENCE_NOW,
+          duration: 1500,
+          resolution: PerformResolution.finished,
+          wasCompletedInSession: true,
+        }),
+        now: DETAIL_REFERENCE_NOW,
+      }),
+    )
+    expect(store.getState().endeavorDetail.endeavor?.performances).toHaveLength(
+      1,
+    )
+    expect(store.getState().endeavorDetail.save).toEqual({ kind: 'idle' })
+  })
+
+  it('surfaces the host refusal as a typed failure the user can read', async () => {
+    const store = storeWith()
+    store.dispatch(onDetailRequested({ endeavor: detailEndeavorMocks.task }))
+    await store.dispatch(
+      attachHostThunk({
+        endeavorId: detailEndeavorMocks.task.id,
+        host: EndeavorHost.googleCalendar,
+      }),
+    )
+    const { save } = store.getState().endeavorDetail
+    expect(save.kind).toBe('failed')
+    if (save.kind === 'failed') {
+      expect(save.exception.kind).toBe('hostAdapterUnavailable')
+    }
+  })
+
+  it('raises the saving lifecycle while a relation write is in flight', () => {
+    const pending = addPerformanceThunk.pending('req', {
+      endeavorId: detailEndeavorMocks.task.id,
+      performance: makePerform({
+        date: DETAIL_REFERENCE_NOW,
+        duration: 1500,
+        resolution: PerformResolution.finished,
+      }),
+      now: DETAIL_REFERENCE_NOW,
+    })
+    expect(reducer(detailStateMocks.performancesOpen, pending).save).toEqual({
+      kind: 'saving',
+    })
+  })
+
+  it('stays quiet when a write is aborted — the one silent exit', () => {
+    const rejected = {
+      ...addPerformanceThunk.rejected(new Error('aborted'), 'req', {
+        endeavorId: detailEndeavorMocks.task.id,
+        performance: makePerform({
+          date: DETAIL_REFERENCE_NOW,
+          duration: 1500,
+          resolution: PerformResolution.finished,
+        }),
+        now: DETAIL_REFERENCE_NOW,
+      }),
+      meta: {
+        arg: {
+          endeavorId: detailEndeavorMocks.task.id,
+          performance: makePerform({
+            date: DETAIL_REFERENCE_NOW,
+            duration: 1500,
+            resolution: PerformResolution.finished,
+          }),
+          now: DETAIL_REFERENCE_NOW,
+        },
+        requestId: 'req',
+        requestStatus: 'rejected' as const,
+        aborted: true,
+        condition: false,
+        rejectedWithValue: false,
+      },
+    }
+    expect(reducer(detailStateMocks.saving, rejected).save).toEqual({
+      kind: 'saving',
+    })
+  })
+})
+
+describe('the save lifecycle’s own arms', () => {
+  it('raises saving on .pending', () => {
+    const pending = saveEndeavorThunk.pending('req', {
+      endeavor: detailEndeavorMocks.task,
+      now: DETAIL_REFERENCE_NOW,
+    })
+    expect(reducer(detailStateMocks.editingDirty, pending).save).toEqual({
+      kind: 'saving',
+    })
+  })
+
+  it('records the exception on a defensive .rejected', () => {
+    const rejected = {
+      ...saveEndeavorThunk.rejected(new Error('boom'), 'req', {
+        endeavor: detailEndeavorMocks.task,
+        now: DETAIL_REFERENCE_NOW,
+      }),
+      meta: {
+        arg: {
+          endeavor: detailEndeavorMocks.task,
+          now: DETAIL_REFERENCE_NOW,
+        },
+        requestId: 'req',
+        requestStatus: 'rejected' as const,
+        aborted: false,
+        condition: false,
+        rejectedWithValue: false,
+      },
+    }
+    const next = reducer(detailStateMocks.editingDirty, rejected)
+    expect(next.save.kind).toBe('failed')
+    if (next.save.kind === 'failed') {
+      expect(next.save.exception.kind).toBe('unknown')
+    }
+  })
+
+  it('leaves a status edit on the presented row once it lands', async () => {
+    const store = storeWith()
+    store.dispatch(onEditRequested({ endeavor: detailEndeavorMocks.task }))
+    store.dispatch(
+      userDidChangeField({
+        change: { field: 'status', value: EndeavorStatus.blocked },
+      }),
+    )
+    const working = store.getState().endeavorDetail.edit?.working
+    if (working === undefined) throw new Error('expected an open editor')
+    await store.dispatch(
+      saveEndeavorThunk({ endeavor: working, now: DETAIL_REFERENCE_NOW }),
+    )
+    expect(store.getState().endeavorDetail.endeavor?.status).toBe(
+      EndeavorStatus.blocked,
+    )
+  })
+})

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailFeature.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailFeature.test.ts
@@ -130,20 +130,26 @@ describe('userDidTapManageRelation obeys the same matrix', () => {
     })
   })
 
-  it('refuses one a calendar event cannot', () => {
+  it('opens a read-only relation a calendar event cannot edit', () => {
     const next = reducer(
       detailStateMocks.presentedEvent,
       userDidTapManageRelation({ relation: EndeavorRelation.performances }),
     )
-    expect(next.destination).toBeNull()
+    expect(next.destination).toEqual({
+      kind: 'relation',
+      relation: EndeavorRelation.performances,
+    })
   })
 
-  it('refuses hosts on a habit', () => {
+  it('opens hosts read-only on a habit — the draft path still refuses', () => {
     const next = reducer(
       detailStateMocks.presentedHabit,
       userDidTapManageRelation({ relation: EndeavorRelation.hosts }),
     )
-    expect(next.destination).toBeNull()
+    expect(next.destination).toEqual({
+      kind: 'relation',
+      relation: EndeavorRelation.hosts,
+    })
   })
 })
 

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailMocks.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailMocks.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The fixtures themselves.
+ *
+ * The matrix suite is only as good as the kinds it runs against, so the spread
+ * this file claims — task, calendar event, habit, blueprint — is asserted here
+ * rather than assumed.
+ */
+import { EndeavorKind, EndeavorStatus } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  DETAIL_REFERENCE_NOW,
+  allDetailEndeavorMocks,
+  detailEndeavorMocks,
+  detailStateMocks,
+} from '../EndeavorDetailMocks'
+
+describe('the endeavor fixtures span the kinds the matrix distinguishes', () => {
+  it('is built from a fixed instant, so nothing depends on when the suite runs', () => {
+    expect(DETAIL_REFERENCE_NOW.getFullYear()).toBe(2026)
+  })
+
+  it('covers a task, a calendar event, a habit and a blueprint', () => {
+    const kinds = new Set(allDetailEndeavorMocks.map((row) => row.kind))
+    expect(kinds).toContain(EndeavorKind.task)
+    expect(kinds).toContain(EndeavorKind.calendarEvent)
+    expect(kinds).toContain(EndeavorKind.habit)
+    expect(kinds).toContain(EndeavorKind.blueprint)
+  })
+
+  it('carries exactly the empirical sample minimum on the sessions fixture', () => {
+    expect(detailEndeavorMocks.taskWithSessions.performances).toHaveLength(3)
+  })
+
+  it('carries one short of it on the locked fixture', () => {
+    expect(detailEndeavorMocks.taskWithOneSession.performances).toHaveLength(1)
+  })
+
+  it('includes a mirrored endeavor, so the shadows list has something in it', () => {
+    expect(detailEndeavorMocks.event.shadows).toHaveLength(1)
+  })
+
+  it('includes a blank-titled row, so the one validation rule has a failing case', () => {
+    expect(detailEndeavorMocks.untitled.title.trim()).toBe('')
+  })
+
+  it('gives every fixture a distinct id', () => {
+    const ids = allDetailEndeavorMocks.map((row) => row.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe('the state variants describe real situations', () => {
+  it('has a closed variant that presents nothing', () => {
+    expect(detailStateMocks.closed.endeavor).toBeNull()
+  })
+
+  it('has a clean editor and a dirty one', () => {
+    expect(detailStateMocks.editingTask.edit?.working).toBe(
+      detailStateMocks.editingTask.edit?.original,
+    )
+    expect(detailStateMocks.editingDirty.edit?.working).not.toBe(
+      detailStateMocks.editingDirty.edit?.original,
+    )
+  })
+
+  it('has an invalid variant whose working title is blank', () => {
+    expect(detailStateMocks.editingInvalid.edit?.working.title).toBe('')
+  })
+
+  it('has a failed save that kept the user’s edit', () => {
+    expect(detailStateMocks.saveFailed.save.kind).toBe('failed')
+    expect(detailStateMocks.saveFailed.edit?.working.title).toBe(
+      'Prepare the deck',
+    )
+  })
+
+  it('has an editable and a read-only relation variant', () => {
+    expect(detailStateMocks.performancesOpen.endeavor?.kind).toBe(
+      EndeavorKind.task,
+    )
+    expect(detailStateMocks.performancesReadOnly.endeavor?.kind).toBe(
+      EndeavorKind.calendarEvent,
+    )
+  })
+
+  it('keeps the presented endeavor’s status intact across the variants', () => {
+    expect(detailStateMocks.presentedTask.endeavor?.status).toBe(
+      EndeavorStatus.pending,
+    )
+  })
+})

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailProducer.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailProducer.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Producers are dispatched for real against a stubbed `LocalStore` injected
+ * through `ThunkExtra` (`RC-54`, `RC-35`). The assertions are on the resolved
+ * `Result` and on what actually reached the store.
+ */
+import type { Endeavor, EndeavorRecord } from '@kro/core'
+import {
+  EndeavorHost,
+  EndeavorKind,
+  PerformResolution,
+  endeavorRecordFromEndeavor,
+  makeDefer,
+  makePerform,
+  makeShadow,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { makeStore } from '../../../library/store'
+import { stubbedGreetingService } from '../../../services/greeting/GreetingService'
+import { makeInMemoryLocalStore } from '../../../services/localStore/InMemoryLocalStore'
+import {
+  DETAIL_REFERENCE_NOW,
+  allDetailEndeavorMocks,
+  detailEndeavorMocks,
+} from '../EndeavorDetailMocks'
+import {
+  addDeferThunk,
+  addPerformanceThunk,
+  addShadowThunk,
+  attachHostThunk,
+  detachHostThunk,
+  removeDeferThunk,
+  removePerformanceThunk,
+  removeShadowThunk,
+  saveEndeavorThunk,
+} from '../EndeavorDetailProducer'
+
+const recordsOf = (
+  endeavors: readonly Endeavor[] = allDetailEndeavorMocks,
+): readonly EndeavorRecord[] =>
+  endeavors.map((endeavor) =>
+    endeavorRecordFromEndeavor(endeavor, { now: DETAIL_REFERENCE_NOW }),
+  )
+
+const storeWith = (records: readonly EndeavorRecord[] = recordsOf()) => {
+  const localStore = makeInMemoryLocalStore({ endeavors: records })
+  return {
+    localStore,
+    store: makeStore({ greetingService: stubbedGreetingService, localStore }),
+  }
+}
+
+const failingStore = () => {
+  const base = makeInMemoryLocalStore({ endeavors: recordsOf() })
+  return makeStore({
+    greetingService: stubbedGreetingService,
+    localStore: {
+      ...base,
+      endeavors: {
+        ...base.endeavors,
+        put: async () => {
+          throw new Error('disk full')
+        },
+      },
+    },
+  })
+}
+
+const performance = makePerform({
+  date: new Date(2026, 5, 18, 14, 0, 0),
+  duration: 1500,
+  resolution: PerformResolution.finished,
+  wasCompletedInSession: true,
+  rewardPoints: 5,
+})
+
+describe('saveEndeavorThunk persists the working copy locally', () => {
+  it('writes the edited row and resolves the snapshot it wrote', async () => {
+    const { store, localStore } = storeWith()
+    const edited = { ...detailEndeavorMocks.task, title: 'Prepare the deck' }
+    const result = await store
+      .dispatch(saveEndeavorThunk({ endeavor: edited, now: DETAIL_REFERENCE_NOW }))
+      .unwrap()
+
+    expect(result.ok).toBe(true)
+    expect((await localStore.endeavors.get(edited.id))?.title).toBe(
+      'Prepare the deck',
+    )
+  })
+
+  it('preserves the row’s sync watermark rather than resetting it', async () => {
+    const localStore = makeInMemoryLocalStore({
+      endeavors: [
+        {
+          ...endeavorRecordFromEndeavor(detailEndeavorMocks.task, {
+            now: DETAIL_REFERENCE_NOW,
+          }),
+          lastSyncedAtEpochMillis: 1234,
+        },
+      ],
+    })
+    const store = makeStore({
+      greetingService: stubbedGreetingService,
+      localStore,
+    })
+    await store
+      .dispatch(
+        saveEndeavorThunk({
+          endeavor: { ...detailEndeavorMocks.task, title: 'Renamed' },
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(
+      (await localStore.endeavors.get(detailEndeavorMocks.task.id))
+        ?.lastSyncedAtEpochMillis,
+    ).toBe(1234)
+  })
+
+  it('resolves a typed failure rather than throwing when the write fails', async () => {
+    const store = failingStore()
+    const result = await store
+      .dispatch(
+        saveEndeavorThunk({
+          endeavor: detailEndeavorMocks.task,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('localPersistenceFailed')
+  })
+})
+
+describe('performances are a child table, plus the endeavor row', () => {
+  it('writes both rows when the kind allows sessions', async () => {
+    const { store, localStore } = storeWith()
+    const result = await store
+      .dispatch(
+        addPerformanceThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          performance,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+
+    expect(result.ok && result.value.performances).toHaveLength(1)
+    expect(
+      await localStore.performances.forEndeavor(detailEndeavorMocks.task.id),
+    ).toHaveLength(1)
+  })
+
+  it('writes NOTHING when the matrix refuses sessions for the kind', async () => {
+    const { store, localStore } = storeWith()
+    const result = await store
+      .dispatch(
+        addPerformanceThunk({
+          endeavorId: detailEndeavorMocks.event.id,
+          performance,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+
+    expect(result.ok && result.value.performances).toEqual([])
+    expect(
+      await localStore.performances.forEndeavor(detailEndeavorMocks.event.id),
+    ).toEqual([])
+  })
+
+  it('removes the row the index names', async () => {
+    const { store, localStore } = storeWith()
+    await store
+      .dispatch(
+        addPerformanceThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          performance,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    const result = await store
+      .dispatch(
+        removePerformanceThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          index: 0,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+
+    expect(result.ok && result.value.performances).toEqual([])
+    expect(
+      await localStore.performances.forEndeavor(detailEndeavorMocks.task.id),
+    ).toEqual([])
+  })
+
+  it('is a no-op on an out-of-range index', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(
+        removePerformanceThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          index: 9,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(result.ok && result.value.performances).toEqual([])
+  })
+
+  it('reports an endeavor that is no longer stored', async () => {
+    const { store } = storeWith([])
+    const result = await store
+      .dispatch(
+        addPerformanceThunk({
+          endeavorId: 'ghost',
+          performance,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('endeavorNotFound')
+  })
+})
+
+describe('defers are a child table too — and never move `due`', () => {
+  const entry = makeDefer({
+    made: DETAIL_REFERENCE_NOW,
+    reason: 'blocked',
+    target: new Date(2026, 5, 20, 9, 0, 0),
+  })
+
+  it('appends the audit entry without touching the endeavor’s due date', async () => {
+    const { store, localStore } = storeWith()
+    const result = await store
+      .dispatch(
+        addDeferThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          entry,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+
+    expect(result.ok && result.value.defers).toHaveLength(1)
+    expect(result.ok && result.value.due).toEqual(detailEndeavorMocks.task.due)
+    expect(
+      await localStore.defers.forEndeavor(detailEndeavorMocks.task.id),
+    ).toHaveLength(1)
+  })
+
+  it('writes nothing for a kind the matrix excludes from defers', async () => {
+    const { store, localStore } = storeWith()
+    await store
+      .dispatch(
+        addDeferThunk({
+          endeavorId: detailEndeavorMocks.habit.id,
+          entry,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(
+      await localStore.defers.forEndeavor(detailEndeavorMocks.habit.id),
+    ).toEqual([])
+  })
+
+  it('removes an entry without undoing the due move it recorded', async () => {
+    const { store } = storeWith()
+    await store
+      .dispatch(
+        addDeferThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          entry,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    const result = await store
+      .dispatch(
+        removeDeferThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          index: 0,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(result.ok && result.value.defers).toEqual([])
+    expect(result.ok && result.value.due).toEqual(detailEndeavorMocks.task.due)
+  })
+})
+
+describe('shadows embed on the endeavor row', () => {
+  const shadow = makeShadow({
+    originalTitle: 'Team sync',
+    sourceIdentifier: 'gcal-42',
+    kind: EndeavorKind.calendarEvent,
+    source: EndeavorHost.googleCalendar,
+  })
+
+  it('adds one and persists it on the row itself', async () => {
+    const { store, localStore } = storeWith()
+    const result = await store
+      .dispatch(
+        addShadowThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          shadow,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(result.ok && result.value.shadows).toHaveLength(1)
+    expect(
+      (await localStore.endeavors.get(detailEndeavorMocks.task.id))
+        ?.shadowsJson,
+    ).toBeTruthy()
+  })
+
+  it('removes one by index', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(
+        removeShadowThunk({
+          endeavorId: detailEndeavorMocks.event.id,
+          index: 0,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(result.ok && result.value.shadows).toBeNull()
+  })
+
+  it('refuses the removal on a kind the matrix excludes from shadows', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(
+        removeShadowThunk({
+          endeavorId: detailEndeavorMocks.habit.id,
+          index: 0,
+          now: DETAIL_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(result.ok && result.value.shadows).toBeNull()
+  })
+})
+
+describe('host attach/detach have no web binding, and say so', () => {
+  it('refuses an attach with a reason the user can read', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(
+        attachHostThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          host: EndeavorHost.googleCalendar,
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.kind).toBe('hostAdapterUnavailable')
+      expect(result.error.message).toContain('not connected yet')
+    }
+  })
+
+  it('refuses a detach symmetrically, rather than orphaning the provider copy', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(
+        detachHostThunk({
+          endeavorId: detailEndeavorMocks.event.id,
+          host: EndeavorHost.googleCalendar,
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('hostAdapterUnavailable')
+  })
+
+  it('names Apple’s providers as impossible rather than merely unwired', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(
+        attachHostThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          host: EndeavorHost.appleReminders,
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.message).toContain('no web equivalent')
+  })
+
+  it('marks the refusal unrecoverable — retrying cannot help', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(
+        attachHostThunk({
+          endeavorId: detailEndeavorMocks.task.id,
+          host: EndeavorHost.outlookCalendar,
+        }),
+      )
+      .unwrap()
+    expect(result.ok === false && result.error.recoverable).toBe(false)
+  })
+})

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailSelectors.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailSelectors.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Selectors run against a hand-built root state, never a live store (`RC-55`).
+ * The other registered slices are filled from their own initial states only
+ * because `RootState` names every one of them.
+ */
+import { EndeavorField, EndeavorHost, EndeavorRelation } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { initialDoState } from '../../do/DoFeature'
+import { initialFindState } from '../../find/FindState'
+import { initialGreetingState } from '../../greeting/GreetingFeature'
+import type { RootState } from '../../../library/store'
+import { initialPlanState } from '../../plan/PlanState'
+import {
+  detailEndeavorMocks,
+  detailStateMocks,
+} from '../EndeavorDetailMocks'
+import {
+  selectDetailAttachedHosts,
+  selectDetailBadges,
+  selectDetailDefers,
+  selectDetailDestination,
+  selectDetailEndeavor,
+  selectDetailException,
+  selectDetailFieldsBySection,
+  selectDetailHostCandidates,
+  selectDetailPerformances,
+  selectDetailRelationCards,
+  selectDetailShadows,
+  selectDetailTitle,
+  selectDetailVisibleSections,
+  selectDurationDraft,
+  selectDurationValidationMessage,
+  selectEditNavigationTitle,
+  selectEditShowsIdentityHeader,
+  selectEditWorkingCopy,
+  selectEditableSections,
+  selectIsDetailPresented,
+  selectIsDetailSaving,
+  selectIsEditDirty,
+  selectIsEditValid,
+  selectIsRelationDraftCommittable,
+  selectIsSaveEnabled,
+  selectManagedRelation,
+  selectObservedFocusTime,
+  selectRelationDraft,
+  selectRelationEmptyState,
+  selectRelationReadOnlyReason,
+} from '../EndeavorDetailSelectors'
+import type { EndeavorDetailState } from '../EndeavorDetailState'
+
+const rootWith = (endeavorDetail: EndeavorDetailState): RootState => ({
+  greeting: initialGreetingState,
+  // Present only because `RootState` names every registered slice.
+  do: initialDoState,
+  plan: initialPlanState,
+  find: initialFindState,
+  endeavorDetail,
+})
+
+describe('presentation', () => {
+  it('reports nothing presented while the surface is closed', () => {
+    const closed = rootWith(detailStateMocks.closed)
+    expect(selectIsDetailPresented(closed)).toBe(false)
+    expect(selectDetailEndeavor(closed)).toBeNull()
+    expect(selectDetailTitle(closed)).toBe('')
+  })
+
+  it('reports the presented endeavor and its display title', () => {
+    const presented = rootWith(detailStateMocks.presentedTask)
+    expect(selectIsDetailPresented(presented)).toBe(true)
+    expect(selectDetailTitle(presented)).toBe(detailEndeavorMocks.task.title)
+  })
+
+  it('reports which editor is open', () => {
+    expect(selectDetailDestination(rootWith(detailStateMocks.durationOpen))).toEqual(
+      { kind: 'duration' },
+    )
+    expect(
+      selectDetailDestination(rootWith(detailStateMocks.presentedTask)),
+    ).toBeNull()
+  })
+})
+
+describe('the read surface’s cards', () => {
+  it('lists every section, empty ones included', () => {
+    expect(
+      selectDetailFieldsBySection(rootWith(detailStateMocks.presentedTask)),
+    ).toHaveLength(3)
+  })
+
+  it('omits an empty section from the ones worth a header', () => {
+    const sections = selectDetailVisibleSections(
+      rootWith(detailStateMocks.presentedEvent),
+    )
+    expect(sections.every((model) => model.fields.length > 0)).toBe(true)
+  })
+
+  it('answers empty while nothing is presented', () => {
+    expect(selectDetailFieldsBySection(rootWith(detailStateMocks.closed))).toEqual(
+      [],
+    )
+    expect(selectDetailRelationCards(rootWith(detailStateMocks.closed))).toEqual(
+      [],
+    )
+  })
+
+  it('marks a relation the kind cannot manage as inert', () => {
+    const cards = selectDetailRelationCards(
+      rootWith(detailStateMocks.presentedEvent),
+    )
+    expect(
+      cards.find((card) => card.relation === EndeavorRelation.performances)
+        ?.isManageable,
+    ).toBe(false)
+  })
+
+  it('leads the header with the kind, then the status', () => {
+    const badges = selectDetailBadges(rootWith(detailStateMocks.presentedTask))
+    expect(badges[0]?.kind).toBe('kind')
+    expect(badges[1]?.kind).toBe('status')
+  })
+})
+
+describe('the editor’s own reads', () => {
+  it('exposes the working copy while an editor is open', () => {
+    expect(
+      selectEditWorkingCopy(rootWith(detailStateMocks.editingTask))?.id,
+    ).toBe(detailEndeavorMocks.task.id)
+    expect(
+      selectEditWorkingCopy(rootWith(detailStateMocks.presentedTask)),
+    ).toBeNull()
+  })
+
+  it('narrows the editable sections to the focused field', () => {
+    const sections = selectEditableSections(
+      rootWith(detailStateMocks.editingTitleOnly),
+    )
+    expect(sections).toHaveLength(1)
+    expect(sections[0]?.fields).toEqual([EndeavorField.title])
+  })
+
+  it('shows the identity header only on the full form', () => {
+    expect(
+      selectEditShowsIdentityHeader(rootWith(detailStateMocks.editingTask)),
+    ).toBe(true)
+    expect(
+      selectEditShowsIdentityHeader(rootWith(detailStateMocks.editingTitleOnly)),
+    ).toBe(false)
+  })
+
+  it('titles the editor by its focus', () => {
+    expect(selectEditNavigationTitle(rootWith(detailStateMocks.editingTask))).toBe(
+      'Edit',
+    )
+    expect(
+      selectEditNavigationTitle(rootWith(detailStateMocks.editingTitleOnly)),
+    ).toBe('Edit title')
+  })
+
+  it('reports dirty, valid and save-enabled independently', () => {
+    expect(selectIsEditDirty(rootWith(detailStateMocks.editingTask))).toBe(false)
+    expect(selectIsEditDirty(rootWith(detailStateMocks.editingDirty))).toBe(true)
+    expect(selectIsEditValid(rootWith(detailStateMocks.editingInvalid))).toBe(
+      false,
+    )
+    expect(selectIsSaveEnabled(rootWith(detailStateMocks.editingDirty))).toBe(
+      true,
+    )
+  })
+
+  it('refuses Save while one is already in flight', () => {
+    expect(selectIsDetailSaving(rootWith(detailStateMocks.saving))).toBe(true)
+    expect(selectIsSaveEnabled(rootWith(detailStateMocks.saving))).toBe(false)
+  })
+
+  it('surfaces the last failure for the banner', () => {
+    expect(
+      selectDetailException(rootWith(detailStateMocks.saveFailed))?.kind,
+    ).toBe('localPersistenceFailed')
+    expect(
+      selectDetailException(rootWith(detailStateMocks.editingTask)),
+    ).toBeNull()
+  })
+})
+
+describe('the duration profile’s reads', () => {
+  it('exposes the draft while the profile is open', () => {
+    expect(
+      selectDurationDraft(rootWith(detailStateMocks.durationOpen)),
+    ).not.toBeNull()
+    expect(selectDurationDraft(rootWith(detailStateMocks.editingTask))).toBeNull()
+  })
+
+  it('computes the observed focus time from the performances', () => {
+    const observed = selectObservedFocusTime(
+      rootWith(detailStateMocks.durationOpen),
+    )
+    expect(observed?.seconds).toBe(1800)
+    expect(observed?.sampleCount).toBe(3)
+  })
+
+  it('answers null for the observed card while nothing is presented', () => {
+    expect(selectObservedFocusTime(rootWith(detailStateMocks.closed))).toBeNull()
+  })
+
+  it('says nothing about validation on a coherent profile', () => {
+    expect(
+      selectDurationValidationMessage(rootWith(detailStateMocks.durationOpen)),
+    ).toBeNull()
+  })
+})
+
+describe('the relation reads', () => {
+  it('lists the performances, defers and shadows as stored', () => {
+    const withSessions = rootWith(detailStateMocks.performancesOpen)
+    expect(selectDetailPerformances(withSessions)).toHaveLength(3)
+    expect(selectDetailDefers(withSessions)).toEqual([])
+    expect(selectDetailShadows(rootWith(detailStateMocks.presentedEvent))).toHaveLength(
+      1,
+    )
+  })
+
+  it('names the relation being managed', () => {
+    expect(selectManagedRelation(rootWith(detailStateMocks.hostsOpen))).toBe(
+      EndeavorRelation.hosts,
+    )
+    expect(
+      selectManagedRelation(rootWith(detailStateMocks.presentedTask)),
+    ).toBeNull()
+  })
+
+  it('states WHY a relation is read-only, instead of merely hiding the form', () => {
+    expect(
+      selectRelationReadOnlyReason(rootWith(detailStateMocks.performancesReadOnly)),
+    ).toBe("This endeavor's kind can't record sessions.")
+    expect(
+      selectRelationReadOnlyReason(rootWith(detailStateMocks.performancesOpen)),
+    ).toBeNull()
+  })
+
+  it('picks the empty-state copy that matches editability', () => {
+    expect(
+      selectRelationEmptyState(rootWith(detailStateMocks.performancesOpen))
+        ?.message,
+    ).toContain('log one below by hand')
+    expect(
+      selectRelationEmptyState(rootWith(detailStateMocks.performancesReadOnly))
+        ?.message,
+    ).toBe('Sessions logged against this endeavor will appear here.')
+  })
+
+  it('reports the attached hosts and the candidates, each with its reason', () => {
+    expect(
+      selectDetailAttachedHosts(rootWith(detailStateMocks.presentedEvent)),
+    ).toEqual([EndeavorHost.googleCalendar])
+    const candidates = selectDetailHostCandidates(
+      rootWith(detailStateMocks.hostsOpen),
+    )
+    expect(candidates.length).toBeGreaterThan(0)
+    expect(candidates.every((candidate) => !candidate.isAttachable)).toBe(true)
+  })
+
+  it('reports whether the open add form can be committed', () => {
+    expect(selectRelationDraft(rootWith(detailStateMocks.hostsOpen))).toBeNull()
+    expect(
+      selectIsRelationDraftCommittable(rootWith(detailStateMocks.hostsOpen)),
+    ).toBe(false)
+  })
+})

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailSelectors.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailSelectors.test.ts
@@ -5,6 +5,7 @@
  */
 import { EndeavorField, EndeavorHost, EndeavorRelation } from '@kro/core'
 import { describe, expect, it } from 'vitest'
+import { initialCaptureState } from '../../capture/CaptureFeature'
 import { initialDoState } from '../../do/DoFeature'
 import { initialFindState } from '../../find/FindState'
 import { initialGreetingState } from '../../greeting/GreetingFeature'
@@ -52,6 +53,7 @@ const rootWith = (endeavorDetail: EndeavorDetailState): RootState => ({
   greeting: initialGreetingState,
   // Present only because `RootState` names every registered slice.
   do: initialDoState,
+  capture: initialCaptureState,
   plan: initialPlanState,
   find: initialFindState,
   endeavorDetail,

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailShifters.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailShifters.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Shifters are pure: no store, no dispatch, no clock (`RC-56`). Every `State`
+ * comes from `EndeavorDetailMocks` rather than being built inline (`RC-31`).
+ */
+import { EndeavorField, EndeavorRelation, EndeavorStatus } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { EndeavorDetailExceptions } from '../EndeavorDetailException'
+import {
+  detailEndeavorMocks,
+  detailStateMocks,
+} from '../EndeavorDetailMocks'
+import {
+  withDestinationDismissed,
+  withDetailDismissed,
+  withDetailPresented,
+  withDurationBoundAdjusted,
+  withDurationBoundToggled,
+  withEditRequested,
+  withFieldChanged,
+  withFieldEditRequested,
+  withRelationDraft,
+  withRelationManagementRequested,
+  withRelationUpdated,
+  withSaveFailed,
+  withSaveStarted,
+  withSaveSucceeded,
+} from '../EndeavorDetailShifters'
+import { DurationBound } from '../EndeavorDuration'
+
+describe('presenting and dismissing Detail', () => {
+  it('opens on the endeavor the caller already holds', () => {
+    const next = withDetailPresented(detailStateMocks.closed, {
+      endeavor: detailEndeavorMocks.task,
+    })
+    expect(next.endeavor).toBe(detailEndeavorMocks.task)
+    expect(next.destination).toBeNull()
+  })
+
+  it('clears every draft left over from the previous endeavor', () => {
+    const next = withDetailPresented(detailStateMocks.editingDirty, {
+      endeavor: detailEndeavorMocks.event,
+    })
+    expect(next.edit).toBeNull()
+    expect(next.duration).toBeNull()
+    expect(next.relationDraft).toBeNull()
+  })
+
+  it('closes back to nothing at all', () => {
+    expect(withDetailDismissed(detailStateMocks.editingDirty)).toEqual(
+      detailStateMocks.closed,
+    )
+  })
+})
+
+describe('a Detail row tap opens the right editor, and only when allowed', () => {
+  it('opens Edit focused on the tapped field', () => {
+    const next = withFieldEditRequested(detailStateMocks.presentedTask, {
+      field: EndeavorField.title,
+    })
+    expect(next.destination).toEqual({ kind: 'edit', focusedField: 'title' })
+    expect(next.edit?.focusedField).toBe(EndeavorField.title)
+  })
+
+  it('routes `duration` to the Duration profile instead, seeding both drafts', () => {
+    const next = withFieldEditRequested(detailStateMocks.presentedTask, {
+      field: EndeavorField.duration,
+    })
+    expect(next.destination).toEqual({ kind: 'duration' })
+    expect(next.duration).not.toBeNull()
+    expect(next.edit).not.toBeNull()
+  })
+
+  it('opens nothing for a field the matrix refuses — the defensive backstop', () => {
+    const next = withFieldEditRequested(detailStateMocks.presentedEvent, {
+      field: EndeavorField.due,
+    })
+    expect(next.destination).toBeNull()
+  })
+
+  it('is a no-op when nothing is presented', () => {
+    const next = withFieldEditRequested(detailStateMocks.closed, {
+      field: EndeavorField.title,
+    })
+    expect(next).toBe(detailStateMocks.closed)
+  })
+
+  it('opens the full editor with no field in focus', () => {
+    const next = withEditRequested(detailStateMocks.presentedTask, {})
+    expect(next.destination).toEqual({ kind: 'edit', focusedField: null })
+    expect(next.edit?.working).toBe(detailEndeavorMocks.task)
+  })
+
+  it('can open the editor on an endeavor handed in from another surface', () => {
+    const next = withEditRequested(detailStateMocks.closed, {
+      endeavor: detailEndeavorMocks.habit,
+    })
+    expect(next.endeavor).toBe(detailEndeavorMocks.habit)
+    expect(next.destination).toEqual({ kind: 'edit', focusedField: null })
+  })
+})
+
+describe('a relation’s manage affordance obeys the same matrix', () => {
+  it('opens the relation screen for a kind that can manage it', () => {
+    const next = withRelationManagementRequested(detailStateMocks.presentedTask, {
+      relation: EndeavorRelation.performances,
+    })
+    expect(next.destination).toEqual({
+      kind: 'relation',
+      relation: EndeavorRelation.performances,
+    })
+  })
+
+  it('refuses performances on a calendar event', () => {
+    const next = withRelationManagementRequested(
+      detailStateMocks.presentedEvent,
+      { relation: EndeavorRelation.performances },
+    )
+    expect(next.destination).toBeNull()
+  })
+
+  it('refuses hosts on a habit', () => {
+    const next = withRelationManagementRequested(detailStateMocks.presentedHabit, {
+      relation: EndeavorRelation.hosts,
+    })
+    expect(next.destination).toBeNull()
+  })
+
+  it('clears the editor drafts when a relation screen takes over', () => {
+    const next = withRelationManagementRequested(detailStateMocks.durationOpen, {
+      relation: EndeavorRelation.performances,
+    })
+    expect(next.edit).toBeNull()
+    expect(next.duration).toBeNull()
+  })
+})
+
+describe('dismissing the presented editor discards the working copy', () => {
+  it('drops the drafts without touching the presented endeavor', () => {
+    const next = withDestinationDismissed(detailStateMocks.editingDirty)
+    expect(next.endeavor).toBe(detailEndeavorMocks.task)
+    expect(next.edit).toBeNull()
+    expect(next.destination).toBeNull()
+  })
+
+  it('clears a stale save failure with it, so reopening starts clean', () => {
+    expect(withDestinationDismissed(detailStateMocks.saveFailed).save).toEqual({
+      kind: 'idle',
+    })
+  })
+
+  it('is harmless when nothing was presented', () => {
+    expect(withDestinationDismissed(detailStateMocks.presentedTask).edit).toBeNull()
+  })
+})
+
+describe('field edits land on the working copy, never the presented one', () => {
+  it('applies an allowed edit to the draft only', () => {
+    const next = withFieldChanged(detailStateMocks.editingTask, {
+      change: { field: 'title', value: 'Prepare the deck' },
+    })
+    expect(next.edit?.working.title).toBe('Prepare the deck')
+    expect(next.endeavor?.title).toBe(detailEndeavorMocks.task.title)
+  })
+
+  it('leaves the draft identical when the matrix refuses the edit', () => {
+    const editingEvent = withEditRequested(detailStateMocks.presentedEvent, {})
+    const next = withFieldChanged(editingEvent, {
+      change: { field: 'due', value: new Date(2026, 5, 20) },
+    })
+    expect(next.edit?.working).toBe(editingEvent.edit?.working)
+  })
+
+  it('supersedes a stale save failure, so the banner does not linger', () => {
+    const next = withFieldChanged(detailStateMocks.saveFailed, {
+      change: { field: 'status', value: EndeavorStatus.ongoing },
+    })
+    expect(next.save).toEqual({ kind: 'idle' })
+  })
+
+  it('is a no-op when no editor is open', () => {
+    expect(
+      withFieldChanged(detailStateMocks.presentedTask, {
+        change: { field: 'title', value: 'x' },
+      }),
+    ).toBe(detailStateMocks.presentedTask)
+  })
+})
+
+describe('the duration bounds and the working copy move together', () => {
+  it('writes an enabled bound into the working copy', () => {
+    const next = withDurationBoundToggled(detailStateMocks.durationOpen, {
+      bound: DurationBound.minimum,
+      isEnabled: true,
+    })
+    expect(next.duration?.isMinimumEnabled).toBe(true)
+    expect(next.edit?.working.minimumDuration).toBe(
+      next.duration?.minimumSeconds,
+    )
+  })
+
+  it('writes null into the working copy for a disabled bound', () => {
+    const enabled = withDurationBoundToggled(detailStateMocks.durationOpen, {
+      bound: DurationBound.preferred,
+      isEnabled: true,
+    })
+    const disabled = withDurationBoundToggled(enabled, {
+      bound: DurationBound.preferred,
+      isEnabled: false,
+    })
+    expect(disabled.edit?.working.duration).toBeNull()
+  })
+
+  it('carries a dialled number through to the working copy', () => {
+    const enabled = withDurationBoundToggled(detailStateMocks.durationOpen, {
+      bound: DurationBound.preferred,
+      isEnabled: true,
+    })
+    const dialled = withDurationBoundAdjusted(enabled, {
+      bound: DurationBound.preferred,
+      seconds: 2400,
+    })
+    expect(dialled.edit?.working.duration).toBe(2400)
+  })
+
+  it('is a no-op when the Duration profile is not open', () => {
+    expect(
+      withDurationBoundAdjusted(detailStateMocks.editingTask, {
+        bound: DurationBound.preferred,
+        seconds: 900,
+      }),
+    ).toBe(detailStateMocks.editingTask)
+  })
+})
+
+describe('the save lifecycle', () => {
+  it('clears a stale failure when a fresh save starts', () => {
+    expect(withSaveStarted(detailStateMocks.saveFailed).save).toEqual({
+      kind: 'saving',
+    })
+  })
+
+  it('adopts the persisted snapshot and resets the dirty baseline', () => {
+    const saved = { ...detailEndeavorMocks.task, title: 'Prepare the deck' }
+    const next = withSaveSucceeded(detailStateMocks.editingDirty, { saved })
+    expect(next.endeavor).toBe(saved)
+    expect(next.edit?.original).toBe(saved)
+    expect(next.edit?.working).toBe(saved)
+  })
+
+  it('keeps a newer edit that raced ahead of the save, still dirty', () => {
+    const raced = withFieldChanged(detailStateMocks.editingDirty, {
+      change: { field: 'title', value: 'Even newer' },
+    })
+    const saved = { ...detailEndeavorMocks.task, title: 'Prepare the deck' }
+    const next = withSaveSucceeded(raced, { saved })
+    expect(next.edit?.working.title).toBe('Even newer')
+    expect(next.edit?.original).toBe(saved)
+  })
+
+  it('leaves the working copy dirty when nothing was persisted', () => {
+    const next = withSaveFailed(detailStateMocks.editingDirty, {
+      exception: EndeavorDetailExceptions.localPersistenceFailed('disk full'),
+    })
+    expect(next.edit?.working.title).toBe('Prepare the deck')
+    expect(next.save.kind).toBe('failed')
+  })
+})
+
+describe('relation writes refresh Detail’s own copy', () => {
+  it('adopts the refreshed endeavor', () => {
+    const updated = { ...detailEndeavorMocks.task, sessionPoints: 12 }
+    const next = withRelationUpdated(detailStateMocks.performancesOpen, {
+      updated,
+    })
+    expect(next.endeavor).toBe(updated)
+  })
+
+  it('closes the add form the write came from', () => {
+    const withForm = withRelationDraft(detailStateMocks.performancesOpen, {
+      draft: { relation: 'defers', draft: { target: new Date(), reason: '' } },
+    })
+    const next = withRelationUpdated(withForm, {
+      updated: detailEndeavorMocks.task,
+    })
+    expect(next.relationDraft).toBeNull()
+  })
+
+  it('leaves the relation screen itself open', () => {
+    const next = withRelationUpdated(detailStateMocks.performancesOpen, {
+      updated: detailEndeavorMocks.task,
+    })
+    expect(next.destination).toEqual({
+      kind: 'relation',
+      relation: 'performances',
+    })
+  })
+})
+
+describe('the relation add form', () => {
+  it('opens a form', () => {
+    const next = withRelationDraft(detailStateMocks.performancesOpen, {
+      draft: { relation: 'hosts', host: null },
+    })
+    expect(next.relationDraft).toEqual({ relation: 'hosts', host: null })
+  })
+
+  it('cancels it', () => {
+    const opened = withRelationDraft(detailStateMocks.performancesOpen, {
+      draft: { relation: 'hosts', host: null },
+    })
+    expect(withRelationDraft(opened, { draft: null }).relationDraft).toBeNull()
+  })
+
+  it('clears a stale failure when the user starts composing again', () => {
+    const next = withRelationDraft(detailStateMocks.saveFailed, {
+      draft: { relation: 'hosts', host: null },
+    })
+    expect(next.save).toEqual({ kind: 'idle' })
+  })
+})

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailShifters.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailShifters.test.ts
@@ -110,19 +110,27 @@ describe('a relation’s manage affordance obeys the same matrix', () => {
     })
   })
 
-  it('refuses performances on a calendar event', () => {
+  it('opens performances read-only on a calendar event', () => {
+    // Canon renders read-only relation screens with their "why" copy; only
+    // the mutation path refuses. Opening must always succeed.
     const next = withRelationManagementRequested(
       detailStateMocks.presentedEvent,
       { relation: EndeavorRelation.performances },
     )
-    expect(next.destination).toBeNull()
+    expect(next.destination).toEqual({
+      kind: 'relation',
+      relation: EndeavorRelation.performances,
+    })
   })
 
-  it('refuses hosts on a habit', () => {
+  it('opens hosts read-only on a habit', () => {
     const next = withRelationManagementRequested(detailStateMocks.presentedHabit, {
       relation: EndeavorRelation.hosts,
     })
-    expect(next.destination).toBeNull()
+    expect(next.destination).toEqual({
+      kind: 'relation',
+      relation: EndeavorRelation.hosts,
+    })
   })
 
   it('clears the editor drafts when a relation screen takes over', () => {

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailState.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailState.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The initial state and the shape of the one lifecycle field.
+ *
+ * The invariant worth pinning is the one canon gets for free from `@Presents`:
+ * a child's draft exists exactly while its destination is presented, and the
+ * closed state has neither.
+ */
+import { describe, expect, it } from 'vitest'
+import { initialEndeavorDetailState } from '../EndeavorDetailState'
+import { detailStateMocks } from '../EndeavorDetailMocks'
+
+describe('the closed state holds nothing at all', () => {
+  it('presents no endeavor and no destination', () => {
+    expect(initialEndeavorDetailState.endeavor).toBeNull()
+    expect(initialEndeavorDetailState.destination).toBeNull()
+  })
+
+  it('carries no draft of any kind', () => {
+    expect(initialEndeavorDetailState.edit).toBeNull()
+    expect(initialEndeavorDetailState.duration).toBeNull()
+    expect(initialEndeavorDetailState.relationDraft).toBeNull()
+  })
+
+  it('starts the save lifecycle idle, as one field rather than two', () => {
+    expect(initialEndeavorDetailState.save).toEqual({ kind: 'idle' })
+  })
+})
+
+describe('a presented destination always carries the draft it needs', () => {
+  it('gives the editor a working copy and a baseline', () => {
+    expect(detailStateMocks.editingTask.edit?.working).not.toBeUndefined()
+    expect(detailStateMocks.editingTask.edit?.original).not.toBeUndefined()
+  })
+
+  it('gives the Duration profile BOTH drafts, because it edits through Edit', () => {
+    expect(detailStateMocks.durationOpen.edit).not.toBeNull()
+    expect(detailStateMocks.durationOpen.duration).not.toBeNull()
+  })
+
+  it('gives a relation screen neither editor draft', () => {
+    expect(detailStateMocks.performancesOpen.edit).toBeNull()
+    expect(detailStateMocks.performancesOpen.duration).toBeNull()
+  })
+})

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDuration.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDuration.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The Duration profile and the read-only observed focus time.
+ *
+ * The seed ladder is the part worth pinning: canon prefills the dials from the
+ * *observed* average without turning it into an authored preference, so a user
+ * who has never set a duration still opens on a sensible number with every
+ * switch off.
+ */
+import { EMPIRICAL_SAMPLE_MINIMUM, PerformResolution, makeEndeavor, makePerform, EndeavorKind } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_DURATION_SEED,
+  DurationBound,
+  draftWithBoundAdjusted,
+  draftWithBoundToggled,
+  durationBounds,
+  durationDraftFor,
+  durationProfileOf,
+  durationValidationMessage,
+  observedFocusTime,
+} from '../EndeavorDuration'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+
+describe('observed focus time is computed from the completed sessions', () => {
+  it('averages three qualifying sessions, rounded to the minute', () => {
+    const observed = observedFocusTime(detailEndeavorMocks.taskWithSessions)
+    // (1500 + 1800 + 2100) / 3 = 1800s = 30 min.
+    expect(observed.seconds).toBe(1800)
+    expect(observed.sampleCount).toBe(3)
+  })
+
+  it('stays locked below the sample minimum, and says what the minimum is', () => {
+    const observed = observedFocusTime(detailEndeavorMocks.taskWithOneSession)
+    expect(observed.seconds).toBeNull()
+    expect(observed.sampleCount).toBe(1)
+    expect(observed.requiredSampleCount).toBe(EMPIRICAL_SAMPLE_MINIMUM)
+  })
+
+  it('reports nothing observed for an endeavor that was never worked on', () => {
+    const observed = observedFocusTime(detailEndeavorMocks.task)
+    expect(observed.seconds).toBeNull()
+    expect(observed.sampleCount).toBe(0)
+  })
+
+  it('excludes an aborted attempt from the sample', () => {
+    const withAborted = makeEndeavor({
+      id: 'aborted',
+      title: 'aborted',
+      kind: EndeavorKind.task,
+      performances: [
+        makePerform({
+          date: new Date(2026, 5, 18, 8),
+          duration: 1800,
+          resolution: PerformResolution.aborted,
+          wasCompletedInSession: true,
+        }),
+      ],
+    })
+    expect(observedFocusTime(withAborted).sampleCount).toBe(0)
+  })
+
+  it('excludes a quick complete that was never a session', () => {
+    const quick = makeEndeavor({
+      id: 'quick',
+      title: 'quick',
+      kind: EndeavorKind.task,
+      performances: [
+        makePerform({
+          date: new Date(2026, 5, 18, 8),
+          duration: 1800,
+          resolution: PerformResolution.finished,
+          wasCompletedInSession: false,
+        }),
+      ],
+    })
+    expect(observedFocusTime(quick).sampleCount).toBe(0)
+  })
+})
+
+describe('the draft seeds from the authored value, then the observed one', () => {
+  it('prefers an authored duration over the observed average', () => {
+    const draft = durationDraftFor(detailEndeavorMocks.task)
+    expect(draft.preferredSeconds).toBe(detailEndeavorMocks.task.duration)
+    expect(draft.isPreferredEnabled).toBe(true)
+  })
+
+  it('prefills from the observed average WITHOUT enabling the switch', () => {
+    const draft = durationDraftFor(detailEndeavorMocks.taskWithSessions)
+    expect(draft.preferredSeconds).toBe(1800)
+    // Enabling it is an explicit act — a learned value is not an authored one.
+    expect(draft.isPreferredEnabled).toBe(false)
+  })
+
+  it('falls back to canon’s 25-minute seed with nothing authored or observed', () => {
+    const draft = durationDraftFor(detailEndeavorMocks.taskWithOneSession)
+    expect(draft.preferredSeconds).toBe(DEFAULT_DURATION_SEED)
+  })
+
+  it('seeds minimum and maximum from the same ladder, both switched off', () => {
+    const draft = durationDraftFor(detailEndeavorMocks.task)
+    expect(draft.minimumSeconds).toBe(detailEndeavorMocks.task.duration)
+    expect(draft.maximumSeconds).toBe(detailEndeavorMocks.task.duration)
+    expect(draft.isMinimumEnabled).toBe(false)
+    expect(draft.isMaximumEnabled).toBe(false)
+  })
+
+  it('names its three bounds in canon’s display order', () => {
+    expect(durationBounds).toEqual([
+      DurationBound.preferred,
+      DurationBound.minimum,
+      DurationBound.maximum,
+    ])
+  })
+})
+
+describe('toggling and dialling a bound are independent', () => {
+  const base = durationDraftFor(detailEndeavorMocks.task)
+
+  it('flips a switch without touching its number', () => {
+    const toggled = draftWithBoundToggled(base, DurationBound.minimum, true)
+    expect(toggled.isMinimumEnabled).toBe(true)
+    expect(toggled.minimumSeconds).toBe(base.minimumSeconds)
+  })
+
+  it('dials a number without touching its switch', () => {
+    const dialled = draftWithBoundAdjusted(base, DurationBound.maximum, 3600)
+    expect(dialled.maximumSeconds).toBe(3600)
+    expect(dialled.isMaximumEnabled).toBe(false)
+  })
+
+  it('keeps the dialled number across an off-then-on toggle', () => {
+    const dialled = draftWithBoundAdjusted(base, DurationBound.preferred, 2400)
+    const off = draftWithBoundToggled(dialled, DurationBound.preferred, false)
+    const on = draftWithBoundToggled(off, DurationBound.preferred, true)
+    expect(on.preferredSeconds).toBe(2400)
+  })
+})
+
+describe('the draft becomes the three nullable columns the domain stores', () => {
+  const base = durationDraftFor(detailEndeavorMocks.task)
+
+  it('writes null for a switched-off bound — "no authored preference"', () => {
+    expect(durationProfileOf(base)).toEqual({
+      preferred: detailEndeavorMocks.task.duration,
+      minimum: null,
+      maximum: null,
+    })
+  })
+
+  it('writes the number for a switched-on bound', () => {
+    const enabled = draftWithBoundToggled(base, DurationBound.minimum, true)
+    expect(durationProfileOf(enabled).minimum).toBe(enabled.minimumSeconds)
+  })
+
+  it('writes all three nulls when every switch is off', () => {
+    const allOff = draftWithBoundToggled(base, DurationBound.preferred, false)
+    expect(durationProfileOf(allOff)).toEqual({
+      preferred: null,
+      minimum: null,
+      maximum: null,
+    })
+  })
+})
+
+describe('validation catches the one incoherent profile', () => {
+  const base = durationDraftFor(detailEndeavorMocks.task)
+  const bothOn = draftWithBoundToggled(
+    draftWithBoundToggled(base, DurationBound.minimum, true),
+    DurationBound.maximum,
+    true,
+  )
+
+  it('complains when an enabled minimum exceeds an enabled maximum', () => {
+    const bad = draftWithBoundAdjusted(
+      draftWithBoundAdjusted(bothOn, DurationBound.minimum, 3600),
+      DurationBound.maximum,
+      600,
+    )
+    expect(durationValidationMessage(bad)).toBe(
+      'Minimum duration must not exceed maximum duration.',
+    )
+  })
+
+  it('accepts a coherent pair', () => {
+    const good = draftWithBoundAdjusted(
+      draftWithBoundAdjusted(bothOn, DurationBound.minimum, 600),
+      DurationBound.maximum,
+      3600,
+    )
+    expect(durationValidationMessage(good)).toBeNull()
+  })
+
+  it('says nothing while only one of the two bounds is enabled', () => {
+    const onlyMinimum = draftWithBoundAdjusted(
+      draftWithBoundToggled(base, DurationBound.minimum, true),
+      DurationBound.minimum,
+      99999,
+    )
+    expect(durationValidationMessage(onlyMinimum)).toBeNull()
+  })
+})

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorRelations.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorRelations.test.ts
@@ -1,0 +1,261 @@
+/**
+ * The four relation surfaces: their lists, their per-kind read-only rules, and
+ * the copy that has to **state why** rather than just disabling a control.
+ */
+import {
+  EndeavorHost,
+  EndeavorKind,
+  EndeavorRelation,
+  PerformResolution,
+  endeavorRelations,
+  isRelationEditable,
+  makeShadow,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import {
+  attachedHostsOf,
+  defersOf,
+  hostAdapterUnavailableReason,
+  hostAttachCandidatesOf,
+  isExternalHost,
+  isRelationDraftCommittable,
+  performancesOf,
+  relationEmptyState,
+  relationReadOnlyReason,
+  shadowsOf,
+} from '../EndeavorRelations'
+
+describe('a read-only relation states WHY, per relation', () => {
+  it('says a calendar event cannot record sessions', () => {
+    expect(
+      relationReadOnlyReason(EndeavorRelation.performances, EndeavorKind.calendarEvent),
+    ).toBe("This endeavor's kind can't record sessions.")
+  })
+
+  it('says a habit cannot record defers', () => {
+    expect(relationReadOnlyReason(EndeavorRelation.defers, EndeavorKind.habit)).toBe(
+      "This endeavor's kind can't record defers.",
+    )
+  })
+
+  it('says a habit cannot change where it is mirrored', () => {
+    expect(relationReadOnlyReason(EndeavorRelation.hosts, EndeavorKind.habit)).toBe(
+      "This endeavor's kind can't change where it's mirrored.",
+    )
+  })
+
+  it('says a blueprint cannot change its external mirrors', () => {
+    expect(
+      relationReadOnlyReason(EndeavorRelation.shadows, EndeavorKind.blueprint),
+    ).toBe("This endeavor's kind can't change its external mirrors.")
+  })
+
+  it('says nothing at all when the relation IS editable', () => {
+    expect(
+      relationReadOnlyReason(EndeavorRelation.performances, EndeavorKind.task),
+    ).toBeNull()
+  })
+
+  it('answers a reason for exactly the relations the domain matrix refuses', () => {
+    for (const relation of endeavorRelations) {
+      for (const kind of [
+        EndeavorKind.task,
+        EndeavorKind.habit,
+        EndeavorKind.calendarEvent,
+        EndeavorKind.blueprint,
+      ]) {
+        const reason = relationReadOnlyReason(relation, kind)
+        expect(reason === null).toBe(isRelationEditable(relation, kind))
+      }
+    }
+  })
+})
+
+describe('the empty states change with editability, as canon’s copy does', () => {
+  it('invites an editable Performances list to log one by hand', () => {
+    expect(
+      relationEmptyState(EndeavorRelation.performances, EndeavorKind.task).message,
+    ).toContain('log one below by hand')
+  })
+
+  it('does NOT invite that on a read-only one — there is no form to use', () => {
+    const state = relationEmptyState(
+      EndeavorRelation.performances,
+      EndeavorKind.calendarEvent,
+    )
+    expect(state.message).toBe(
+      'Sessions logged against this endeavor will appear here.',
+    )
+  })
+
+  it('describes an un-deferred endeavor as having kept every due date', () => {
+    const state = relationEmptyState(EndeavorRelation.defers, EndeavorKind.task)
+    expect(state.title).toBe('Never deferred')
+  })
+
+  it('tells an un-mirrored endeavor apart by whether it can be mirrored', () => {
+    expect(
+      relationEmptyState(EndeavorRelation.hosts, EndeavorKind.task).message,
+    ).toContain('Attach a provider')
+    expect(
+      relationEmptyState(EndeavorRelation.hosts, EndeavorKind.habit).message,
+    ).toBe('This endeavor lives only in Kro.')
+  })
+
+  it('explains what a shadow even is on an empty list', () => {
+    expect(
+      relationEmptyState(EndeavorRelation.shadows, EndeavorKind.task).message,
+    ).toContain('mirrored from a calendar')
+  })
+})
+
+describe('the relation lists read straight off the endeavor', () => {
+  it('lists the performances as stored', () => {
+    expect(performancesOf(detailEndeavorMocks.taskWithSessions)).toHaveLength(3)
+  })
+
+  it('normalises a null shadow list to an empty array', () => {
+    expect(shadowsOf(detailEndeavorMocks.task)).toEqual([])
+    expect(shadowsOf(detailEndeavorMocks.event)).toHaveLength(1)
+  })
+
+  it('lists the defer history in order', () => {
+    expect(defersOf(detailEndeavorMocks.task)).toEqual([])
+  })
+})
+
+describe('hosts: the candidates are listed, and each says why it is unavailable', () => {
+  it('treats Kro’s own two stores as internal, not attachable providers', () => {
+    expect(isExternalHost(EndeavorHost.local)).toBe(false)
+    expect(isExternalHost(EndeavorHost.supabase)).toBe(false)
+    expect(isExternalHost(EndeavorHost.googleCalendar)).toBe(true)
+  })
+
+  it('reports only the external hosts an endeavor is actually on', () => {
+    expect(attachedHostsOf(detailEndeavorMocks.event)).toEqual([
+      EndeavorHost.googleCalendar,
+    ])
+    expect(attachedHostsOf(detailEndeavorMocks.task)).toEqual([])
+  })
+
+  it('offers every unattached external host as a candidate', () => {
+    const candidates = hostAttachCandidatesOf(detailEndeavorMocks.event).map(
+      (candidate) => candidate.host,
+    )
+    expect(candidates).not.toContain(EndeavorHost.googleCalendar)
+    expect(candidates).toContain(EndeavorHost.appleReminders)
+  })
+
+  it('marks EVERY candidate unattachable in this build, with a reason', () => {
+    for (const candidate of hostAttachCandidatesOf(detailEndeavorMocks.task)) {
+      expect(candidate.isAttachable).toBe(false)
+      expect(candidate.unavailableReason?.length ?? 0).toBeGreaterThan(0)
+    }
+  })
+
+  it('says Apple’s two providers have no web equivalent at all', () => {
+    expect(hostAdapterUnavailableReason(EndeavorHost.appleCalendar)).toContain(
+      'no web equivalent',
+    )
+  })
+
+  it('says Google Calendar is simply not connected yet', () => {
+    expect(hostAdapterUnavailableReason(EndeavorHost.googleCalendar)).toContain(
+      'not connected yet',
+    )
+  })
+})
+
+describe('an add form commits only once it means something', () => {
+  it('refuses a performance with no duration', () => {
+    expect(
+      isRelationDraftCommittable({
+        relation: 'performances',
+        draft: {
+          date: new Date(2026, 5, 18, 9),
+          durationSeconds: 0,
+          resolution: PerformResolution.complete,
+          notes: '',
+          rewardPoints: 0,
+          wasCompletedInSession: false,
+          editingIndex: null,
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('accepts one with a positive duration', () => {
+    expect(
+      isRelationDraftCommittable({
+        relation: 'performances',
+        draft: {
+          date: new Date(2026, 5, 18, 9),
+          durationSeconds: 1500,
+          resolution: PerformResolution.finished,
+          notes: '',
+          rewardPoints: 0,
+          wasCompletedInSession: true,
+          editingIndex: null,
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('accepts a defer with no reason — the reason is optional by design', () => {
+    expect(
+      isRelationDraftCommittable({
+        relation: 'defers',
+        draft: { target: new Date(2026, 5, 19, 9), reason: '' },
+      }),
+    ).toBe(true)
+  })
+
+  it('refuses a shadow missing either half of its identity', () => {
+    expect(
+      isRelationDraftCommittable({
+        relation: 'shadows',
+        draft: {
+          originalTitle: 'Team sync',
+          sourceIdentifier: '   ',
+          source: EndeavorHost.googleCalendar,
+          kind: EndeavorKind.calendarEvent,
+          group: '',
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('accepts a complete shadow', () => {
+    const shadow = makeShadow({
+      originalTitle: 'Team sync',
+      sourceIdentifier: 'gcal-9',
+      kind: EndeavorKind.calendarEvent,
+      source: EndeavorHost.googleCalendar,
+    })
+    expect(
+      isRelationDraftCommittable({
+        relation: 'shadows',
+        draft: {
+          originalTitle: shadow.originalTitle,
+          sourceIdentifier: shadow.sourceIdentifier,
+          source: shadow.source,
+          kind: shadow.kind,
+          group: '',
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('refuses a host form with nothing selected', () => {
+    expect(isRelationDraftCommittable({ relation: 'hosts', host: null })).toBe(
+      false,
+    )
+    expect(
+      isRelationDraftCommittable({
+        relation: 'hosts',
+        host: EndeavorHost.googleCalendar,
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/app/src/features/endeavorDetail/index.ts
+++ b/packages/app/src/features/endeavorDetail/index.ts
@@ -1,0 +1,17 @@
+/**
+ * The Endeavor Detail feature's public surface — a pure re-export barrel.
+ *
+ * `#30` imports from here rather than reaching into individual modules, so the
+ * boundary between the logic tier and the render tier is one line to read.
+ */
+export * from './EndeavorDetailCards'
+export * from './EndeavorDetailEditing'
+export * from './EndeavorDetailException'
+export * from './EndeavorDetailFeature'
+export * from './EndeavorDetailMocks'
+export * from './EndeavorDetailProducer'
+export * from './EndeavorDetailSelectors'
+export * from './EndeavorDetailShifters'
+export * from './EndeavorDetailState'
+export * from './EndeavorDuration'
+export * from './EndeavorRelations'

--- a/packages/app/src/features/find/FindAdapters.ts
+++ b/packages/app/src/features/find/FindAdapters.ts
@@ -1,0 +1,162 @@
+/**
+ * The Adapter layer — the port of canon's `KroUI/Find/FindAdapters.swift` and
+ * the `endeavorOperations(_:on:enabledFlags:onOperation:)` modifier it composes
+ * with (`KroUI`).
+ *
+ * Canon's Adapter is a *view* artifact: it turns one `Endeavor` into a row and
+ * attaches the vista's capability bindings as swipe actions, a context menu and
+ * a tap. Only the second half is business logic, and it is the half `#29` owns —
+ * `#30` renders the row. So this file is the **row action model**: given an
+ * endeavor and its vista's (already flag-resolved) capabilities, which actions
+ * exist, under which gesture, in which order.
+ *
+ * It is the only bridge from a vista to an operation. A surface never reads
+ * `vista.capabilities` and builds its own gesture list — that is exactly the
+ * duplication the issue's "adapters as the only vista→row bridge" constraint
+ * exists to prevent.
+ *
+ * ## Order is behaviour, not tidiness
+ *
+ * `EndeavorCapabilities.operations` is ordered, and `#9`'s own doc says a
+ * registry edit that reshuffles it *is a behaviour change*: declaration order is
+ * swipe-button order, and `buttonRow` carries an explicit `position`. Every
+ * accessor here preserves declaration order; only `buttonRowActions` re-sorts,
+ * and only by the position the binding itself declares (**stably** — two
+ * bindings sharing a position keep declaration order between them).
+ *
+ * ## Flag gating happens once, upstream
+ *
+ * A binding's `requires` is resolved by `resolveEndeavorCapabilities` (#9) at
+ * install time, against the flags cached on the slice. This file therefore takes
+ * capabilities that are **already** resolved and never sees a flag — which is
+ * what keeps it pure and keeps "the flag was on when we fetched" from becoming
+ * "the flag is on right now, at render time", a value a Selector cannot read.
+ */
+import {
+  type Endeavor,
+  type EndeavorCapabilities,
+  type EndeavorOperation,
+  type EndeavorOperationBinding,
+  type OperationGestureKind,
+  type OperationRole,
+  type OperationTint,
+  bindingsForGesture,
+  effectiveTintOf,
+} from '@kro/core'
+
+/** One actionable affordance on a row, with everything a renderer needs. */
+export interface EndeavorRowAction {
+  readonly operation: EndeavorOperation
+  readonly label: string
+  /** The SF Symbol name canon declares; #6 maps it onto the web icon set. */
+  readonly icon: string
+  readonly role: OperationRole
+  /** The tint after the role's default is applied (`effectiveTintOf`). */
+  readonly tint: OperationTint | null
+  /** `buttonRow` position; `null` for every other gesture. */
+  readonly position: number | null
+}
+
+/**
+ * One row, adapted: the endeavor plus the actions each gesture surfaces.
+ *
+ * Every list is present even when empty, so a renderer can read any gesture
+ * without an optional — the same reason `#9`'s Detail selectors give an empty
+ * array per section rather than omitting the key.
+ */
+export interface EndeavorRowAdapter {
+  /** The row's stable identity — the endeavor's id, so a keyed list is stable. */
+  readonly id: string
+  readonly endeavor: Endeavor
+  readonly leadingSwipeActions: readonly EndeavorRowAction[]
+  readonly trailingSwipeActions: readonly EndeavorRowAction[]
+  readonly contextMenuActions: readonly EndeavorRowAction[]
+  readonly buttonRowActions: readonly EndeavorRowAction[]
+  readonly prepOverlayActions: readonly EndeavorRowAction[]
+  /**
+   * The tap binding, or `null` when the vista declares none (or its flag is
+   * off). Canon allows at most one meaningful tap per row; where a vista
+   * declares several, the **first** wins, matching declaration order.
+   */
+  readonly tapAction: EndeavorRowAction | null
+}
+
+/** One binding, flattened into the render-ready action shape. */
+export const rowActionFrom = (
+  binding: EndeavorOperationBinding,
+): EndeavorRowAction => ({
+  operation: binding.operation,
+  label: binding.label,
+  icon: binding.icon,
+  role: binding.role,
+  tint: effectiveTintOf(binding),
+  position: binding.gesture.kind === 'buttonRow' ? binding.gesture.position : null,
+})
+
+/** Every action a capability set surfaces under one gesture, in declaration order. */
+export const rowActionsForGesture = (
+  capabilities: EndeavorCapabilities,
+  gesture: OperationGestureKind,
+): readonly EndeavorRowAction[] =>
+  bindingsForGesture(capabilities, gesture).map(rowActionFrom)
+
+/**
+ * `buttonRow` actions ordered by declared position, lowest first ("lower
+ * `position` renders first (leftmost)"). `Array.prototype.sort` is stable in
+ * every runtime this targets, so equal positions keep declaration order.
+ */
+const buttonRowActions = (
+  capabilities: EndeavorCapabilities,
+): readonly EndeavorRowAction[] =>
+  [...rowActionsForGesture(capabilities, 'buttonRow')].sort(
+    (left, right) => (left.position ?? 0) - (right.position ?? 0),
+  )
+
+/** Adapt one endeavor against one (already flag-resolved) capability set. */
+export const endeavorRowAdapter = (
+  endeavor: Endeavor,
+  capabilities: EndeavorCapabilities,
+): EndeavorRowAdapter => {
+  const tapActions = rowActionsForGesture(capabilities, 'tap')
+  return {
+    id: endeavor.id,
+    endeavor,
+    leadingSwipeActions: rowActionsForGesture(capabilities, 'swipeLeading'),
+    trailingSwipeActions: rowActionsForGesture(capabilities, 'swipeTrailing'),
+    contextMenuActions: rowActionsForGesture(capabilities, 'contextMenu'),
+    buttonRowActions: buttonRowActions(capabilities),
+    prepOverlayActions: rowActionsForGesture(capabilities, 'prepOverlay'),
+    tapAction: tapActions[0] ?? null,
+  }
+}
+
+/** Adapt a whole list. One capability set, one pass. */
+export const endeavorRowAdapters = (
+  endeavors: readonly Endeavor[],
+  capabilities: EndeavorCapabilities,
+): readonly EndeavorRowAdapter[] =>
+  endeavors.map((endeavor) => endeavorRowAdapter(endeavor, capabilities))
+
+/**
+ * Every operation the adapted row can actually raise, de-duplicated in
+ * declaration order. The coverage suite uses this to prove the adapter surfaces
+ * exactly what the vista declared — no more (an invented gesture) and no less
+ * (a declared binding the adapter forgot to expose).
+ */
+export const adaptedOperations = (
+  adapter: EndeavorRowAdapter,
+): readonly EndeavorOperation[] => {
+  const seen: EndeavorOperation[] = []
+  const all = [
+    ...adapter.leadingSwipeActions,
+    ...adapter.trailingSwipeActions,
+    ...adapter.contextMenuActions,
+    ...adapter.buttonRowActions,
+    ...adapter.prepOverlayActions,
+    ...(adapter.tapAction === null ? [] : [adapter.tapAction]),
+  ]
+  for (const action of all) {
+    if (!seen.includes(action.operation)) seen.push(action.operation)
+  }
+  return seen
+}

--- a/packages/app/src/features/find/FindException.ts
+++ b/packages/app/src/features/find/FindException.ts
@@ -1,0 +1,55 @@
+/**
+ * The Find/Tasks surface's typed failure union (`RC-8`, `UZF-8`).
+ *
+ * Canon spreads these across `FindFeature`'s silent lens failures and
+ * `TasksFeature`'s `OpError`/`onFailedDeleting`/`onFailedMarking` arms. They
+ * are folded into **one** union here for `RC-24`'s reason: each surface carries
+ * a single `load` lifecycle field, and a field typed as a union of unions would
+ * let a reader believe a fetch failure and an operation failure can coexist.
+ *
+ * `recoverable` says whether the surface should offer a retry: a failed write
+ * can be retried, an operation aimed at a row that is no longer in the pool
+ * cannot (retrying looks the same row up and misses again).
+ */
+import { type Exception, exception } from '@kro/core'
+
+export type FindException =
+  /** The vista's fetch failed. Canon keeps the previous rows and clears the spinner. */
+  | Exception<'fetchFailed'>
+  /** One row operation (complete, defer, delete, archive…) failed to persist. */
+  | Exception<'operationFailed'>
+  /** A bulk delete-all / archive-all could not finish every row. */
+  | Exception<'bulkOperationFailed'>
+  /** The operation names a row that is not in the installed pool — a stale tap. */
+  | Exception<'endeavorNotFound'>
+  /** The defensive `.rejected` fallback's landing shape (`RC-26`). */
+  | Exception<'unknown'>
+
+export const FindExceptions = {
+  fetchFailed: (reason: string): FindException =>
+    exception('fetchFailed', `Couldn't load your endeavors: ${reason}`, true),
+
+  operationFailed: (reason: string): FindException =>
+    exception('operationFailed', `Couldn't save that change: ${reason}`, true),
+
+  bulkOperationFailed: (reason: string): FindException =>
+    exception(
+      'bulkOperationFailed',
+      `Couldn't finish that on every visible endeavor: ${reason}`,
+      true,
+    ),
+
+  endeavorNotFound: (id: string): FindException =>
+    exception(
+      'endeavorNotFound',
+      `No endeavor with id '${id}' is on this surface.`,
+      false,
+    ),
+
+  unknown: (message: string): FindException =>
+    exception('unknown', message, true),
+} as const
+
+/** Narrows an unknown thrown value into this feature's `message` shape. */
+export const findExceptionMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)

--- a/packages/app/src/features/find/FindFeature.ts
+++ b/packages/app/src/features/find/FindFeature.ts
@@ -1,0 +1,389 @@
+/**
+ * The Find slice (`RC-1`, `RC-2`, `RC-23`, `RC-36`) — the port of canon's
+ * `FindFeature.swift` **and** `TasksFeature.swift`, which after the
+ * EndeavorsVista migration are the same surface over two different vistas.
+ *
+ * `State` lives in the sibling `FindState.ts` under `RC-1`'s size clause.
+ * Selectors, Shifters, the Adapter layer, the operations catalog and the
+ * Producers each own their own file; this one owns the **events** and the arms
+ * that route them.
+ *
+ * ## Names encode intent, never mechanism (`RC-2`)
+ *
+ * `on…` for a lifecycle signal, `userDid…` for user intent, `child…Delegated…`
+ * for a child talking back. There is no `fetchEndeavors` action — the effect is
+ * a Producer thunk whose type string is itself an event name, and whose three
+ * lifecycle phases are the one completion event (`UZF-3`).
+ *
+ * ## Where this reducer deliberately differs from canon's
+ *
+ * - **One slice, two surfaces.** Canon has `FindFeature` and `TasksFeature`;
+ *   here every arm carries the surface it acts on. See `FindState.ts` for why
+ *   the split would have been the duplication.
+ * - **Optimism is uniform.** Canon's Find removes/closes rows optimistically
+ *   while canon's Tasks additionally flips a per-row `inActivity` spinner. There
+ *   is no `inActivity` on this tier's `Endeavor` mutations path, so every local
+ *   operation applies its effect optimistically in `.pending` — through the
+ *   *same* `endeavorAfterOperation` the Producer persists — and the authoritative
+ *   row lands on `.fulfilled`.
+ * - **No `userDidTapRefresh` arm.** Canon guards a flag, flips it and returns an
+ *   effect; here `.pending` raises `load` from the thunk itself, so a separate
+ *   arm would set it twice.
+ * - **Cross-feature actions are intents, not delegates.** Canon sends
+ *   `.delegate(.startSession(…))` up to `MainFeature`. There is no parent store
+ *   here and a slice may not import a sibling (`RC-20`), so they are parked as
+ *   intent events and drained by `childIntentDelegatedConsumed`.
+ */
+import { type PayloadAction, createSlice } from '@reduxjs/toolkit'
+import type { EndeavorGroupingCriteria } from '@kro/core'
+import { FindExceptions } from './FindException'
+import {
+  type EndeavorOperationRequest,
+  type FindSurface,
+  endeavorAfterOperation,
+  isRemovingOperation,
+} from './FindOperations'
+import {
+  fetchFindEndeavorsThunk,
+  performBulkOperationThunk,
+  performEndeavorOperationThunk,
+  restoreFindLensThunk,
+} from './FindProducer'
+import {
+  withEndeavorReplaced,
+  withEndeavorsInstalled,
+  withFetchStarted,
+  withFilterToggled,
+  withFindException,
+  withFindViewLoaded,
+  withGroupExpanded,
+  withGroupsCollapsed,
+  withGrouping,
+  withIntentConsumed,
+  withIntentEnqueued,
+  withLensSnapshotRestored,
+  withRowsArchived,
+  withRowsRemoved,
+  withSearchQuery,
+  withShowArchivedToggled,
+  withTasksVistaSelected,
+  surfaceOf,
+} from './FindShifters'
+import type {
+  FindFilterToggle,
+  FindState,
+  TasksVistaSelection,
+} from './FindState'
+import { initialFindState } from './FindState'
+
+export type { FindState } from './FindState'
+export { initialFindState } from './FindState'
+
+export const findSlice = createSlice({
+  name: 'find',
+  initialState: initialFindState,
+  reducers: {
+    /**
+     * Lifecycle: one of the two surfaces mounted. Stamps the clock it will
+     * classify against and the feature flags its capability gating reads —
+     * canon caches the `endeavorDetail` flag at `.onViewLoaded` for exactly
+     * this reason, so a Selector never reaches for a flag service.
+     */
+    onViewLoaded(
+      state,
+      action: PayloadAction<{
+        surface: FindSurface
+        now: Date
+        enabledFlags: readonly string[]
+      }>,
+    ) {
+      Object.assign(state, withFindViewLoaded(state as FindState, action.payload))
+    },
+
+    /** User intent: All Tasks was pointed at a different `.tasks*` vista. */
+    userDidSelectTasksVista(
+      state,
+      action: PayloadAction<{
+        selection: TasksVistaSelection
+        customTitle?: string | null
+      }>,
+    ) {
+      Object.assign(state, withTasksVistaSelected(state as FindState, action.payload))
+    },
+
+    /** User intent: the search field changed. Canon persists it with the lens. */
+    userDidChangeSearchQuery(
+      state,
+      action: PayloadAction<{ surface: FindSurface; query: string }>,
+    ) {
+      Object.assign(state, withSearchQuery(state as FindState, action.payload))
+    },
+
+    /** User intent: one kind/host/status/calendar chip flipped. */
+    userDidToggleFilter(
+      state,
+      action: PayloadAction<{ surface: FindSurface; toggle: FindFilterToggle }>,
+    ) {
+      Object.assign(state, withFilterToggled(state as FindState, action.payload))
+    },
+
+    /** User intent: the Archived chip flipped. */
+    userDidToggleShowArchived(
+      state,
+      action: PayloadAction<{ surface: FindSurface }>,
+    ) {
+      Object.assign(
+        state,
+        withShowArchivedToggled(state as FindState, action.payload),
+      )
+    },
+
+    /** User intent: the grouping picker changed. */
+    userDidSelectGrouping(
+      state,
+      action: PayloadAction<{
+        surface: FindSurface
+        grouping: EndeavorGroupingCriteria
+      }>,
+    ) {
+      Object.assign(state, withGrouping(state as FindState, action.payload))
+    },
+
+    /**
+     * User intent: a group's "Show all" was pressed, or its header tapped open.
+     * Canon has `userDidTapExpand` and `userDidTapShowAll` land on the same
+     * mutation; one arm carries both because the two are the same request.
+     */
+    userDidTapExpandGroup(
+      state,
+      action: PayloadAction<{ surface: FindSurface; groupKey: string }>,
+    ) {
+      Object.assign(state, withGroupExpanded(state as FindState, action.payload))
+    },
+
+    /** User intent: the focused group was closed, re-clipping every group. */
+    userDidTapCollapseGroups(
+      state,
+      action: PayloadAction<{ surface: FindSurface }>,
+    ) {
+      Object.assign(state, withGroupsCollapsed(state as FindState, action.payload))
+    },
+
+    /**
+     * A child talking back: the feature that owns an intent has handled it, so
+     * the request leaves the queue. By id — two Start taps on two rows are two
+     * intents, and draining by position would acknowledge the wrong one.
+     */
+    childIntentDelegatedConsumed(
+      state,
+      action: PayloadAction<{ intentId: number }>,
+    ) {
+      Object.assign(state, withIntentConsumed(state as FindState, action.payload))
+    },
+  },
+
+  extraReducers: (builder) => {
+    builder
+      // ------------------------------------------------------- the fetch
+      .addCase(fetchFindEndeavorsThunk.pending, (state, action) => {
+        Object.assign(
+          state,
+          withFetchStarted(state as FindState, {
+            surface: action.meta.arg.surface,
+          }),
+        )
+      })
+      .addCase(fetchFindEndeavorsThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(
+            state,
+            withEndeavorsInstalled(state as FindState, {
+              surface: result.value.surface,
+              endeavors: result.value.endeavors,
+              now: result.value.now,
+            }),
+          )
+        } else {
+          Object.assign(
+            state,
+            withFindException(state as FindState, {
+              surface: action.meta.arg.surface,
+              exception: result.error,
+            }),
+          )
+        }
+      })
+      .addCase(fetchFindEndeavorsThunk.rejected, (state, action) => {
+        // Cancellation is the only silent exit (`UZF-14`).
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withFindException(state as FindState, {
+            surface: action.meta.arg.surface,
+            exception: FindExceptions.unknown(
+              action.error.message ?? 'Unknown error',
+            ),
+          }),
+        )
+      })
+
+      // ------------------------------------------------ the lens restore
+      .addCase(restoreFindLensThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        Object.assign(
+          state,
+          withLensSnapshotRestored(state as FindState, {
+            surface: action.meta.arg.surface,
+            lens: result.ok ? result.value : null,
+          }),
+        )
+      })
+      .addCase(restoreFindLensThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        // A restore that cannot answer still has to *settle*: leaving the
+        // surface waiting would suppress its filter-driven empty state forever.
+        Object.assign(
+          state,
+          withLensSnapshotRestored(state as FindState, {
+            surface: action.meta.arg.surface,
+            lens: null,
+          }),
+        )
+      })
+
+      // -------------------------------------------------- one operation
+      .addCase(performEndeavorOperationThunk.pending, (state, action) => {
+        const request: EndeavorOperationRequest = action.meta.arg
+        if (isRemovingOperation(request.operation)) {
+          Object.assign(
+            state,
+            withRowsRemoved(state as FindState, {
+              surface: request.surface,
+              endeavorIds: [request.endeavorId],
+            }),
+          )
+          return
+        }
+        const surface = surfaceOf(state as FindState, request.surface)
+        const target = surface.endeavors.find(
+          (endeavor) => endeavor.id === request.endeavorId,
+        )
+        if (target === undefined) return
+        Object.assign(
+          state,
+          withEndeavorReplaced(state as FindState, {
+            surface: request.surface,
+            endeavor: endeavorAfterOperation(target, request),
+          }),
+        )
+      })
+      .addCase(performEndeavorOperationThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (!result.ok) {
+          Object.assign(
+            state,
+            withFindException(state as FindState, {
+              surface: action.meta.arg.surface,
+              exception: result.error,
+            }),
+          )
+          return
+        }
+        const outcome = result.value
+        switch (outcome.kind) {
+          case 'mutated':
+            Object.assign(
+              state,
+              withEndeavorReplaced(state as FindState, {
+                surface: outcome.surface,
+                endeavor: outcome.endeavor,
+              }),
+            )
+            return
+          case 'removed':
+            Object.assign(
+              state,
+              withRowsRemoved(state as FindState, {
+                surface: outcome.surface,
+                endeavorIds: [outcome.endeavorId],
+              }),
+            )
+            return
+          default:
+            Object.assign(
+              state,
+              withIntentEnqueued(state as FindState, {
+                surface: outcome.surface,
+                operation: outcome.operation,
+                endeavorId: outcome.endeavorId,
+              }),
+            )
+        }
+      })
+      .addCase(performEndeavorOperationThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withFindException(state as FindState, {
+            surface: action.meta.arg.surface,
+            exception: FindExceptions.unknown(
+              action.error.message ?? 'Unknown error',
+            ),
+          }),
+        )
+      })
+
+      // ------------------------------------- delete-all / archive-all
+      .addCase(performBulkOperationThunk.pending, (state, action) => {
+        const request = action.meta.arg
+        Object.assign(
+          state,
+          request.operation === 'delete'
+            ? withRowsRemoved(state as FindState, {
+                surface: request.surface,
+                endeavorIds: request.endeavorIds,
+              })
+            : withRowsArchived(state as FindState, {
+                surface: request.surface,
+                endeavorIds: request.endeavorIds,
+              }),
+        )
+      })
+      .addCase(performBulkOperationThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) return
+        Object.assign(
+          state,
+          withFindException(state as FindState, {
+            surface: action.meta.arg.surface,
+            exception: result.error,
+          }),
+        )
+      })
+      .addCase(performBulkOperationThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withFindException(state as FindState, {
+            surface: action.meta.arg.surface,
+            exception: FindExceptions.unknown(
+              action.error.message ?? 'Unknown error',
+            ),
+          }),
+        )
+      })
+  },
+})
+
+export const {
+  childIntentDelegatedConsumed,
+  onViewLoaded,
+  userDidChangeSearchQuery,
+  userDidSelectGrouping,
+  userDidSelectTasksVista,
+  userDidTapCollapseGroups,
+  userDidTapExpandGroup,
+  userDidToggleFilter,
+  userDidToggleShowArchived,
+} = findSlice.actions

--- a/packages/app/src/features/find/FindGrouping.ts
+++ b/packages/app/src/features/find/FindGrouping.ts
@@ -1,0 +1,395 @@
+/**
+ * The grouping engine — the port of canon's `Array<Endeavor>.grouped(by:)`,
+ * `ListGroup.sorted(using:)` and `.limited(by:)`
+ * (`KroCore/Model/Endeavor/Endeavor.swift`) plus the `EndeavorGroupingCriteria`
+ * group/comparison tables (`KroCore/Model/Endeavor/EndeavorCriteria.swift`).
+ *
+ * `@kro/core`'s `EndeavorCriteria.ts` ported the **declaration** of the four
+ * criteria and said, in its own header, that the engine *"belongs to whichever
+ * child first renders a grouped list (#16 / #29)"*. #16 built Do's lanes rather
+ * than groups, so this is that child, and this is that engine. It lives in the
+ * feature lane rather than in `@kro/core` because `domain/**` and `vistas/**`
+ * are other children's lanes; if a later child moves it down, every call site
+ * here imports it by name and nothing else changes.
+ *
+ * ## Everything here is pure
+ *
+ * No clock, no store, no service. `dueSection` reads only the due date's own
+ * local hour — canon reads `Calendar.current.dateComponents([.hour], from: due)`
+ * and never consults `now` — so a group is answerable at any instant.
+ *
+ * ## The two rules that surprise people
+ *
+ * - **`host` grouping puts one endeavor in several groups.** Canon's
+ *   `groups(_:)` for `.host` zips `hostedBy` into one excerpt per host, so a
+ *   task mirrored to Reminders *and* Kro appears under both. Every other
+ *   criterion yields exactly one excerpt. A host-less endeavor therefore
+ *   appears in **no** group under `.host` — canon's behaviour, preserved.
+ * - **Sorting is chunked, not a single comparator.** Canon walks the sorting
+ *   parameters in order; each parameter sorts only the rows that *have* a value
+ *   for its criterion, appends them, and hands the value-less remainder to the
+ *   next parameter. Rows with no value for any parameter keep their arrival
+ *   order at the end. A plain `sort` with fallbacks would reorder them.
+ */
+import {
+  type Endeavor,
+  EndeavorGroupingCriteria,
+  type EndeavorSortingCriteria,
+  EndeavorSortingCriteria as SortBy,
+  type EndeavorSortingParameter,
+  assertNever,
+  compareEndeavorStatuses,
+  descendingBy,
+  ascendingBy,
+  endeavorHostDisplayName,
+  endeavorKindDisplayName,
+  endeavorStatusDisplayName,
+  endeavorStatusFromRawValue,
+} from '@kro/core'
+
+// ---------------------------------------------------------------------------
+// DaySection
+// ---------------------------------------------------------------------------
+
+/**
+ * Canon's `DaySection` — the six wall-clock bands a due time falls into, plus
+ * `anytime` for an endeavor with no due date at all.
+ */
+export const DaySection = {
+  earlyMorning: 'earlyMorning',
+  morning: 'morning',
+  afternoon: 'afternoon',
+  evening: 'evening',
+  night: 'night',
+  lateNight: 'lateNight',
+  anytime: 'anytime',
+} as const
+
+export type DaySection = (typeof DaySection)[keyof typeof DaySection]
+
+/** Every band, in canon declaration order. */
+export const daySections: readonly DaySection[] = [
+  DaySection.earlyMorning,
+  DaySection.morning,
+  DaySection.afternoon,
+  DaySection.evening,
+  DaySection.night,
+  DaySection.lateNight,
+  DaySection.anytime,
+]
+
+/** `DaySection(rawValue:)` — narrows a raw group key, or `null`. */
+export const daySectionFromRawValue = (raw: string): DaySection | null =>
+  daySections.find((section) => section === raw) ?? null
+
+/**
+ * `DaySection.orderIndex` — the sort key. `anytime` is **-1**, so undated work
+ * leads the list rather than trailing it; that is canon's ordering, not an
+ * accident of declaration order.
+ */
+export const daySectionOrderIndex = (section: DaySection): number => {
+  switch (section) {
+    case DaySection.anytime:
+      return -1
+    case DaySection.earlyMorning:
+      return 0
+    case DaySection.morning:
+      return 1
+    case DaySection.afternoon:
+      return 2
+    case DaySection.evening:
+      return 3
+    case DaySection.night:
+      return 4
+    case DaySection.lateNight:
+      return 5
+    default:
+      return assertNever(section)
+  }
+}
+
+/** `DaySection.displayName`. */
+export const daySectionDisplayName = (section: DaySection): string => {
+  switch (section) {
+    case DaySection.earlyMorning:
+      return 'Early Morning'
+    case DaySection.morning:
+      return 'Morning'
+    case DaySection.afternoon:
+      return 'Afternoon'
+    case DaySection.evening:
+      return 'Evening'
+    case DaySection.night:
+      return 'Night'
+    case DaySection.lateNight:
+      return 'Late Night'
+    case DaySection.anytime:
+      return 'Anytime'
+    default:
+      return assertNever(section)
+  }
+}
+
+/**
+ * `Endeavor.dueSection` — canon's hour bands, boundaries included:
+ * 4–7 early morning, 7–12 morning, 12–17 afternoon, 17–20 evening,
+ * 20–24 night, 0–4 late night. No due date at all is `anytime`.
+ */
+export const dueSectionOf = (endeavor: Endeavor): DaySection => {
+  const due = endeavor.due
+  if (due === null) return DaySection.anytime
+  const hour = due.getHours()
+  if (hour >= 4 && hour < 7) return DaySection.earlyMorning
+  if (hour >= 7 && hour < 12) return DaySection.morning
+  if (hour >= 12 && hour < 17) return DaySection.afternoon
+  if (hour >= 17 && hour < 20) return DaySection.evening
+  if (hour >= 20 && hour < 24) return DaySection.night
+  if (hour >= 0 && hour < 4) return DaySection.lateNight
+  return DaySection.anytime
+}
+
+// ---------------------------------------------------------------------------
+// Groups
+// ---------------------------------------------------------------------------
+
+/**
+ * One rendered group. `totalCount` is the size **before** any display limit, so
+ * a trimmed group can still say "7 of 23" without re-deriving it, and
+ * `isTrimmed` is what the "Show all" affordance keys on.
+ */
+export interface EndeavorRowGroup {
+  /** The stable group key — canon's raw value (a status, a host, a kind, a band). */
+  readonly key: string
+  /** The group's display title. */
+  readonly title: string
+  readonly endeavors: readonly Endeavor[]
+  /** How many rows the group holds before the display limit. */
+  readonly totalCount: number
+  /** True when the display limit dropped at least one row. */
+  readonly isTrimmed: boolean
+}
+
+/**
+ * Canon's `GroupForTasks.state`: `clipped` while every group shows at most the
+ * limit, `expanded` for the one group the user opened, `collapsed` for its
+ * siblings while it is open.
+ */
+export const EndeavorGroupDisplayState = {
+  clipped: 'clipped',
+  expanded: 'expanded',
+  collapsed: 'collapsed',
+} as const
+
+export type EndeavorGroupDisplayState =
+  (typeof EndeavorGroupDisplayState)[keyof typeof EndeavorGroupDisplayState]
+
+/**
+ * Canon's `GroupForTasks.sortingParameters` default: most recently completed
+ * first, then soonest due, then most recently created. The chunked walk in
+ * `sortEndeavorsByParameters` is what makes that sequence meaningful.
+ */
+export const DEFAULT_GROUP_SORTING: readonly EndeavorSortingParameter[] = [
+  descendingBy(SortBy.completedOn),
+  ascendingBy(SortBy.due),
+  descendingBy(SortBy.createdAt),
+]
+
+/** Canon's `EndeavorSortingCriteria.valuePath` — `null` when the row has none. */
+const sortingValueOf = (
+  criteria: EndeavorSortingCriteria,
+  endeavor: Endeavor,
+): number | null => {
+  switch (criteria) {
+    case SortBy.due:
+      return endeavor.due?.getTime() ?? null
+    case SortBy.duration:
+      return endeavor.duration
+    case SortBy.createdAt:
+      return endeavor.createdAt?.getTime() ?? null
+    case SortBy.completedOn:
+      return endeavor.completed?.getTime() ?? null
+    default:
+      return assertNever(criteria)
+  }
+}
+
+/**
+ * Canon's chunked sort. Each parameter orders only the rows that carry a value
+ * for its criterion; the rest fall through to the next parameter, and whatever
+ * no parameter could order keeps its arrival order at the end.
+ */
+export const sortEndeavorsByParameters = (
+  endeavors: readonly Endeavor[],
+  parameters: readonly EndeavorSortingParameter[] = DEFAULT_GROUP_SORTING,
+): readonly Endeavor[] => {
+  let remaining = [...endeavors]
+  const sorted: Endeavor[] = []
+
+  for (const parameter of parameters) {
+    if (remaining.length === 0) break
+    const withValue = remaining.filter(
+      (endeavor) => sortingValueOf(parameter.criteria, endeavor) !== null,
+    )
+    withValue.sort((left, right) => {
+      const leftValue = sortingValueOf(parameter.criteria, left) ?? 0
+      const rightValue = sortingValueOf(parameter.criteria, right) ?? 0
+      return parameter.direction === 'ascending'
+        ? leftValue - rightValue
+        : rightValue - leftValue
+    })
+    sorted.push(...withValue)
+    remaining = remaining.filter(
+      (endeavor) => sortingValueOf(parameter.criteria, endeavor) === null,
+    )
+  }
+
+  sorted.push(...remaining)
+  return sorted
+}
+
+/** One `(key, title)` membership. Canon's `EndeavorGroupingExcerpt`. */
+interface GroupingExcerpt {
+  readonly key: string
+  readonly title: string
+}
+
+/** Canon's `EndeavorGroupingCriteria.groups(_:)`. `.host` yields one per host. */
+const excerptsFor = (
+  criteria: EndeavorGroupingCriteria,
+  endeavor: Endeavor,
+): readonly GroupingExcerpt[] => {
+  switch (criteria) {
+    case EndeavorGroupingCriteria.status:
+      return [
+        {
+          key: endeavor.status,
+          title: endeavorStatusDisplayName(endeavor.status),
+        },
+      ]
+    case EndeavorGroupingCriteria.host:
+      return endeavor.hostedBy.map((host) => ({
+        key: host,
+        title: endeavorHostDisplayName(host),
+      }))
+    case EndeavorGroupingCriteria.kind:
+      return [
+        { key: endeavor.kind, title: endeavorKindDisplayName(endeavor.kind) },
+      ]
+    case EndeavorGroupingCriteria.dueSection: {
+      const section = dueSectionOf(endeavor)
+      return [{ key: section, title: daySectionDisplayName(section) }]
+    }
+    default:
+      return assertNever(criteria)
+  }
+}
+
+/** Canon's `EndeavorGroupingCriteria.comparison` over two group keys. */
+const compareGroupKeys = (
+  criteria: EndeavorGroupingCriteria,
+  left: string,
+  right: string,
+): number => {
+  switch (criteria) {
+    case EndeavorGroupingCriteria.status: {
+      const leftStatus = endeavorStatusFromRawValue(left)
+      const rightStatus = endeavorStatusFromRawValue(right)
+      if (leftStatus === null || rightStatus === null) return 0
+      return compareEndeavorStatuses(leftStatus, rightStatus)
+    }
+    case EndeavorGroupingCriteria.host:
+    case EndeavorGroupingCriteria.kind:
+      return left < right ? -1 : left > right ? 1 : 0
+    case EndeavorGroupingCriteria.dueSection: {
+      const leftSection = daySectionFromRawValue(left)
+      const rightSection = daySectionFromRawValue(right)
+      if (leftSection === null || rightSection === null) return 0
+      return (
+        daySectionOrderIndex(leftSection) - daySectionOrderIndex(rightSection)
+      )
+    }
+    default:
+      return assertNever(criteria)
+  }
+}
+
+/**
+ * `grouped(by:)` then `sorted()` — partition into groups in first-appearance
+ * order, sort each group's rows by `parameters`, then order the groups
+ * themselves by the criterion's own comparison.
+ */
+export const groupEndeavors = (
+  endeavors: readonly Endeavor[],
+  criteria: EndeavorGroupingCriteria,
+  parameters: readonly EndeavorSortingParameter[] = DEFAULT_GROUP_SORTING,
+): readonly EndeavorRowGroup[] => {
+  const buckets = new Map<string, { title: string; rows: Endeavor[] }>()
+
+  for (const endeavor of endeavors) {
+    for (const excerpt of excerptsFor(criteria, endeavor)) {
+      const bucket = buckets.get(excerpt.key)
+      if (bucket === undefined) {
+        buckets.set(excerpt.key, { title: excerpt.title, rows: [endeavor] })
+      } else {
+        bucket.rows.push(endeavor)
+      }
+    }
+  }
+
+  return [...buckets.entries()]
+    .map(([key, bucket]): EndeavorRowGroup => {
+      const rows = sortEndeavorsByParameters(bucket.rows, parameters)
+      return {
+        key,
+        title: bucket.title,
+        endeavors: rows,
+        totalCount: rows.length,
+        isTrimmed: false,
+      }
+    })
+    .sort((left, right) => compareGroupKeys(criteria, left.key, right.key))
+}
+
+/**
+ * `limited(by:)` — keep the first `limit` rows and record that the rest exist.
+ * A `null` limit is "no limit", matching `PresentationStyle.itemLimit`.
+ */
+export const limitGroup = (
+  group: EndeavorRowGroup,
+  limit: number | null,
+): EndeavorRowGroup => {
+  if (limit === null || group.endeavors.length <= limit) {
+    return { ...group, isTrimmed: false }
+  }
+  return {
+    ...group,
+    endeavors: group.endeavors.slice(0, limit),
+    isTrimmed: true,
+  }
+}
+
+/**
+ * The display rule canon's `applyReprocess` step 4/5 encodes: while **no**
+ * group is expanded every group is clipped to the vista's `itemLimit`; once one
+ * group is expanded it shows in full and the limit is lifted from its siblings
+ * too — canon skips `limited(by:)` entirely when `currentFocusGroup != nil`.
+ */
+export const limitGroups = (
+  groups: readonly EndeavorRowGroup[],
+  limit: number | null,
+  expandedGroupKey: string | null,
+): readonly EndeavorRowGroup[] =>
+  expandedGroupKey === null
+    ? groups.map((group) => limitGroup(group, limit))
+    : groups.map((group) => ({ ...group, isTrimmed: false }))
+
+/** Canon's `GroupForTasks.state` for one group, given the expanded key. */
+export const groupDisplayState = (
+  group: EndeavorRowGroup,
+  expandedGroupKey: string | null,
+): EndeavorGroupDisplayState => {
+  if (expandedGroupKey === null) return EndeavorGroupDisplayState.clipped
+  return group.key === expandedGroupKey
+    ? EndeavorGroupDisplayState.expanded
+    : EndeavorGroupDisplayState.collapsed
+}

--- a/packages/app/src/features/find/FindMocks.ts
+++ b/packages/app/src/features/find/FindMocks.ts
@@ -1,0 +1,284 @@
+/**
+ * Canned `FindState` variants and the endeavor fixtures behind them (`RC-31`,
+ * `UZF-18`).
+ *
+ * Every test in this feature reads its state from here — a `State` is never
+ * constructed inline, so the set of situations the two browsing surfaces claim
+ * to support is enumerable in one file, and `#30`'s stories will consume the
+ * same variants the reducer tests do.
+ *
+ * All times are built from `FIND_REFERENCE_NOW`, a fixed local instant, so
+ * nothing here depends on when the suite runs. The fixtures deliberately span
+ * every axis the surfaces filter on — kind, host, status, archived, due band —
+ * because a grouping or filter assertion is only worth something against a set
+ * that can actually be split.
+ */
+import type { Endeavor } from '@kro/core'
+import {
+  EndeavorHost,
+  EndeavorKind,
+  EndeavorStatus,
+  makeEndeavor,
+  makePerform,
+  PerformResolution,
+} from '@kro/core'
+import { FindExceptions } from './FindException'
+import type { EndeavorIntent } from './FindOperations'
+import type { FindState, FindSurfaceState } from './FindState'
+import { initialFindState } from './FindState'
+
+/** A fixed Thursday morning. Every fixture below is relative to it. */
+export const FIND_REFERENCE_NOW = new Date(2026, 5, 18, 9, 40, 0, 0)
+
+/** `FIND_REFERENCE_NOW`'s calendar day at a given local hour and minute. */
+export const findAt = (hour: number, minute = 0): Date =>
+  new Date(2026, 5, 18, hour, minute, 0, 0)
+
+/**
+ * Seven endeavors spanning the axes the surfaces filter and group on.
+ *
+ * Names say what each one is *for*, because a grouping assertion reads far
+ * better as "the morning task" than as "endeavor 3".
+ */
+export const findEndeavorMocks = {
+  /** Task, local host, pending, due mid-morning. The ordinary row. */
+  morningTask: makeEndeavor({
+    id: 'task-morning',
+    title: 'Prepare quarterly slides',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.pending,
+    due: findAt(9, 0),
+    createdAt: findAt(7, 0),
+    hostedBy: [EndeavorHost.local],
+  }),
+
+  /** Task, Kro host, ongoing, due in the afternoon. */
+  afternoonTask: makeEndeavor({
+    id: 'task-afternoon',
+    title: 'Review the auth flow PR',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.ongoing,
+    due: findAt(14, 30),
+    createdAt: findAt(8, 0),
+    hostedBy: [EndeavorHost.supabase],
+  }),
+
+  /** Task on two hosts — the multi-host row the host filter must not hide. */
+  mirroredTask: makeEndeavor({
+    id: 'task-mirrored',
+    title: 'File the expense report',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.pending,
+    due: findAt(19, 15),
+    createdAt: findAt(6, 30),
+    hostedBy: [EndeavorHost.local, EndeavorHost.appleReminders],
+  }),
+
+  /** Task with no due date at all — the `anytime` band. */
+  undatedTask: makeEndeavor({
+    id: 'task-undated',
+    title: 'Read the design doc',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.pending,
+    createdAt: findAt(5, 0),
+    hostedBy: [EndeavorHost.local],
+  }),
+
+  /** Closed task — invisible unless Show Archived is on. */
+  archivedTask: makeEndeavor({
+    id: 'task-archived',
+    title: 'Renew the domain',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.closed,
+    due: findAt(8, 0),
+    completed: findAt(8, 30),
+    createdAt: findAt(4, 0),
+    hostedBy: [EndeavorHost.local],
+  }),
+
+  /** Calendar event — no due date by matrix, so it never defers. */
+  teamSync: makeEndeavor({
+    id: 'event-sync',
+    title: 'Team sync',
+    kind: EndeavorKind.calendarEvent,
+    status: EndeavorStatus.planned,
+    start: findAt(11, 0),
+    duration: 3600,
+    createdAt: findAt(3, 0),
+    hostedBy: [EndeavorHost.googleCalendar],
+  }),
+
+  /** Habit — session-trackable, never due-dated. */
+  stretch: makeEndeavor({
+    id: 'habit-stretch',
+    title: 'Stretch',
+    kind: EndeavorKind.habit,
+    status: EndeavorStatus.pending,
+    createdAt: findAt(2, 0),
+    hostedBy: [EndeavorHost.local],
+    performances: [
+      makePerform({
+        date: findAt(7, 30),
+        duration: 900,
+        resolution: PerformResolution.finished,
+        wasCompletedInSession: true,
+        rewardPoints: 3,
+      }),
+    ],
+  }),
+} as const
+
+/** Every fixture, in declaration order. */
+export const allFindEndeavorMocks: readonly Endeavor[] = Object.values(
+  findEndeavorMocks,
+)
+
+/**
+ * Nine tasks in one status, so the seven-per-group display limit has something
+ * to trim. Two beyond the limit is enough to prove both the cut and the count.
+ */
+export const nineOpenTasks: readonly Endeavor[] = Array.from(
+  { length: 9 },
+  (_unused, index) =>
+    makeEndeavor({
+      id: `task-bulk-${index}`,
+      title: `Bulk task ${index}`,
+      kind: EndeavorKind.task,
+      status: EndeavorStatus.pending,
+      due: findAt(9, index),
+      createdAt: findAt(6, index),
+      hostedBy: [EndeavorHost.local],
+    }),
+)
+
+const loadedSurface = (
+  base: FindSurfaceState,
+  endeavors: readonly Endeavor[],
+  enabledFlags: readonly string[] = [],
+): FindSurfaceState => ({
+  ...base,
+  load: { kind: 'loaded' },
+  endeavors,
+  clockAnchor: FIND_REFERENCE_NOW,
+  isLensRestored: true,
+  enabledFlags,
+})
+
+const intent: EndeavorIntent = {
+  id: 1,
+  operation: 'startSession',
+  endeavorId: findEndeavorMocks.morningTask.id,
+  surface: 'find',
+}
+
+export const findStateMocks = {
+  /** Nothing asked for yet. */
+  idle: initialFindState,
+
+  /** A read is in flight on Find. */
+  loading: {
+    ...initialFindState,
+    find: { ...initialFindState.find, load: { kind: 'loading' } },
+  } satisfies FindState as FindState,
+
+  /** The typical loaded Find surface: every fixture, no filter touched. */
+  loaded: {
+    ...initialFindState,
+    find: loadedSurface(initialFindState.find, allFindEndeavorMocks),
+  } satisfies FindState as FindState,
+
+  /** Loaded, with the `endeavorDetail` flag on — the tap binding exists. */
+  loadedWithDetailFlag: {
+    ...initialFindState,
+    find: loadedSurface(initialFindState.find, allFindEndeavorMocks, [
+      'endeavorDetail',
+    ]),
+  } satisfies FindState as FindState,
+
+  /** Loaded but every kind, host and status hidden — canon's "No Filters Selected". */
+  everythingHidden: {
+    ...initialFindState,
+    find: {
+      ...loadedSurface(initialFindState.find, allFindEndeavorMocks),
+      lens: {
+        ...initialFindState.find.lens,
+        hiddenKinds: [
+          'task',
+          'reminder',
+          'calendarEvent',
+          'habit',
+          'background',
+          'behavior',
+          'blueprint',
+        ],
+        hiddenHosts: [
+          'supabase',
+          'local',
+          'appleCalendar',
+          'googleCalendar',
+          'outlookCalendar',
+          'appleReminders',
+        ],
+        hiddenStatuses: [
+          'pending',
+          'planned',
+          'ongoing',
+          'paused',
+          'blocked',
+          'delegated',
+          'reviewing',
+          'qa',
+          'closed',
+          'skipped',
+        ],
+      },
+    },
+  } satisfies FindState as FindState,
+
+  /** Loaded, with a search that matches nothing — canon's "No Results". */
+  searchWithNoMatches: {
+    ...initialFindState,
+    find: {
+      ...loadedSurface(initialFindState.find, allFindEndeavorMocks),
+      lens: { ...initialFindState.find.lens, searchQuery: 'zzzz' },
+    },
+  } satisfies FindState as FindState,
+
+  /** The read failed, and the previously loaded rows are still shown. */
+  failedAfterLoad: {
+    ...initialFindState,
+    find: {
+      ...loadedSurface(initialFindState.find, allFindEndeavorMocks),
+      load: { kind: 'failed', exception: FindExceptions.fetchFailed('offline') },
+    },
+  } satisfies FindState as FindState,
+
+  /** All Tasks loaded with the default vista and nine same-status rows. */
+  tasksLoaded: {
+    ...initialFindState,
+    tasks: loadedSurface(initialFindState.tasks, nineOpenTasks),
+  } satisfies FindState as FindState,
+
+  /** All Tasks with one group expanded, so the limit is lifted. */
+  tasksExpanded: {
+    ...initialFindState,
+    tasks: {
+      ...loadedSurface(initialFindState.tasks, nineOpenTasks),
+      expandedGroupKey: EndeavorStatus.pending,
+    },
+  } satisfies FindState as FindState,
+
+  /** All Tasks over the mixed fixture set — several groups, several kinds. */
+  tasksMixed: {
+    ...initialFindState,
+    tasks: loadedSurface(initialFindState.tasks, allFindEndeavorMocks),
+  } satisfies FindState as FindState,
+
+  /** One cross-feature request parked, awaiting the session surface. */
+  withPendingIntent: {
+    ...initialFindState,
+    find: loadedSurface(initialFindState.find, allFindEndeavorMocks),
+    intents: [intent],
+    nextIntentId: 2,
+  } satisfies FindState as FindState,
+} as const

--- a/packages/app/src/features/find/FindOperations.ts
+++ b/packages/app/src/features/find/FindOperations.ts
@@ -1,0 +1,313 @@
+/**
+ * The operations catalog — every `EndeavorOperation` a vista can declare,
+ * paired with the concrete thing this repo does about it.
+ *
+ * `EndeavorCapabilities` (#9) is the *declaration*: a vista says a row can be
+ * completed, deferred, archived, started, triaged. Canon realizes those in
+ * `KroUI`'s `endeavorOperations(_:on:enabledFlags:onOperation:)` modifier, which
+ * hands the operation up to the Screen, which routes it — to a local mutation,
+ * or to `MainFeature` as a delegate. This file is that routing table, lifted out
+ * of any view so it is **testable without one**: the capability-coverage suite
+ * walks every vista in the registry and asserts that no declared operation is
+ * unbound (acceptance criterion 1).
+ *
+ * ## Two handlings, and why the split is not a shortcut
+ *
+ * - **`local`** — the mutation is this feature's own: it rewrites the endeavor
+ *   row through `extra.localStore` and the domain's guarded `with…` helpers.
+ *   `FindProducer.performEndeavorOperationThunk` executes it.
+ * - **`intent`** — the action belongs to *another* feature (a focus session,
+ *   Triage, the Detail/Edit surface, Do's suggestion lane) or to a Service this
+ *   repo has not stood up yet. A slice may not import a sibling slice (`RC-20`),
+ *   and a Producer may not reach into one either, so the operation resolves into
+ *   an **intent event** parked on the slice and consumed by whoever owns it. The
+ *   queue is drained by a named event (`childIntentDelegatedConsumed`), never by
+ *   a view noticing a boolean and resetting it (`UZF-3`, and the one-shot rule in
+ *   `spec/architecture/web.md` § 4).
+ *
+ * An intent is **not** a silent drop: the operation still resolves `ok`, the
+ * intent is observable through `selectFindPendingIntents`, and the coverage test
+ * asserts every one of them lands. What each intent's consumer is (and which are
+ * not built yet) is named per entry below and in the PR body.
+ */
+import {
+  type Endeavor,
+  type EndeavorOperation,
+  EndeavorOperation as Operation,
+  EndeavorStatus,
+  type EndeavorsVista,
+  assertNever,
+  endeavorOperations,
+  withDeferred,
+} from '@kro/core'
+
+/** Which of the two browse surfaces a request came from. */
+export const FindSurface = {
+  /** The `.find` vista — the all-endeavors browser. */
+  find: 'find',
+  /** Whichever `.tasks*` vista the All Tasks surface is installed with. */
+  tasks: 'tasks',
+} as const
+
+export type FindSurface = (typeof FindSurface)[keyof typeof FindSurface]
+
+/** Every surface key, for a suite that walks both. */
+export const findSurfaces: readonly FindSurface[] = [
+  FindSurface.find,
+  FindSurface.tasks,
+]
+
+/** How this repo answers one declared operation. */
+export const OperationHandling = {
+  /** This feature persists it itself. */
+  local: 'local',
+  /** It resolves into a cross-feature intent event. */
+  intent: 'intent',
+} as const
+
+export type OperationHandling =
+  (typeof OperationHandling)[keyof typeof OperationHandling]
+
+/** What a `local` operation writes to the installed row. */
+export const OperationEffect = {
+  /** Close the row and stamp `completed` (the backdate lands here). */
+  complete: 'complete',
+  /** Reopen a closed row: back to pending, completion timestamp cleared. */
+  reopen: 'reopen',
+  /** Move `due` and append the `Defer` audit entry, matrix-guarded. */
+  defer: 'defer',
+  /** Soft delete — tombstone the record, drop the row from the pool. */
+  softDelete: 'softDelete',
+  /** Archive: canon's Find sets `status = .closed` with no completion stamp. */
+  archive: 'archive',
+  /** Unarchive: back to pending, leaving any completion timestamp alone. */
+  unarchive: 'unarchive',
+} as const
+
+export type OperationEffect =
+  (typeof OperationEffect)[keyof typeof OperationEffect]
+
+export interface FindOperationBinding {
+  readonly operation: EndeavorOperation
+  readonly handling: OperationHandling
+  /** The write, for a `local` binding; `null` for an intent. */
+  readonly effect: OperationEffect | null
+  /**
+   * Who consumes the intent, for an `intent` binding; `null` for a local one.
+   * Free text on purpose — it is documentation the coverage report prints, not
+   * a key anything dispatches on.
+   */
+  readonly consumer: string | null
+}
+
+const local = (
+  operation: EndeavorOperation,
+  effect: OperationEffect,
+): FindOperationBinding => ({
+  operation,
+  handling: OperationHandling.local,
+  effect,
+  consumer: null,
+})
+
+const intent = (
+  operation: EndeavorOperation,
+  consumer: string,
+): FindOperationBinding => ({
+  operation,
+  handling: OperationHandling.intent,
+  effect: null,
+  consumer,
+})
+
+/**
+ * The whole catalog, keyed by operation.
+ *
+ * `Record<EndeavorOperation, …>` makes it **structurally total**: adding a case
+ * to the closed `EndeavorOperation` catalog in `@kro/core` fails this file's
+ * typecheck before it fails a test. The coverage suite then proves the same
+ * thing at runtime against the vista registry, so a capability declared by a
+ * vista that this table forgot cannot reach a user as a dead gesture.
+ */
+export const findOperationBindings: Record<
+  EndeavorOperation,
+  FindOperationBinding
+> = {
+  [Operation.markComplete]: local(Operation.markComplete, OperationEffect.complete),
+  [Operation.markIncomplete]: local(Operation.markIncomplete, OperationEffect.reopen),
+  [Operation.defer]: local(Operation.defer, OperationEffect.defer),
+  [Operation.delete]: local(Operation.delete, OperationEffect.softDelete),
+  [Operation.archive]: local(Operation.archive, OperationEffect.archive),
+  [Operation.unarchive]: local(Operation.unarchive, OperationEffect.unarchive),
+  // The focus-session domain (#8) exists; the session *surface* that owns
+  // starting one does not live in this lane, and a slice never imports a
+  // sibling slice.
+  [Operation.startSession]: intent(Operation.startSession, 'session surface'),
+  // Do's pre-execution overlay "Start now" — the same hand-off as
+  // `startSession`, raised from the overlay rather than a row gesture.
+  [Operation.execute]: intent(Operation.execute, 'session surface (Do prep overlay)'),
+  // The editor is the Endeavor Detail slice's, registered beside this one.
+  [Operation.edit]: intent(Operation.edit, 'endeavorDetail slice'),
+  // Web has `navigator.share`, but a platform capability is a Service behind
+  // `ThunkExtra` (`RC-6`) and none is wired yet. Named rather than dropped.
+  [Operation.share]: intent(Operation.share, 'share Service (not wired yet)'),
+  [Operation.triage]: intent(Operation.triage, 'triage surface'),
+  // The suggestion lane is Do's own state; Find can only ask.
+  [Operation.dismissSuggestion]: intent(Operation.dismissSuggestion, 'do slice'),
+  [Operation.viewDetail]: intent(Operation.viewDetail, 'endeavorDetail slice'),
+}
+
+/** The binding for one operation. Total by construction. */
+export const findOperationBinding = (
+  operation: EndeavorOperation,
+): FindOperationBinding => findOperationBindings[operation]
+
+/** Whether this feature persists the operation itself. */
+export const isLocallyHandledOperation = (
+  operation: EndeavorOperation,
+): boolean =>
+  findOperationBinding(operation).handling === OperationHandling.local
+
+/**
+ * Every distinct operation a set of vistas declares, in first-declaration
+ * order — the exact set the coverage assertion must find a binding for.
+ */
+export const vistaDeclaredOperations = (
+  vistas: readonly EndeavorsVista[],
+): readonly EndeavorOperation[] => {
+  const seen: EndeavorOperation[] = []
+  for (const vista of vistas) {
+    for (const binding of vista.capabilities.operations) {
+      if (!seen.includes(binding.operation)) seen.push(binding.operation)
+    }
+  }
+  return seen
+}
+
+/**
+ * The coverage assertion's subject: declared operations with no entry in the
+ * catalog. **Always empty** — a non-empty result is the defect.
+ */
+export const unboundVistaOperations = (
+  vistas: readonly EndeavorsVista[],
+): readonly EndeavorOperation[] =>
+  vistaDeclaredOperations(vistas).filter(
+    (operation) => findOperationBindings[operation] === undefined,
+  )
+
+/** Every operation in the closed catalog that this table did not bind. */
+export const unboundOperations = (): readonly EndeavorOperation[] =>
+  endeavorOperations.filter(
+    (operation) => findOperationBindings[operation] === undefined,
+  )
+
+// ---------------------------------------------------------------------------
+// The request, and the effect it has on a row
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything one operation can need. The optional fields belong to one effect
+ * each, so a request that carries none is still valid for the ten operations
+ * that need none.
+ */
+export interface EndeavorOperationRequest {
+  readonly surface: FindSurface
+  readonly operation: EndeavorOperation
+  readonly endeavorId: string
+  readonly now: Date
+  /**
+   * `markComplete` only — when the work was actually done. Separate from `now`
+   * because the user may have **backdated** it, and the row must record when it
+   * was done, not when it was saved.
+   */
+  readonly completionDate?: Date
+  /** `defer` only — the moment the endeavor is pushed to. */
+  readonly deferTarget?: Date
+  /** `defer` only — why, when the user gave a reason. */
+  readonly deferReason?: string | null
+}
+
+/**
+ * The row after one operation — the **single** definition of what each local
+ * effect does.
+ *
+ * The reducer applies it optimistically the moment the request is dispatched,
+ * and the Producer applies the same function before persisting, so the row the
+ * user sees and the row that lands on disk cannot drift. An `intent` operation
+ * and a `softDelete` both return the endeavor untouched: the first is somebody
+ * else's write, the second removes the row rather than rewriting it.
+ *
+ * `defer` goes through the domain's guarded `withDeferred`, so a kind the
+ * matrix says has no due date gets **the same object back** — the refusal is
+ * the domain's, not a check restated here.
+ */
+export const endeavorAfterOperation = (
+  endeavor: Endeavor,
+  request: EndeavorOperationRequest,
+): Endeavor => {
+  const { effect } = findOperationBinding(request.operation)
+  switch (effect) {
+    case OperationEffect.complete:
+      return {
+        ...endeavor,
+        status: EndeavorStatus.closed,
+        completed: request.completionDate ?? request.now,
+      }
+    case OperationEffect.reopen:
+      return { ...endeavor, status: EndeavorStatus.pending, completed: null }
+    case OperationEffect.defer:
+      return withDeferred(endeavor, {
+        target: request.deferTarget ?? request.now,
+        made: request.now,
+        reason: request.deferReason ?? null,
+      })
+    case OperationEffect.archive:
+      // Canon's Find archives by closing the row — deliberately with **no**
+      // completion stamp: archiving is a filing action, not an achievement.
+      return { ...endeavor, status: EndeavorStatus.closed }
+    case OperationEffect.unarchive:
+      return { ...endeavor, status: EndeavorStatus.pending }
+    default:
+      return endeavor
+  }
+}
+
+/** Whether the operation removes the row rather than rewriting it. */
+export const isRemovingOperation = (operation: EndeavorOperation): boolean =>
+  findOperationBinding(operation).effect === OperationEffect.softDelete
+
+// ---------------------------------------------------------------------------
+// Intents
+// ---------------------------------------------------------------------------
+
+/**
+ * A cross-feature request, parked in slice state until its owner consumes it.
+ *
+ * `id` is a slice-issued sequence number, not a timestamp: it needs to be
+ * unique and orderable, and a reducer has no clock (`RC-4`). The consumer
+ * acknowledges by id, so two identical requests for the same row are two
+ * distinct intents rather than one that silently swallows the second.
+ */
+export interface EndeavorIntent {
+  readonly id: number
+  readonly operation: EndeavorOperation
+  readonly endeavorId: string
+  readonly surface: FindSurface
+}
+
+/**
+ * Whether an operation resolves into an intent rather than a local write.
+ * `assertNever` on the handling keeps this honest if a third handling is ever
+ * added.
+ */
+export const isIntentOperation = (operation: EndeavorOperation): boolean => {
+  const { handling } = findOperationBinding(operation)
+  switch (handling) {
+    case OperationHandling.intent:
+      return true
+    case OperationHandling.local:
+      return false
+    default:
+      return assertNever(handling)
+  }
+}

--- a/packages/app/src/features/find/FindOperations.ts
+++ b/packages/app/src/features/find/FindOperations.ts
@@ -264,9 +264,12 @@ export const endeavorAfterOperation = (
     case OperationEffect.archive:
       // Canon's Find archives by closing the row — deliberately with **no**
       // completion stamp: archiving is a filing action, not an achievement.
-      return { ...endeavor, status: EndeavorStatus.closed }
+      // Clearing `completed` is what makes that true for a previously
+      // completed row too: closed-with-a-stamp reads as completed, and an
+      // archived row must never match completedToday.
+      return { ...endeavor, status: EndeavorStatus.closed, completed: null }
     case OperationEffect.unarchive:
-      return { ...endeavor, status: EndeavorStatus.pending }
+      return { ...endeavor, status: EndeavorStatus.pending, completed: null }
     default:
       return endeavor
   }

--- a/packages/app/src/features/find/FindProducer.ts
+++ b/packages/app/src/features/find/FindProducer.ts
@@ -1,0 +1,393 @@
+/**
+ * Find/Tasks Producers (`RC-3`, `RC-6`, `RC-7`, `RC-25`) — canon's
+ * `produceFetchEndeavorsEffect`, `produceRestoreLensEffect` /
+ * `producePersistLensEffect` (`FindProducer.swift`) and the mutation effects
+ * `TasksProducer.swift` fans out.
+ *
+ * Five thunks, one shape: read services through `extra`, never throw, always
+ * resolve a `Result`. None reads a clock — `now` is an argument, so the reducer
+ * classifies against the same instant the effect used.
+ *
+ * ## One entry point for every operation
+ *
+ * `performEndeavorOperationThunk` is the single door every capability the vista
+ * registry declares goes through. That is what makes acceptance criterion 1
+ * checkable without a view: the coverage suite walks the registry, dispatches
+ * each declared operation, and asserts none of them lands on "unbound". A
+ * per-operation thunk set would have made the same assertion a list somebody has
+ * to remember to extend.
+ *
+ * ## Raw pass-through, reconcile at install
+ *
+ * The fetch returns the **stored** rows untouched; `withEndeavorsInstalled` owns
+ * the single reconcile pass (`#12`'s reconcile-before-grouping contract, applied
+ * exactly once — the `#49`-round pattern this repo settled on for Do).
+ */
+import {
+  type Defer,
+  type Endeavor,
+  type EndeavorRecord,
+  EndeavorStatus,
+  type LocalStore,
+  type ReconciliationContext,
+  type Result,
+  deferFromRecord,
+  deferRecordFromDefer,
+  endeavorFromRecord,
+  endeavorRecordFromEndeavor,
+  epochMillisFromDate,
+  err,
+  livingChildRecords,
+  makeDefer,
+  makeEndeavorsLensSnapshot,
+  makeReconciliationContext,
+  ok,
+  performFromRecord,
+  resolvedKind,
+  withDeferred,
+} from '@kro/core'
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import type { ThunkExtra } from '../../library/store'
+import type { FindException } from './FindException'
+import { FindExceptions, findExceptionMessage } from './FindException'
+import type {
+  EndeavorOperationRequest,
+  FindSurface,
+} from './FindOperations'
+import {
+  OperationEffect,
+  OperationHandling,
+  endeavorAfterOperation,
+  findOperationBinding,
+} from './FindOperations'
+import type { FindLensState } from './FindState'
+
+export type { EndeavorOperationRequest } from './FindOperations'
+
+/** A whole-surface snapshot and the instant it was read at. */
+export interface FindSnapshot {
+  readonly surface: FindSurface
+  readonly endeavors: readonly Endeavor[]
+  readonly now: Date
+}
+
+/** What one operation resolved into, for the reducer to install. */
+export type FindOperationOutcome =
+  /** The row was rewritten and persisted; install the authoritative copy. */
+  | {
+      readonly kind: 'mutated'
+      readonly surface: FindSurface
+      readonly endeavor: Endeavor
+    }
+  /** The row was soft-deleted; it is gone from the surface. */
+  | {
+      readonly kind: 'removed'
+      readonly surface: FindSurface
+      readonly endeavorId: string
+    }
+  /** The operation belongs elsewhere; the reducer parks it as an intent. */
+  | {
+      readonly kind: 'intent'
+      readonly surface: FindSurface
+      readonly operation: EndeavorOperationRequest['operation']
+      readonly endeavorId: string
+    }
+
+/**
+ * Every stored endeavor, hydrated with its relations.
+ *
+ * The two child stores are read **once each** and grouped in memory rather than
+ * queried per endeavor: a list of a hundred rows would otherwise cost two
+ * hundred extra round-trips. A row that fails to decode is skipped, never
+ * fatal — canon's caller *"treats the failure as skip this row"*, and one
+ * corrupt row must not blank the whole surface.
+ */
+const readStoredEndeavors = async (
+  localStore: LocalStore,
+): Promise<readonly Endeavor[]> => {
+  const [endeavorRecords, deferRecords, performanceRecords] = await Promise.all([
+    localStore.endeavors.all(),
+    localStore.defers.all(),
+    localStore.performances.all(),
+  ])
+
+  const defersByEndeavor = new Map<string, Defer[]>()
+  for (const record of livingChildRecords(deferRecords)) {
+    const bucket = defersByEndeavor.get(record.endeavorId) ?? []
+    bucket.push(deferFromRecord(record))
+    defersByEndeavor.set(record.endeavorId, bucket)
+  }
+
+  const performancesByEndeavor = new Map<
+    string,
+    ReturnType<typeof performFromRecord>[]
+  >()
+  for (const record of livingChildRecords(performanceRecords)) {
+    const bucket = performancesByEndeavor.get(record.endeavorId) ?? []
+    bucket.push(performFromRecord(record))
+    performancesByEndeavor.set(record.endeavorId, bucket)
+  }
+
+  const endeavors: Endeavor[] = []
+  for (const record of endeavorRecords) {
+    const hydrated = endeavorFromRecord(record, {
+      defers: defersByEndeavor.get(record.id) ?? [],
+      performances: performancesByEndeavor.get(record.id) ?? [],
+    })
+    if (hydrated.ok) endeavors.push(hydrated.value)
+  }
+  return endeavors
+}
+
+/**
+ * Rewrites one stored endeavor, preserving its sync watermark.
+ *
+ * Dropping `lastSyncedAtEpochMillis` would present an already-synced row to the
+ * next push sweep as if it had never left the device.
+ */
+const persistEndeavor = async (
+  localStore: LocalStore,
+  endeavor: Endeavor,
+  now: Date,
+  context: ReconciliationContext,
+): Promise<void> => {
+  const existing: EndeavorRecord | null = await localStore.endeavors.get(
+    endeavor.id,
+  )
+  await localStore.endeavors.put(
+    endeavorRecordFromEndeavor(endeavor, {
+      now,
+      lastSyncedAtEpochMillis: existing?.lastSyncedAtEpochMillis ?? null,
+      resolvedKind: resolvedKind(endeavor, context),
+    }),
+  )
+}
+
+const findEndeavor = async (
+  localStore: LocalStore,
+  endeavorId: string,
+): Promise<Endeavor | null> => {
+  const stored = await readStoredEndeavors(localStore)
+  return stored.find((endeavor) => endeavor.id === endeavorId) ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+/**
+ * The surface's fetch. One read for the whole vista; the query and the lens
+ * narrow it downstream, so the "no data" and "filtered out" empty states stay
+ * distinguishable.
+ */
+export const fetchFindEndeavorsThunk = createAsyncThunk<
+  Result<FindSnapshot, FindException>,
+  { readonly surface: FindSurface; readonly now: Date },
+  { extra: ThunkExtra }
+>('find/onEndeavorsFetchCompleted', async ({ surface, now }, { extra }) => {
+  try {
+    const stored = await readStoredEndeavors(extra.localStore)
+    // Raw pass-through: the install shifter owns the single reconcile pass.
+    return ok({ surface, endeavors: stored, now })
+  } catch (error) {
+    return err(FindExceptions.fetchFailed(findExceptionMessage(error)))
+  }
+})
+
+/**
+ * Restore the persisted lens for a vista id.
+ *
+ * A miss and a failure both resolve `ok(null)` — canon's restore is *"silent
+ * (nil → use defaults)"*, because a filter preference that cannot be read is
+ * not a reason to show the user an error over a screen that works fine.
+ */
+export const restoreFindLensThunk = createAsyncThunk<
+  Result<FindLensState | null, FindException>,
+  { readonly surface: FindSurface; readonly vistaId: string },
+  { extra: ThunkExtra }
+>('find/onLensRestoreCompleted', async ({ vistaId }, { extra }) => {
+  try {
+    const snapshot = await extra.localStore.lensSnapshots.read(vistaId)
+    if (snapshot === null) return ok(null)
+    return ok({
+      hiddenKinds: [...snapshot.hiddenKinds],
+      hiddenHosts: [...snapshot.hiddenHosts],
+      hiddenStatuses: [...snapshot.hiddenStatuses],
+      hiddenComputedStates: [...snapshot.hiddenComputedStates],
+      hiddenCalendarIds: [...snapshot.hiddenCalendarIds],
+      searchQuery: snapshot.searchQuery,
+      showArchived: snapshot.showArchived,
+      grouping: snapshot.grouping,
+    })
+  } catch {
+    return ok(null)
+  }
+})
+
+/**
+ * Persist the current lens. Fire-and-forget by design: canon says *"Persistence
+ * failure is non-fatal: the user's filter UI still works for the current
+ * session"*, so a failure resolves `ok` and nothing reaches the surface.
+ */
+export const persistFindLensThunk = createAsyncThunk<
+  Result<null, FindException>,
+  {
+    readonly surface: FindSurface
+    readonly vistaId: string
+    readonly lens: FindLensState
+  },
+  { extra: ThunkExtra }
+>('find/onLensPersistCompleted', async ({ vistaId, lens }, { extra }) => {
+  try {
+    await extra.localStore.lensSnapshots.write(
+      vistaId,
+      makeEndeavorsLensSnapshot(lens),
+    )
+  } catch {
+    // Deliberately swallowed — see the doc comment.
+  }
+  return ok(null)
+})
+
+// ---------------------------------------------------------------------------
+// Operations
+// ---------------------------------------------------------------------------
+
+/**
+ * The defer audit row that goes with a `defer`, or `null` when the domain
+ * refused the edit (the matrix said this kind has no due date to push).
+ */
+const newDeferOf = (
+  before: Endeavor,
+  after: Endeavor,
+  request: EndeavorOperationRequest,
+): Defer | null => {
+  if (after.defers.length === before.defers.length) return null
+  return makeDefer({
+    made: request.now,
+    reason: request.deferReason ?? null,
+    target: request.deferTarget ?? request.now,
+  })
+}
+
+/**
+ * Perform one vista-declared operation.
+ *
+ * Local effects write through `extra.localStore`; everything else resolves into
+ * an intent the reducer parks for its owner. Both paths resolve `ok` — an
+ * operation that is *handled elsewhere* has not failed, and reporting it as a
+ * failure would make the surface show an error for a working hand-off.
+ */
+export const performEndeavorOperationThunk = createAsyncThunk<
+  Result<FindOperationOutcome, FindException>,
+  EndeavorOperationRequest,
+  { extra: ThunkExtra }
+>('find/onEndeavorOperationCompleted', async (request, { extra }) => {
+  const binding = findOperationBinding(request.operation)
+
+  if (binding.handling === OperationHandling.intent) {
+    return ok({
+      kind: 'intent',
+      surface: request.surface,
+      operation: request.operation,
+      endeavorId: request.endeavorId,
+    })
+  }
+
+  try {
+    const context = makeReconciliationContext({ now: request.now })
+    const target = await findEndeavor(extra.localStore, request.endeavorId)
+    if (target === null) {
+      return err(FindExceptions.endeavorNotFound(request.endeavorId))
+    }
+
+    if (binding.effect === OperationEffect.softDelete) {
+      await extra.localStore.endeavors.softDelete(
+        target.id,
+        epochMillisFromDate(request.now),
+      )
+      return ok({
+        kind: 'removed',
+        surface: request.surface,
+        endeavorId: target.id,
+      })
+    }
+
+    const updated = endeavorAfterOperation(target, request)
+    await persistEndeavor(extra.localStore, updated, request.now, context)
+
+    // A defer is two rows: the endeavor's moved `due` above, and the audit
+    // entry in its own child table. The entry is written only when the domain
+    // actually appended one, so a matrix-refused defer writes neither.
+    const appended = newDeferOf(target, updated, request)
+    if (appended !== null) {
+      await extra.localStore.defers.put(
+        deferRecordFromDefer(appended, {
+          endeavorId: updated.id,
+          now: request.now,
+          nowMillis: epochMillisFromDate(request.now),
+        }),
+      )
+    }
+
+    return ok({ kind: 'mutated', surface: request.surface, endeavor: updated })
+  } catch (error) {
+    return err(FindExceptions.operationFailed(findExceptionMessage(error)))
+  }
+})
+
+/** Which bulk operation the ellipsis menu raised. */
+export type FindBulkOperation = 'delete' | 'archive'
+
+export interface FindBulkRequest {
+  readonly surface: FindSurface
+  readonly operation: FindBulkOperation
+  /** Exactly the rows currently visible — the count the menu label shows. */
+  readonly endeavorIds: readonly string[]
+  readonly now: Date
+}
+
+/**
+ * Delete-all-visible / Archive-all-visible.
+ *
+ * Canon's ellipsis menu raises these with **no confirmation step** — the
+ * destructive *role* on "Delete all visible (N)" is the only affordance, and
+ * both apply immediately and optimistically. That is ported as-is rather than
+ * "improved" with a confirm dialog: adding one would be a new business rule and
+ * would put the two platforms' Find menus out of step (named in the PR body).
+ *
+ * Rows are written one at a time and the first failure stops the walk, so a
+ * partial result is reported as a failure rather than silently claimed as
+ * success. The surface has already applied the whole set optimistically; the
+ * next fetch reconciles whatever actually landed.
+ */
+export const performBulkOperationThunk = createAsyncThunk<
+  Result<FindBulkRequest, FindException>,
+  FindBulkRequest,
+  { extra: ThunkExtra }
+>('find/onBulkOperationCompleted', async (request, { extra }) => {
+  try {
+    const context = makeReconciliationContext({ now: request.now })
+    const nowMillis = epochMillisFromDate(request.now)
+    const stored = await readStoredEndeavors(extra.localStore)
+    const byId = new Map(stored.map((endeavor) => [endeavor.id, endeavor]))
+
+    for (const endeavorId of request.endeavorIds) {
+      const target = byId.get(endeavorId)
+      if (target === undefined) continue
+      if (request.operation === 'delete') {
+        await extra.localStore.endeavors.softDelete(endeavorId, nowMillis)
+      } else {
+        await persistEndeavor(
+          extra.localStore,
+          { ...target, status: EndeavorStatus.closed },
+          request.now,
+          context,
+        )
+      }
+    }
+    return ok(request)
+  } catch (error) {
+    return err(FindExceptions.bulkOperationFailed(findExceptionMessage(error)))
+  }
+})

--- a/packages/app/src/features/find/FindSelectors.ts
+++ b/packages/app/src/features/find/FindSelectors.ts
@@ -1,0 +1,474 @@
+/**
+ * Find/Tasks Selectors (`RC-5`, `RC-20`) — canon's `FindSelectors.swift` and
+ * `TasksSelectors.swift`, plus the narrowing half of `TasksShifters.applyReprocess`.
+ *
+ * Every derived read lives here, built with `createSelector` over `RootState`
+ * alone. **None reads a clock**: the reducer parked the instant it installed
+ * against in `clockAnchor`, and the predicates read it as ordinary state — which
+ * is what canon's own `FindSelectors` note says it would have to do the moment a
+ * Find vista exposed computed states.
+ *
+ * ## The two surfaces narrow differently, and that is canon's shape
+ *
+ * - **Find** applies the **lens only**. Canon's `displayedEndeavorsSelector`
+ *   pipes `allEndeavors` through `vista.lens.apply(to:)` and nothing else: the
+ *   query was already executed by the query client at fetch time. Re-applying it
+ *   in memory would break Show Archived, because `everything`'s
+ *   `includeArchived` is `false` and would strip closed rows *before* the lens
+ *   could reveal them.
+ * - **All Tasks** applies the query's **kinds / lists / predicates** and then
+ *   the lens — exactly canon's `applyReprocess` steps 2 and 3, which likewise
+ *   omit the query's status and archive terms for the same reason.
+ *
+ * That is why `@kro/core`'s `applyQuery` (which applies *every* term, including
+ * `includeArchived`) is deliberately not used here: it is the fetch-side filter,
+ * and this is the in-memory one.
+ */
+import {
+  type Endeavor,
+  type EndeavorCapabilities,
+  type EndeavorGroupingCriteria,
+  type EndeavorHost,
+  type EndeavorKind,
+  type EndeavorStatus,
+  type EndeavorsVista,
+  EndeavorsVistas,
+  applyLens,
+  endeavorHosts,
+  endeavorKinds,
+  endeavorStatuses,
+  lensApplyingSnapshot,
+  makeEndeavorsLensSnapshot,
+  matchesEndeavorPredicate,
+  resolveEndeavorCapabilities,
+  vistaWithLens,
+} from '@kro/core'
+import { createSelector } from '@reduxjs/toolkit'
+import type { RootState } from '../../library/store'
+import type { EndeavorRowAdapter } from './FindAdapters'
+import { endeavorRowAdapters } from './FindAdapters'
+import type { FindException } from './FindException'
+import type { EndeavorRowGroup } from './FindGrouping'
+import { groupEndeavors, limitGroups } from './FindGrouping'
+import type { EndeavorIntent } from './FindOperations'
+import type {
+  FindEmptyState,
+  FindLensState,
+  FindState,
+  FindSurfaceState,
+  TasksVistaSelection,
+} from './FindState'
+
+const selectFindSlice = (state: RootState): FindState => state.find
+
+const selectFindSurface = createSelector(
+  [selectFindSlice],
+  (slice): FindSurfaceState => slice.find,
+)
+
+const selectTasksSurface = createSelector(
+  [selectFindSlice],
+  (slice): FindSurfaceState => slice.tasks,
+)
+
+const selectTasksSelection = createSelector(
+  [selectFindSlice],
+  (slice): TasksVistaSelection => slice.tasksSelection,
+)
+
+/**
+ * The instant every predicate is evaluated against.
+ *
+ * Before the first install there is nothing to classify, so the epoch stands in
+ * — a constant, not a clock read, which is what keeps this tier of Selectors
+ * pure. The pool is empty at that point, so no predicate ever sees it.
+ */
+const anchorOf = (surface: FindSurfaceState): Date =>
+  surface.clockAnchor ?? new Date(0)
+
+/** The registry vista a `.tasks*` selection names. */
+const tasksVistaFor = (selection: TasksVistaSelection): EndeavorsVista => {
+  switch (selection.kind) {
+    case 'today':
+      return EndeavorsVistas.tasksToday
+    case 'list':
+      return EndeavorsVistas.tasksForList(selection.listId)
+    case 'search':
+      return EndeavorsVistas.tasksForSearch(selection.query)
+    default:
+      return EndeavorsVistas.tasksDefault
+  }
+}
+
+/**
+ * Materialises the real vista: the registry's own defaults, carrying the user's
+ * stored lens. `sort` and `exposes` survive untouched, so a saved preference can
+ * never change which toggles a screen offers.
+ */
+const vistaCarrying = (
+  base: EndeavorsVista,
+  lens: FindLensState,
+): EndeavorsVista =>
+  vistaWithLens(base, lensApplyingSnapshot(base.lens, makeEndeavorsLensSnapshot(lens)))
+
+// ---------------------------------------------------------------------------
+// Vistas and capabilities
+// ---------------------------------------------------------------------------
+
+export const selectFindVista = createSelector(
+  [selectFindSurface],
+  (surface): EndeavorsVista => vistaCarrying(EndeavorsVistas.find, surface.lens),
+)
+
+export const selectTasksVista = createSelector(
+  [selectTasksSurface, selectTasksSelection],
+  (surface, selection): EndeavorsVista =>
+    vistaCarrying(tasksVistaFor(selection), surface.lens),
+)
+
+/**
+ * The Find vista's capabilities **after** flag gating.
+ *
+ * `resolveEndeavorCapabilities` drops every binding whose `requires` flag is
+ * off, so the `viewDetail` tap simply does not exist until `endeavorDetail` is
+ * enabled — canon's *"Operations gated by a feature flag the user doesn't have
+ * are simply not shown"*, applied once, here, rather than per gesture in a view.
+ */
+export const selectFindCapabilities = createSelector(
+  [selectFindVista, selectFindSurface],
+  (vista, surface): EndeavorCapabilities =>
+    resolveEndeavorCapabilities(vista.capabilities, (flag) =>
+      surface.enabledFlags.includes(flag),
+    ),
+)
+
+export const selectTasksCapabilities = createSelector(
+  [selectTasksVista, selectTasksSurface],
+  (vista, surface): EndeavorCapabilities =>
+    resolveEndeavorCapabilities(vista.capabilities, (flag) =>
+      surface.enabledFlags.includes(flag),
+    ),
+)
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+export const selectIsFindLoading = createSelector(
+  [selectFindSurface],
+  (surface) => surface.load.kind === 'loading',
+)
+
+export const selectFindException = createSelector(
+  [selectFindSurface],
+  (surface): FindException | null =>
+    surface.load.kind === 'failed' ? surface.load.exception : null,
+)
+
+export const selectIsTasksLoading = createSelector(
+  [selectTasksSurface],
+  (surface) => surface.load.kind === 'loading',
+)
+
+export const selectTasksException = createSelector(
+  [selectTasksSurface],
+  (surface): FindException | null =>
+    surface.load.kind === 'failed' ? surface.load.exception : null,
+)
+
+/** True until the persisted lens has landed — canon's `isLoadingLens`. */
+export const selectIsFindLensLoading = createSelector(
+  [selectFindSurface],
+  (surface) => !surface.isLensRestored,
+)
+
+// ---------------------------------------------------------------------------
+// Filter chips
+// ---------------------------------------------------------------------------
+
+/**
+ * The kinds the user is currently **showing** — the complement of the lens's
+ * hidden set, which is what a chip's selected state renders from.
+ */
+export const selectFindSelectedKinds = createSelector(
+  [selectFindSurface],
+  (surface): readonly EndeavorKind[] =>
+    endeavorKinds.filter((kind) => !surface.lens.hiddenKinds.includes(kind)),
+)
+
+export const selectFindSelectedHosts = createSelector(
+  [selectFindSurface],
+  (surface): readonly EndeavorHost[] =>
+    endeavorHosts.filter((host) => !surface.lens.hiddenHosts.includes(host)),
+)
+
+export const selectFindSelectedStatuses = createSelector(
+  [selectFindSurface],
+  (surface): readonly EndeavorStatus[] =>
+    endeavorStatuses.filter(
+      (status) => !surface.lens.hiddenStatuses.includes(status),
+    ),
+)
+
+export const selectFindShowArchived = createSelector(
+  [selectFindSurface],
+  (surface) => surface.lens.showArchived,
+)
+
+export const selectFindSearchQuery = createSelector(
+  [selectFindSurface],
+  (surface) => surface.lens.searchQuery,
+)
+
+/**
+ * Canon's `noFiltersSelectedSelector`: the user has hidden **every** kind,
+ * **every** host and **every** status, and archived display is off. The
+ * displayed list short-circuits to empty in that case, and the surface says
+ * "No Filters Selected" rather than "No Results".
+ */
+export const selectFindHasNoFiltersSelected = createSelector(
+  [
+    selectFindSelectedKinds,
+    selectFindSelectedHosts,
+    selectFindSelectedStatuses,
+    selectFindShowArchived,
+  ],
+  (kinds, hosts, statuses, showArchived) =>
+    kinds.length === 0 &&
+    hosts.length === 0 &&
+    statuses.length === 0 &&
+    !showArchived,
+)
+
+/** Canon's `allKindsHiddenSelector` — every selectable kind is hidden. */
+export const selectFindAreAllKindsHidden = createSelector(
+  [selectFindSurface],
+  (surface) => surface.lens.hiddenKinds.length === endeavorKinds.length,
+)
+
+// ---------------------------------------------------------------------------
+// Find's displayed rows
+// ---------------------------------------------------------------------------
+
+/**
+ * Canon's Find sort: `start ?? due` ascending, **nil dates trailing**. A row
+ * with neither keeps its relative order against another such row.
+ */
+const findSortKey = (endeavor: Endeavor): number | null =>
+  (endeavor.start ?? endeavor.due)?.getTime() ?? null
+
+const sortForFind = (endeavors: readonly Endeavor[]): readonly Endeavor[] =>
+  [...endeavors].sort((left, right) => {
+    const leftKey = findSortKey(left)
+    const rightKey = findSortKey(right)
+    if (leftKey === null && rightKey === null) return 0
+    if (leftKey === null) return 1
+    if (rightKey === null) return -1
+    return leftKey - rightKey
+  })
+
+/**
+ * The Find list: lens-narrowed, then sorted. Short-circuits to empty when every
+ * filter is off, which is what preserves canon's pre-migration semantics.
+ */
+export const selectFindRows = createSelector(
+  [selectFindSurface, selectFindVista, selectFindHasNoFiltersSelected],
+  (surface, vista, noFilters): readonly Endeavor[] => {
+    if (noFilters) return []
+    return sortForFind(
+      applyLens(vista.lens, surface.endeavors, anchorOf(surface)),
+    )
+  },
+)
+
+/** The count the ellipsis menu's "Delete all visible (N)" label shows. */
+export const selectFindVisibleCount = createSelector(
+  [selectFindRows],
+  (rows) => rows.length,
+)
+
+/** Exactly the ids a bulk operation applies to — "all **visible**". */
+export const selectFindVisibleIds = createSelector(
+  [selectFindRows],
+  (rows): readonly string[] => rows.map((endeavor) => endeavor.id),
+)
+
+/** The rows, adapted against the flag-resolved capabilities (`#30` renders these). */
+export const selectFindRowAdapters = createSelector(
+  [selectFindRows, selectFindCapabilities],
+  (rows, capabilities): readonly EndeavorRowAdapter[] =>
+    endeavorRowAdapters(rows, capabilities),
+)
+
+/**
+ * Which empty state Find is in — canon's `FindView.mainContent` branch order,
+ * preserved exactly: no data at all, then no filters, then no search results,
+ * then filtered-out.
+ */
+export const selectFindEmptyState = createSelector(
+  [
+    selectFindSurface,
+    selectFindRows,
+    selectFindHasNoFiltersSelected,
+    selectFindSearchQuery,
+  ],
+  (surface, rows, noFilters, query): FindEmptyState | null => {
+    if (surface.endeavors.length === 0) return { kind: 'noData' }
+    if (noFilters) return { kind: 'noFilters' }
+    if (rows.length > 0) return null
+    if (query.length > 0) return { kind: 'noResults', query }
+    return { kind: 'filteredOut' }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// All Tasks' groups
+// ---------------------------------------------------------------------------
+
+/**
+ * Canon's `applyReprocess` step 2 — the query's **kinds, lists and predicates**
+ * applied in memory. Statuses, hosts and `includeArchived` are deliberately not
+ * applied: they belong to the fetch, and applying `includeArchived` here would
+ * hide archived rows before Show Archived could reveal them.
+ */
+const applyTasksQueryPostFilter = (
+  vista: EndeavorsVista,
+  endeavors: readonly Endeavor[],
+  now: Date,
+): readonly Endeavor[] =>
+  endeavors.filter((endeavor) => {
+    const { kinds, lists, predicates } = vista.query
+    if (kinds !== null && kinds.size > 0 && !kinds.has(endeavor.kind)) {
+      return false
+    }
+    if (lists !== null && lists.size > 0) {
+      const listId = endeavor.list?.id
+      if (listId === undefined || !lists.has(listId)) return false
+    }
+    if (predicates !== null && predicates.size > 0) {
+      for (const predicate of predicates) {
+        if (!matchesEndeavorPredicate(predicate, endeavor, now)) return false
+      }
+    }
+    return true
+  })
+
+/** The narrowed task rows, before grouping. */
+export const selectTasksRows = createSelector(
+  [selectTasksSurface, selectTasksVista],
+  (surface, vista): readonly Endeavor[] => {
+    const now = anchorOf(surface)
+    return applyLens(
+      vista.lens,
+      applyTasksQueryPostFilter(vista, surface.endeavors, now),
+      now,
+    )
+  },
+)
+
+export const selectTasksGrouping = createSelector(
+  [selectTasksSurface],
+  (surface): EndeavorGroupingCriteria => surface.lens.grouping,
+)
+
+export const selectTasksExpandedGroupKey = createSelector(
+  [selectTasksSurface],
+  (surface): string | null => surface.expandedGroupKey,
+)
+
+export const selectTasksSearchQuery = createSelector(
+  [selectTasksSurface],
+  (surface) => surface.lens.searchQuery,
+)
+
+/**
+ * The grouped, sorted, display-limited list.
+ *
+ * The limit is the vista's own `presentation.itemLimit` — 7 for every Tasks
+ * variant — and it applies only while **no** group is expanded, which is canon's
+ * rule: `applyReprocess` skips `limited(by:)` entirely once a group has focus.
+ */
+export const selectTasksGroups = createSelector(
+  [selectTasksRows, selectTasksVista, selectTasksExpandedGroupKey],
+  (rows, vista, expandedGroupKey): readonly EndeavorRowGroup[] =>
+    limitGroups(
+      groupEndeavors(rows, vista.lens.grouping),
+      vista.presentation.itemLimit,
+      expandedGroupKey,
+    ),
+)
+
+/** Every group's rows, adapted — one adapter per visible row. */
+export const selectTasksGroupAdapters = createSelector(
+  [selectTasksGroups, selectTasksCapabilities],
+  (
+    groups,
+    capabilities,
+  ): readonly {
+    readonly group: EndeavorRowGroup
+    readonly rows: readonly EndeavorRowAdapter[]
+  }[] =>
+    groups.map((group) => ({
+      group,
+      rows: endeavorRowAdapters(group.endeavors, capabilities),
+    })),
+)
+
+/** Which empty state All Tasks is in. Same branch order as Find's. */
+export const selectTasksEmptyState = createSelector(
+  [selectTasksSurface, selectTasksRows, selectTasksSearchQuery],
+  (surface, rows, query): FindEmptyState | null => {
+    if (surface.endeavors.length === 0) return { kind: 'noData' }
+    if (rows.length > 0) return null
+    if (query.length > 0) return { kind: 'noResults', query }
+    return { kind: 'filteredOut' }
+  },
+)
+
+/**
+ * Canon's `expectedHeadingSelector`: the caller's override, then the scoped
+ * list's title, then the live search, then the generic label.
+ */
+export const selectTasksHeading = createSelector(
+  [selectFindSlice, selectTasksSearchQuery],
+  (slice, query): string => {
+    if (slice.tasksCustomTitle !== null) return slice.tasksCustomTitle
+    if (slice.tasksSelection.kind === 'list') {
+      const { listTitle } = slice.tasksSelection
+      if (listTitle !== null) return listTitle
+    }
+    if (query.length > 0) return `Searching: "${query}"`
+    return 'Tasks'
+  },
+)
+
+/**
+ * Canon's `expectedTitleSelector` — the macOS navigation subtitle. Empty string
+ * for an unscoped, unfiltered vista, which is canon's own "no subtitle" value.
+ */
+export const selectTasksTitle = createSelector(
+  [selectFindSlice, selectTasksVista, selectTasksSearchQuery],
+  (slice, vista, query): string => {
+    if (slice.tasksSelection.kind === 'list') return 'List'
+    if (query.length > 0) return 'Search'
+    const predicates = vista.query.predicates
+    if (predicates !== null && predicates.size > 0) return 'Tasks'
+    return ''
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Intents
+// ---------------------------------------------------------------------------
+
+/** Every cross-feature request awaiting its owner, oldest first. */
+export const selectFindPendingIntents = createSelector(
+  [selectFindSlice],
+  (slice): readonly EndeavorIntent[] => slice.intents,
+)
+
+/** The next request to hand over, or `null` when the queue is empty. */
+export const selectFindNextIntent = createSelector(
+  [selectFindPendingIntents],
+  (intents): EndeavorIntent | null => intents[0] ?? null,
+)

--- a/packages/app/src/features/find/FindShifters.ts
+++ b/packages/app/src/features/find/FindShifters.ts
@@ -1,0 +1,467 @@
+/**
+ * Find/Tasks Shifters (`RC-4`, `RC-19`) — every state transition the two
+ * browsing surfaces make, as pure `with…(state, args) => FindState` functions.
+ *
+ * No clock, no store, no service: where a transition needs the current instant
+ * it takes one as an argument, which is what makes an archived-row or
+ * computed-state case a plain unit test rather than a mocked global.
+ *
+ * ## Reconcile once, at install
+ *
+ * `withEndeavorsInstalled` is the **only** place source reconciliation runs on
+ * this surface, and it runs before anything narrows or groups — `#12`'s
+ * call-order contract, and the same shape `#16`'s `withEndeavorsInstalled`
+ * settled on. The Producer therefore hands the reducer the **raw** stored list;
+ * reconciling in both places would be two passes, and reconciling later could
+ * never repair a stale row because the lens would already have dropped the
+ * fresh evidence that proves it stale.
+ *
+ * ## Surface-scoped, by argument
+ *
+ * Every shifter takes the surface it acts on, and `withSurface` is the one
+ * lifter that writes it back. The per-surface transitions themselves are
+ * written against `FindSurfaceState`, so a test can exercise them without
+ * building the whole slice.
+ */
+import {
+  type Endeavor,
+  EndeavorStatus,
+  makeReconciliationContext,
+  reconcile,
+} from '@kro/core'
+import type { EndeavorIntent, FindSurface } from './FindOperations'
+import type { FindException } from './FindException'
+import type {
+  FindFilterToggle,
+  FindLensState,
+  FindState,
+  FindSurfaceState,
+  TasksVistaSelection,
+} from './FindState'
+import { lensDefaultsForTasksSelection } from './FindState'
+
+// ---------------------------------------------------------------------------
+// The lifter
+// ---------------------------------------------------------------------------
+
+/** Writes one surface back into the slice. The only path that does. */
+export function withSurface(
+  state: FindState,
+  surface: FindSurface,
+  next: FindSurfaceState,
+): FindState {
+  return surface === 'find' ? { ...state, find: next } : { ...state, tasks: next }
+}
+
+/** Reads the surface a transition is about. */
+export const surfaceOf = (
+  state: FindState,
+  surface: FindSurface,
+): FindSurfaceState => (surface === 'find' ? state.find : state.tasks)
+
+const mapSurface = (
+  state: FindState,
+  surface: FindSurface,
+  change: (current: FindSurfaceState) => FindSurfaceState,
+): FindState => withSurface(state, surface, change(surfaceOf(state, surface)))
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * One concern: the surface mounted. Stamps the clock it will classify against
+ * and the flags its capability gating reads, and arms the lens restore.
+ *
+ * `isLensRestored` goes **false** rather than staying whatever it was: a
+ * remount asks for the saved lens again, and until it lands the surface must
+ * not present a filter-driven empty state it cannot yet justify.
+ */
+export function withFindViewLoaded(
+  state: FindState,
+  args: {
+    readonly surface: FindSurface
+    readonly now: Date
+    readonly enabledFlags: readonly string[]
+  },
+): FindState {
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    clockAnchor: args.now,
+    enabledFlags: [...args.enabledFlags],
+    isLensRestored: false,
+  }))
+}
+
+/**
+ * One concern: the persisted lens snapshot came back.
+ *
+ * `null` means there was none — the vista's own defaults stand, which is the
+ * restore path's documented behaviour rather than an error. A restore that
+ * lands **after** the user has already touched a filter is dropped: canon's
+ * *"their live choice wins — don't overwrite it with stale saved prefs"*, which
+ * `isLensRestored` is the flag for.
+ */
+export function withLensSnapshotRestored(
+  state: FindState,
+  args: {
+    readonly surface: FindSurface
+    readonly lens: FindLensState | null
+  },
+): FindState {
+  return mapSurface(state, args.surface, (current) => {
+    if (current.isLensRestored) return current
+    return {
+      ...current,
+      isLensRestored: true,
+      lens: args.lens ?? current.lens,
+    }
+  })
+}
+
+/** One concern: a read is in flight, so any prior exception is cleared. */
+export function withFetchStarted(
+  state: FindState,
+  args: { readonly surface: FindSurface },
+): FindState {
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    load: { kind: 'loading' },
+  }))
+}
+
+/**
+ * `applyFetchedEndeavors` — install ONE reconciled snapshot atomically.
+ *
+ * The rows land un-narrowed; the query and the lens are Selector-side, so the
+ * "no data at all" and "everything is filtered out" empty states stay
+ * distinguishable. The clock anchor moves with the install so the two are never
+ * a step apart.
+ */
+export function withEndeavorsInstalled(
+  state: FindState,
+  args: {
+    readonly surface: FindSurface
+    readonly endeavors: readonly Endeavor[]
+    readonly now: Date
+  },
+): FindState {
+  const context = makeReconciliationContext({ now: args.now })
+  const reconciled = reconcile(args.endeavors, context)
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    load: { kind: 'loaded' },
+    endeavors: reconciled,
+    clockAnchor: args.now,
+  }))
+}
+
+/**
+ * One concern: something failed.
+ *
+ * The installed rows are untouched — canon *"keeps the existing data"* on a
+ * hard fetch failure, which is why `load` is a field beside the pool rather
+ * than the container of it.
+ */
+export function withFindException(
+  state: FindState,
+  args: {
+    readonly surface: FindSurface
+    readonly exception: FindException
+  },
+): FindState {
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    load: { kind: 'failed', exception: args.exception },
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Lens
+// ---------------------------------------------------------------------------
+
+const toggleIn = <T>(values: readonly T[], value: T): readonly T[] =>
+  values.includes(value)
+    ? values.filter((existing) => existing !== value)
+    : [...values, value]
+
+/**
+ * One concern: one filter chip flipped. Canon's `applyKindToggled` /
+ * `applyHostToggled` / `applyStatusToggled` over the lens's hidden sets — a
+ * chip the user *deselects* is what lands in a hidden set.
+ *
+ * Touching a filter also settles the restore race: the choice is now the
+ * user's, so a late snapshot must not overwrite it.
+ */
+export function withFilterToggled(
+  state: FindState,
+  args: {
+    readonly surface: FindSurface
+    readonly toggle: FindFilterToggle
+  },
+): FindState {
+  return mapSurface(state, args.surface, (current) => {
+    const { lens } = current
+    const { toggle } = args
+    const next: FindLensState =
+      toggle.axis === 'kind'
+        ? { ...lens, hiddenKinds: toggleIn(lens.hiddenKinds, toggle.value) }
+        : toggle.axis === 'host'
+          ? { ...lens, hiddenHosts: toggleIn(lens.hiddenHosts, toggle.value) }
+          : toggle.axis === 'status'
+            ? {
+                ...lens,
+                hiddenStatuses: toggleIn(lens.hiddenStatuses, toggle.value),
+              }
+            : toggle.axis === 'computedState'
+              ? {
+                  ...lens,
+                  hiddenComputedStates: toggleIn(
+                    lens.hiddenComputedStates,
+                    toggle.value,
+                  ),
+                }
+              : {
+                  ...lens,
+                  hiddenCalendarIds: toggleIn(
+                    lens.hiddenCalendarIds,
+                    toggle.value,
+                  ),
+                }
+    return { ...current, lens: next, isLensRestored: true }
+  })
+}
+
+/** One concern: the Archived chip flipped. Canon's `applyShowArchivedToggled`. */
+export function withShowArchivedToggled(
+  state: FindState,
+  args: { readonly surface: FindSurface },
+): FindState {
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    lens: { ...current.lens, showArchived: !current.lens.showArchived },
+    isLensRestored: true,
+  }))
+}
+
+/**
+ * One concern: the search field changed.
+ *
+ * Canon persists the query with the rest of the lens, so a returning user finds
+ * the search they left. It is stored verbatim; the case fold happens in
+ * `lensPredicate`, where the comparison does.
+ */
+export function withSearchQuery(
+  state: FindState,
+  args: { readonly surface: FindSurface; readonly query: string },
+): FindState {
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    lens: { ...current.lens, searchQuery: args.query },
+    isLensRestored: true,
+  }))
+}
+
+/**
+ * One concern: the grouping picker changed.
+ *
+ * The expanded group is released with it: a key minted under "by status" names
+ * nothing under "by due section", and leaving it set would clip every group
+ * against a focus that no longer exists.
+ */
+export function withGrouping(
+  state: FindState,
+  args: {
+    readonly surface: FindSurface
+    readonly grouping: FindLensState['grouping']
+  },
+): FindState {
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    lens: { ...current.lens, grouping: args.grouping },
+    expandedGroupKey: null,
+    isLensRestored: true,
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Groups
+// ---------------------------------------------------------------------------
+
+/**
+ * One concern: a group was opened. Canon's `applyExpanded` — one focus group at
+ * a time, and while one is focused the item limit is lifted from every group.
+ */
+export function withGroupExpanded(
+  state: FindState,
+  args: { readonly surface: FindSurface; readonly groupKey: string },
+): FindState {
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    expandedGroupKey: args.groupKey,
+  }))
+}
+
+/** One concern: the focus was released. Canon's `applyCollapsed`. */
+export function withGroupsCollapsed(
+  state: FindState,
+  args: { readonly surface: FindSurface },
+): FindState {
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    expandedGroupKey: null,
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// The tasks vista selection
+// ---------------------------------------------------------------------------
+
+/**
+ * One concern: All Tasks was pointed at a different vista.
+ *
+ * The lens resets to that vista's own defaults — `.tasksToday` groups by due
+ * section where `.tasksDefault` groups by status, and carrying the previous
+ * screen's grouping across would silently override the new vista's declaration.
+ * The saved snapshot for the new id is restored right after, by its own event.
+ */
+export function withTasksVistaSelected(
+  state: FindState,
+  args: {
+    readonly selection: TasksVistaSelection
+    readonly customTitle?: string | null
+  },
+): FindState {
+  return {
+    ...state,
+    tasksSelection: args.selection,
+    tasksCustomTitle: args.customTitle ?? null,
+    tasks: {
+      ...state.tasks,
+      lens: lensDefaultsForTasksSelection(args.selection),
+      expandedGroupKey: null,
+      isLensRestored: false,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * One concern: rows left the surface.
+ *
+ * Canon's Find deletes optimistically — *"Optimistic removal … The next
+ * appearance refetch reconciles with the authoritative store"* — so the row
+ * goes before the write resolves and comes back only if the refetch says so.
+ */
+export function withRowsRemoved(
+  state: FindState,
+  args: {
+    readonly surface: FindSurface
+    readonly endeavorIds: readonly string[]
+  },
+): FindState {
+  const removed = new Set(args.endeavorIds)
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    endeavors: current.endeavors.filter(
+      (endeavor) => !removed.has(endeavor.id),
+    ),
+  }))
+}
+
+/**
+ * One concern: rows were archived.
+ *
+ * Canon marks them `closed` **in place** rather than removing them, *"so the
+ * lens hides them immediately"* — which is also what makes them reappear the
+ * moment the user turns Show Archived on, with no refetch.
+ */
+export function withRowsArchived(
+  state: FindState,
+  args: {
+    readonly surface: FindSurface
+    readonly endeavorIds: readonly string[]
+  },
+): FindState {
+  const archived = new Set(args.endeavorIds)
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    endeavors: current.endeavors.map((endeavor) =>
+      archived.has(endeavor.id)
+        ? { ...endeavor, status: EndeavorStatus.closed }
+        : endeavor,
+    ),
+  }))
+}
+
+/**
+ * One concern: one row was rewritten by a completed operation.
+ *
+ * A row that is no longer in the pool is left alone rather than appended: it
+ * was deleted (or filtered out of the fetch) while the write was in flight, and
+ * re-adding it would resurrect it.
+ */
+export function withEndeavorReplaced(
+  state: FindState,
+  args: { readonly surface: FindSurface; readonly endeavor: Endeavor },
+): FindState {
+  return mapSurface(state, args.surface, (current) => ({
+    ...current,
+    endeavors: current.endeavors.map((endeavor) =>
+      endeavor.id === args.endeavor.id ? args.endeavor : endeavor,
+    ),
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Intents
+// ---------------------------------------------------------------------------
+
+/**
+ * One concern: a cross-feature request was raised.
+ *
+ * Two fields move together — the queue and the id counter — which is precisely
+ * `RC-4`'s "an invariant between fields" test: an id issued twice would let a
+ * consumer acknowledge the wrong request.
+ */
+export function withIntentEnqueued(
+  state: FindState,
+  args: {
+    readonly surface: FindSurface
+    readonly operation: EndeavorIntent['operation']
+    readonly endeavorId: string
+  },
+): FindState {
+  const intent: EndeavorIntent = {
+    id: state.nextIntentId,
+    operation: args.operation,
+    endeavorId: args.endeavorId,
+    surface: args.surface,
+  }
+  return {
+    ...state,
+    intents: [...state.intents, intent],
+    nextIntentId: state.nextIntentId + 1,
+  }
+}
+
+/**
+ * One concern: the owner handled a request.
+ *
+ * By id, not "the first one": two taps on Start for two different rows are two
+ * intents, and consuming by position would drop the wrong one if the second
+ * owner answered first. An unknown id is a no-op, never an error — a consumer
+ * acknowledging twice is harmless.
+ */
+export function withIntentConsumed(
+  state: FindState,
+  args: { readonly intentId: number },
+): FindState {
+  return {
+    ...state,
+    intents: state.intents.filter((intent) => intent.id !== args.intentId),
+  }
+}

--- a/packages/app/src/features/find/FindState.ts
+++ b/packages/app/src/features/find/FindState.ts
@@ -1,0 +1,262 @@
+/**
+ * `FindState` — the shape behind **both** vista-browsing surfaces: Find (the
+ * `.find` vista) and All Tasks (`.tasksDefault` / `.tasksToday` /
+ * `.tasksForList(listId)` / `.tasksForSearch(query)`).
+ *
+ * Split out of `FindFeature.ts` under `RC-1`'s size clause, exactly as
+ * `PlanState.ts` is.
+ *
+ * ## Why one slice carries two surfaces
+ *
+ * Canon has two Features because TCA composes one store per screen. Here they
+ * are one slice **with two instances of the same surface state**, because
+ * after the vista migration the two screens differ only in which vista is
+ * installed and which controls the vista `exposes` — the fetch, the lens, the
+ * search, the grouping, the capability wiring and the row adapter are the same
+ * code. Two slices would have been two copies of it, which is the `RC-32`
+ * failure ("a missing child feature or a missing Producer split") read
+ * backwards: the split would be the duplication.
+ *
+ * They stay **two independent instances** rather than one shared surface,
+ * because Find's filter chips and All Tasks' grouping are different user
+ * choices over different vistas: a search typed into Find must not appear in
+ * All Tasks, and each vista persists its own lens snapshot under its own id.
+ *
+ * ## The lens is stored flat, and materialised in a Selector
+ *
+ * `EndeavorsLens` carries `ReadonlySet`s, which are not serialisable and would
+ * trip the store's `serializableCheck`. State therefore holds the same eight
+ * user-mutable fields as plain arrays — the same arrangement `PlanState`
+ * arrived at — and `selectFindVista` / `selectTasksVista` materialise the real
+ * vista on top of the registry's defaults. `sort` and `exposes` are never
+ * stored, exactly as `lensApplyingSnapshot` refuses to restore them.
+ *
+ * ## One lifecycle field, with the pool beside it
+ *
+ * `load` is the single discriminated lifecycle (`RC-24`, `UZF-9`). The rows sit
+ * **beside** it rather than inside its `loaded` case, because canon keeps the
+ * fetched set usable through a failed refresh (`FindProducer`: *"On hard
+ * failure the existing data is kept"*) — a `loaded`-carries-the-data union
+ * could not represent "showing the last good list, and the refresh just
+ * failed" without throwing the list away.
+ */
+import type {
+  Endeavor,
+  EndeavorComputedState,
+  EndeavorGroupingCriteria,
+  EndeavorHost,
+  EndeavorKind,
+  EndeavorStatus,
+} from '@kro/core'
+import { EndeavorsVistas } from '@kro/core'
+import type { FindException } from './FindException'
+import type { EndeavorIntent } from './FindOperations'
+
+/** The one lifecycle field (`RC-24`, `UZF-9`). */
+export type FindLoadState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'loaded' }
+  | { readonly kind: 'failed'; readonly exception: FindException }
+
+/** The persisted, user-mutable half of a vista's lens, in plain form. */
+export interface FindLensState {
+  readonly hiddenKinds: readonly EndeavorKind[]
+  readonly hiddenHosts: readonly EndeavorHost[]
+  readonly hiddenStatuses: readonly EndeavorStatus[]
+  readonly hiddenComputedStates: readonly EndeavorComputedState[]
+  readonly hiddenCalendarIds: readonly string[]
+  readonly searchQuery: string
+  readonly showArchived: boolean
+  readonly grouping: EndeavorGroupingCriteria
+}
+
+/** One filter toggle, by axis — the shape every chip dispatches. */
+export type FindFilterToggle =
+  | { readonly axis: 'kind'; readonly value: EndeavorKind }
+  | { readonly axis: 'host'; readonly value: EndeavorHost }
+  | { readonly axis: 'status'; readonly value: EndeavorStatus }
+  | { readonly axis: 'computedState'; readonly value: EndeavorComputedState }
+  | { readonly axis: 'calendar'; readonly value: string }
+
+/**
+ * Which `.tasks*` vista the All Tasks surface is currently installed with.
+ *
+ * The registry's two parameterized entries are functions, so the *parameter*
+ * lives here and the vista is rebuilt from it — storing the built vista would
+ * put `Set`s in state and would pin a snapshot of the registry taken at mount.
+ */
+export type TasksVistaSelection =
+  | { readonly kind: 'default' }
+  | { readonly kind: 'today' }
+  | {
+      readonly kind: 'list'
+      readonly listId: string
+      /** The list's display title — canon's `selectedList.title`. */
+      readonly listTitle: string | null
+    }
+  /** `.tasksForSearch(query)` — the seed goes into the lens, not the query. */
+  | { readonly kind: 'search'; readonly query: string }
+
+/** One browsing surface's whole state. Two of these exist per store. */
+export interface FindSurfaceState {
+  readonly load: FindLoadState
+  /**
+   * The reconciled snapshot, installed in one pass. Not narrowed: the query and
+   * the lens are applied by the Selectors, so the "empty because there is no
+   * data" and "empty because of a filter" states stay tellable apart.
+   */
+  readonly endeavors: readonly Endeavor[]
+  /**
+   * The instant the snapshot was installed at. The lens's computed-state terms
+   * and the query's predicates are evaluated against it, so a Selector never
+   * has to read a clock (`RC-5`).
+   */
+  readonly clockAnchor: Date | null
+  /**
+   * False between mount and the persisted lens landing. Canon's `isLoadingLens`
+   * inverted: it lets a surface suppress a filter-driven empty hint until the
+   * user's saved filters are actually in place, and it is what makes a late
+   * restore lose to a filter the user has already touched.
+   */
+  readonly isLensRestored: boolean
+  /**
+   * The feature flags enabled at install, cached so capability gating is a pure
+   * read. Canon caches `isEndeavorDetailEnabled` at `.onViewLoaded` for exactly
+   * this reason: *"so the tap→Detail row binding can be flag-gated without a
+   * Selector reaching into `@Dependency`"*.
+   */
+  readonly enabledFlags: readonly string[]
+  /**
+   * The one group shown in full; `null` means every group is clipped to the
+   * vista's `itemLimit`. Canon's `currentFocusGroup`, by key.
+   */
+  readonly expandedGroupKey: string | null
+  readonly lens: FindLensState
+}
+
+export interface FindState {
+  /** The `.find` vista's surface. */
+  readonly find: FindSurfaceState
+  /** The All Tasks surface, over whichever `.tasks*` vista is selected. */
+  readonly tasks: FindSurfaceState
+  readonly tasksSelection: TasksVistaSelection
+  /**
+   * Canon's `TasksFeature.State.customTitle` — a caller-supplied heading
+   * override. Kept beside the selection rather than inside it because it is
+   * orthogonal to which vista is installed.
+   */
+  readonly tasksCustomTitle: string | null
+  /**
+   * Cross-feature requests awaiting their owner, oldest first. Drained by
+   * `childIntentDelegatedConsumed`, never by a view flipping a flag.
+   */
+  readonly intents: readonly EndeavorIntent[]
+  /** The next intent id. A counter, because a reducer has no clock. */
+  readonly nextIntentId: number
+}
+
+/** Flattens a registry lens into the plain, storable subset. */
+const lensStateOf = (lens: {
+  readonly hiddenKinds: ReadonlySet<EndeavorKind>
+  readonly hiddenHosts: ReadonlySet<EndeavorHost>
+  readonly hiddenStatuses: ReadonlySet<EndeavorStatus>
+  readonly hiddenComputedStates: ReadonlySet<EndeavorComputedState>
+  readonly hiddenCalendarIds: ReadonlySet<string>
+  readonly searchQuery: string
+  readonly showArchived: boolean
+  readonly grouping: EndeavorGroupingCriteria
+}): FindLensState => ({
+  hiddenKinds: [...lens.hiddenKinds],
+  hiddenHosts: [...lens.hiddenHosts],
+  hiddenStatuses: [...lens.hiddenStatuses],
+  hiddenComputedStates: [...lens.hiddenComputedStates],
+  hiddenCalendarIds: [...lens.hiddenCalendarIds],
+  searchQuery: lens.searchQuery,
+  showArchived: lens.showArchived,
+  grouping: lens.grouping,
+})
+
+/**
+ * The lens defaults each surface starts from, read from the registry rather
+ * than restated — so a registry edit cannot silently disagree with the slice's
+ * initial state.
+ */
+export const initialFindLens: FindLensState = lensStateOf(
+  EndeavorsVistas.find.lens,
+)
+
+export const initialTasksLens: FindLensState = lensStateOf(
+  EndeavorsVistas.tasksDefault.lens,
+)
+
+const emptySurface = (lens: FindLensState): FindSurfaceState => ({
+  load: { kind: 'idle' },
+  endeavors: [],
+  clockAnchor: null,
+  isLensRestored: false,
+  enabledFlags: [],
+  expandedGroupKey: null,
+  lens,
+})
+
+export const initialFindSurfaceState: FindSurfaceState =
+  emptySurface(initialFindLens)
+
+export const initialTasksSurfaceState: FindSurfaceState =
+  emptySurface(initialTasksLens)
+
+export const initialFindState: FindState = {
+  find: initialFindSurfaceState,
+  tasks: initialTasksSurfaceState,
+  tasksSelection: { kind: 'default' },
+  tasksCustomTitle: null,
+  intents: [],
+  nextIntentId: 1,
+}
+
+/** The lens defaults for a given `.tasks*` selection. */
+export const lensDefaultsForTasksSelection = (
+  selection: TasksVistaSelection,
+): FindLensState => {
+  switch (selection.kind) {
+    case 'today':
+      return lensStateOf(EndeavorsVistas.tasksToday.lens)
+    case 'list':
+      return lensStateOf(EndeavorsVistas.tasksForList(selection.listId).lens)
+    case 'search':
+      return lensStateOf(EndeavorsVistas.tasksForSearch(selection.query).lens)
+    default:
+      return lensStateOf(EndeavorsVistas.tasksDefault.lens)
+  }
+}
+
+/** The vista id a selection's lens snapshot is persisted under. */
+export const tasksVistaIdFor = (selection: TasksVistaSelection): string => {
+  switch (selection.kind) {
+    case 'today':
+      return EndeavorsVistas.tasksToday.id
+    case 'list':
+      return EndeavorsVistas.tasksForList(selection.listId).id
+    case 'search':
+      return EndeavorsVistas.tasksForSearch(selection.query).id
+    default:
+      return EndeavorsVistas.tasksDefault.id
+  }
+}
+
+/**
+ * Which empty state a surface is in. Canon's `FindView.mainContent` branches on
+ * exactly these four, in this order, and they are different messages for
+ * different reasons — telling them apart is the whole point of applying the
+ * query and the lens as two stages.
+ */
+export type FindEmptyState =
+  /** Nothing was fetched at all. "No Endeavors Yet". */
+  | { readonly kind: 'noData' }
+  /** Every kind, host and status is hidden and archived is off. "No Filters Selected". */
+  | { readonly kind: 'noFilters' }
+  /** A search is active and matched nothing. "No Results". */
+  | { readonly kind: 'noResults'; readonly query: string }
+  /** Rows exist, filters hid all of them. "Nothing Here". */
+  | { readonly kind: 'filteredOut' }

--- a/packages/app/src/features/find/__tests__/FindAdapters.test.ts
+++ b/packages/app/src/features/find/__tests__/FindAdapters.test.ts
@@ -1,0 +1,183 @@
+/**
+ * The Adapter layer — the only bridge from a vista's capabilities to a row's
+ * actions. The cases that matter are the ones a hand-rolled gesture list gets
+ * wrong: declaration order, the role's default tint, `buttonRow` positions, and
+ * a flag-gated binding that must simply not exist.
+ */
+import {
+  EndeavorOperation,
+  NO_ENDEAVOR_CAPABILITIES,
+  OperationRole,
+  OperationTint,
+  EndeavorsVistas,
+  buttonRowGesture,
+  contextMenuGesture,
+  makeEndeavorCapabilities,
+  makeEndeavorOperationBinding,
+  resolveEndeavorCapabilities,
+  swipeTrailingGesture,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  adaptedOperations,
+  endeavorRowAdapter,
+  endeavorRowAdapters,
+  rowActionsForGesture,
+} from '../FindAdapters'
+import { findEndeavorMocks } from '../FindMocks'
+
+const task = findEndeavorMocks.morningTask
+const allFlagsOff = resolveEndeavorCapabilities(
+  EndeavorsVistas.find.capabilities,
+  () => false,
+)
+const detailFlagOn = resolveEndeavorCapabilities(
+  EndeavorsVistas.find.capabilities,
+  (flag) => flag === 'endeavorDetail',
+)
+
+describe('endeavorRowAdapter maps the Find vista onto one row', () => {
+  it('keeps the leading swipe pair in declaration order — Start then Edit', () => {
+    const adapter = endeavorRowAdapter(task, allFlagsOff)
+    expect(adapter.leadingSwipeActions.map((action) => action.operation)).toEqual([
+      EndeavorOperation.startSession,
+      EndeavorOperation.edit,
+    ])
+  })
+
+  it('keeps the trailing swipe pair in declaration order — Delete then Archive', () => {
+    const adapter = endeavorRowAdapter(task, allFlagsOff)
+    expect(
+      adapter.trailingSwipeActions.map((action) => action.operation),
+    ).toEqual([EndeavorOperation.delete, EndeavorOperation.archive])
+  })
+
+  it('carries the row identity so a keyed list stays stable', () => {
+    expect(endeavorRowAdapter(task, allFlagsOff).id).toBe(task.id)
+  })
+
+  it('offers NO tap action while the endeavorDetail flag is off', () => {
+    expect(endeavorRowAdapter(task, allFlagsOff).tapAction).toBeNull()
+  })
+
+  it('offers the View Detail tap once the flag is on', () => {
+    const adapter = endeavorRowAdapter(task, detailFlagOn)
+    expect(adapter.tapAction?.operation).toBe(EndeavorOperation.viewDetail)
+  })
+
+  it('adapts a whole list in one pass', () => {
+    const adapters = endeavorRowAdapters(
+      [task, findEndeavorMocks.afternoonTask],
+      allFlagsOff,
+    )
+    expect(adapters.map((adapter) => adapter.id)).toEqual([
+      task.id,
+      findEndeavorMocks.afternoonTask.id,
+    ])
+  })
+
+  it('gives a display-only vista no actions at all', () => {
+    const adapter = endeavorRowAdapter(task, NO_ENDEAVOR_CAPABILITIES)
+    expect(adaptedOperations(adapter)).toEqual([])
+    expect(adapter.tapAction).toBeNull()
+  })
+})
+
+describe('tints and roles resolve exactly once, at the adapter', () => {
+  it('applies red to a destructive binding that declares no tint', () => {
+    const [deleteAction] = rowActionsForGesture(allFlagsOff, 'swipeTrailing')
+    expect(deleteAction?.role).toBe(OperationRole.destructive)
+    expect(deleteAction?.tint).toBe(OperationTint.red)
+  })
+
+  it('keeps a binding’s own tint over the role default', () => {
+    const actions = rowActionsForGesture(allFlagsOff, 'swipeLeading')
+    expect(actions[0]?.tint).toBe(OperationTint.green)
+    expect(actions[1]?.tint).toBe(OperationTint.blue)
+  })
+
+  it('leaves a standard binding with no tint of its own untinted', () => {
+    const capabilities = makeEndeavorCapabilities([
+      makeEndeavorOperationBinding({
+        operation: EndeavorOperation.triage,
+        gesture: contextMenuGesture,
+        icon: 'tray',
+        label: 'Triage',
+      }),
+    ])
+    expect(rowActionsForGesture(capabilities, 'contextMenu')[0]?.tint).toBeNull()
+  })
+})
+
+describe('buttonRow actions honour their declared position', () => {
+  const capabilities = makeEndeavorCapabilities([
+    makeEndeavorOperationBinding({
+      operation: EndeavorOperation.archive,
+      gesture: buttonRowGesture(2),
+      icon: 'archivebox',
+      label: 'Archive',
+    }),
+    makeEndeavorOperationBinding({
+      operation: EndeavorOperation.markComplete,
+      gesture: buttonRowGesture(1),
+      icon: 'checkmark',
+      label: 'Complete',
+    }),
+    makeEndeavorOperationBinding({
+      operation: EndeavorOperation.delete,
+      gesture: swipeTrailingGesture,
+      role: OperationRole.destructive,
+      icon: 'trash',
+      label: 'Delete',
+    }),
+  ])
+
+  it('renders the lower position first, whatever the declaration order', () => {
+    const adapter = endeavorRowAdapter(task, capabilities)
+    expect(adapter.buttonRowActions.map((action) => action.operation)).toEqual([
+      EndeavorOperation.markComplete,
+      EndeavorOperation.archive,
+    ])
+  })
+
+  it('carries each button’s position through for the renderer', () => {
+    const adapter = endeavorRowAdapter(task, capabilities)
+    expect(adapter.buttonRowActions.map((action) => action.position)).toEqual([
+      1, 2,
+    ])
+  })
+
+  it('leaves position null for every other gesture', () => {
+    const adapter = endeavorRowAdapter(task, capabilities)
+    expect(adapter.trailingSwipeActions[0]?.position).toBeNull()
+  })
+})
+
+describe('adaptedOperations reports exactly what the vista declared', () => {
+  it('surfaces every Find binding once the flag is on', () => {
+    const adapter = endeavorRowAdapter(task, detailFlagOn)
+    expect(adaptedOperations(adapter)).toEqual([
+      EndeavorOperation.startSession,
+      EndeavorOperation.edit,
+      EndeavorOperation.delete,
+      EndeavorOperation.archive,
+      EndeavorOperation.viewDetail,
+    ])
+  })
+
+  it('drops the gated one when its flag is off', () => {
+    const adapter = endeavorRowAdapter(task, allFlagsOff)
+    expect(adaptedOperations(adapter)).not.toContain(
+      EndeavorOperation.viewDetail,
+    )
+  })
+
+  it('de-duplicates an operation declared under two gestures', () => {
+    const adapter = endeavorRowAdapter(
+      task,
+      EndeavorsVistas.planDay.capabilities,
+    )
+    const operations = adaptedOperations(adapter)
+    expect(new Set(operations).size).toBe(operations.length)
+  })
+})

--- a/packages/app/src/features/find/__tests__/FindException.test.ts
+++ b/packages/app/src/features/find/__tests__/FindException.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The typed failure union. Each case is asserted on its `kind` and its
+ * `recoverable` flag, because those two are what a surface branches on — the
+ * message is copy, not control flow (`RC-8`).
+ */
+import { describe, expect, it } from 'vitest'
+import { FindExceptions, findExceptionMessage } from '../FindException'
+
+describe('FindExceptions carries a retryable answer per failure', () => {
+  it('marks a failed refresh retryable — the user can pull again', () => {
+    const exception = FindExceptions.fetchFailed('offline')
+    expect(exception.kind).toBe('fetchFailed')
+    expect(exception.recoverable).toBe(true)
+    expect(exception.message).toContain('offline')
+  })
+
+  it('marks a failed write retryable', () => {
+    expect(FindExceptions.operationFailed('disk full').recoverable).toBe(true)
+  })
+
+  it('marks a partial bulk operation retryable, naming the reason', () => {
+    const exception = FindExceptions.bulkOperationFailed('quota exceeded')
+    expect(exception.kind).toBe('bulkOperationFailed')
+    expect(exception.message).toContain('quota exceeded')
+  })
+
+  it('marks a stale row tap NOT retryable — the same lookup would miss again', () => {
+    const exception = FindExceptions.endeavorNotFound('ghost')
+    expect(exception.recoverable).toBe(false)
+    expect(exception.message).toContain('ghost')
+  })
+
+  it('carries the defensive fallback for a thunk that genuinely threw', () => {
+    expect(FindExceptions.unknown('boom').kind).toBe('unknown')
+  })
+})
+
+describe('findExceptionMessage narrows whatever was thrown', () => {
+  it('uses an Error’s own message', () => {
+    expect(findExceptionMessage(new Error('disk gone'))).toBe('disk gone')
+  })
+
+  it('stringifies a thrown non-Error', () => {
+    expect(findExceptionMessage('plain string')).toBe('plain string')
+  })
+
+  it('survives a thrown null without crashing the failure path', () => {
+    expect(findExceptionMessage(null)).toBe('null')
+  })
+})

--- a/packages/app/src/features/find/__tests__/FindFeature.test.ts
+++ b/packages/app/src/features/find/__tests__/FindFeature.test.ts
@@ -1,0 +1,505 @@
+/**
+ * Reducer arms.
+ *
+ * Synchronous arms are called directly against the slice's reducer — no store,
+ * no middleware (`RC-12`). Thunk lifecycle arms are driven through the **real**
+ * thunk against a stubbed `LocalStore` injected via `ThunkExtra` (`RC-54`), so
+ * the optimistic `.pending` write and the authoritative `.fulfilled` install are
+ * both exercised the way they actually run.
+ */
+import type { EndeavorRecord } from '@kro/core'
+import {
+  EndeavorKind,
+  EndeavorOperation,
+  EndeavorStatus,
+  endeavorRecordFromEndeavor,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { makeStore } from '../../../library/store'
+import { stubbedGreetingService } from '../../../services/greeting/GreetingService'
+import { makeInMemoryLocalStore } from '../../../services/localStore/InMemoryLocalStore'
+import {
+  childIntentDelegatedConsumed,
+  findSlice,
+  initialFindState,
+  onViewLoaded,
+  userDidChangeSearchQuery,
+  userDidSelectGrouping,
+  userDidSelectTasksVista,
+  userDidTapCollapseGroups,
+  userDidTapExpandGroup,
+  userDidToggleFilter,
+  userDidToggleShowArchived,
+} from '../FindFeature'
+import {
+  FIND_REFERENCE_NOW,
+  allFindEndeavorMocks,
+  findEndeavorMocks,
+  findStateMocks,
+} from '../FindMocks'
+import {
+  fetchFindEndeavorsThunk,
+  performBulkOperationThunk,
+  performEndeavorOperationThunk,
+  restoreFindLensThunk,
+} from '../FindProducer'
+
+const reducer = findSlice.reducer
+
+const recordsOf = (): readonly EndeavorRecord[] =>
+  allFindEndeavorMocks.map((endeavor) =>
+    endeavorRecordFromEndeavor(endeavor, { now: FIND_REFERENCE_NOW }),
+  )
+
+const storeWith = (records: readonly EndeavorRecord[] = recordsOf()) => {
+  const localStore = makeInMemoryLocalStore({ endeavors: records })
+  return makeStore({ greetingService: stubbedGreetingService, localStore })
+}
+
+describe('onViewLoaded — a surface mounts', () => {
+  it('stamps the clock and the flags for the surface that mounted', () => {
+    const next = reducer(
+      initialFindState,
+      onViewLoaded({
+        surface: 'find',
+        now: FIND_REFERENCE_NOW,
+        enabledFlags: ['endeavorDetail'],
+      }),
+    )
+    expect(next.find.clockAnchor).toEqual(FIND_REFERENCE_NOW)
+    expect(next.find.enabledFlags).toEqual(['endeavorDetail'])
+  })
+
+  it('leaves the other surface untouched', () => {
+    const next = reducer(
+      initialFindState,
+      onViewLoaded({ surface: 'tasks', now: FIND_REFERENCE_NOW, enabledFlags: [] }),
+    )
+    expect(next.find.clockAnchor).toBeNull()
+  })
+
+  it('re-arms the lens restore on a remount', () => {
+    const next = reducer(
+      findStateMocks.loaded,
+      onViewLoaded({ surface: 'find', now: FIND_REFERENCE_NOW, enabledFlags: [] }),
+    )
+    expect(next.find.isLensRestored).toBe(false)
+  })
+})
+
+describe('the filter and grouping intents', () => {
+  it('types a search query into the surface that asked', () => {
+    const next = reducer(
+      findStateMocks.loaded,
+      userDidChangeSearchQuery({ surface: 'find', query: 'slides' }),
+    )
+    expect(next.find.lens.searchQuery).toBe('slides')
+    expect(next.tasks.lens.searchQuery).toBe('')
+  })
+
+  it('flips a kind chip, then flips it back', () => {
+    const hidden = reducer(
+      findStateMocks.loaded,
+      userDidToggleFilter({
+        surface: 'find',
+        toggle: { axis: 'kind', value: EndeavorKind.habit },
+      }),
+    )
+    expect(hidden.find.lens.hiddenKinds).toEqual([EndeavorKind.habit])
+    const shown = reducer(
+      hidden,
+      userDidToggleFilter({
+        surface: 'find',
+        toggle: { axis: 'kind', value: EndeavorKind.habit },
+      }),
+    )
+    expect(shown.find.lens.hiddenKinds).toEqual([])
+  })
+
+  it('flips show-archived', () => {
+    const next = reducer(
+      findStateMocks.loaded,
+      userDidToggleShowArchived({ surface: 'find' }),
+    )
+    expect(next.find.lens.showArchived).toBe(true)
+  })
+
+  it('re-points All Tasks at another vista and resets its lens defaults', () => {
+    const next = reducer(
+      findStateMocks.tasksLoaded,
+      userDidSelectTasksVista({ selection: { kind: 'today' } }),
+    )
+    expect(next.tasksSelection).toEqual({ kind: 'today' })
+    expect(next.tasks.lens.grouping).toBe('dueSection')
+  })
+
+  it('changes the grouping and releases the focused group with it', () => {
+    const next = reducer(
+      findStateMocks.tasksExpanded,
+      userDidSelectGrouping({ surface: 'tasks', grouping: 'kind' }),
+    )
+    expect(next.tasks.lens.grouping).toBe('kind')
+    expect(next.tasks.expandedGroupKey).toBeNull()
+  })
+})
+
+describe('the group focus intents', () => {
+  it('expands one group', () => {
+    const next = reducer(
+      findStateMocks.tasksLoaded,
+      userDidTapExpandGroup({ surface: 'tasks', groupKey: 'pending' }),
+    )
+    expect(next.tasks.expandedGroupKey).toBe('pending')
+  })
+
+  it('replaces the focus on a second expand', () => {
+    const first = reducer(
+      findStateMocks.tasksLoaded,
+      userDidTapExpandGroup({ surface: 'tasks', groupKey: 'pending' }),
+    )
+    const second = reducer(
+      first,
+      userDidTapExpandGroup({ surface: 'tasks', groupKey: 'ongoing' }),
+    )
+    expect(second.tasks.expandedGroupKey).toBe('ongoing')
+  })
+
+  it('collapses back to clipped', () => {
+    const next = reducer(
+      findStateMocks.tasksExpanded,
+      userDidTapCollapseGroups({ surface: 'tasks' }),
+    )
+    expect(next.tasks.expandedGroupKey).toBeNull()
+  })
+})
+
+describe('childIntentDelegatedConsumed — the owner handled a request', () => {
+  it('drains the intent it names', () => {
+    const next = reducer(
+      findStateMocks.withPendingIntent,
+      childIntentDelegatedConsumed({ intentId: 1 }),
+    )
+    expect(next.intents).toEqual([])
+  })
+
+  it('ignores an id that is not queued', () => {
+    const next = reducer(
+      findStateMocks.withPendingIntent,
+      childIntentDelegatedConsumed({ intentId: 42 }),
+    )
+    expect(next.intents).toHaveLength(1)
+  })
+
+  it('is a no-op on an empty queue', () => {
+    const next = reducer(
+      findStateMocks.loaded,
+      childIntentDelegatedConsumed({ intentId: 1 }),
+    )
+    expect(next.intents).toEqual([])
+  })
+})
+
+describe('the fetch lifecycle', () => {
+  it('installs the day on success — user opens Find for the first time', async () => {
+    const store = storeWith()
+    await store.dispatch(
+      fetchFindEndeavorsThunk({ surface: 'find', now: FIND_REFERENCE_NOW }),
+    )
+    const { find } = store.getState().find
+    expect(find.load).toEqual({ kind: 'loaded' })
+    expect(find.endeavors).toHaveLength(allFindEndeavorMocks.length)
+  })
+
+  it('surfaces a typed exception when the store cannot be read', async () => {
+    const base = makeInMemoryLocalStore()
+    const store = makeStore({
+      greetingService: stubbedGreetingService,
+      localStore: {
+        ...base,
+        endeavors: {
+          ...base.endeavors,
+          all: async () => {
+            throw new Error('disk gone')
+          },
+        },
+      },
+    })
+    await store.dispatch(
+      fetchFindEndeavorsThunk({ surface: 'find', now: FIND_REFERENCE_NOW }),
+    )
+    const { load } = store.getState().find.find
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') expect(load.exception.kind).toBe('fetchFailed')
+  })
+
+  it('raises the loading lifecycle while the read is in flight', () => {
+    const pending = fetchFindEndeavorsThunk.pending('req', {
+      surface: 'find',
+      now: FIND_REFERENCE_NOW,
+    })
+    expect(reducer(findStateMocks.idle, pending).find.load).toEqual({
+      kind: 'loading',
+    })
+  })
+
+  it('stays quiet when a superseded read is aborted — the one silent exit', () => {
+    const rejected = {
+      ...fetchFindEndeavorsThunk.rejected(new Error('aborted'), 'req', {
+        surface: 'find',
+        now: FIND_REFERENCE_NOW,
+      }),
+      meta: {
+        arg: { surface: 'find' as const, now: FIND_REFERENCE_NOW },
+        requestId: 'req',
+        requestStatus: 'rejected' as const,
+        aborted: true,
+        condition: false,
+        rejectedWithValue: false,
+      },
+    }
+    expect(reducer(findStateMocks.loaded, rejected).find.load).toEqual({
+      kind: 'loaded',
+    })
+  })
+})
+
+describe('the lens restore lifecycle', () => {
+  it('settles with the vista defaults when nothing was saved', async () => {
+    const store = storeWith()
+    await store.dispatch(restoreFindLensThunk({ surface: 'find', vistaId: 'find' }))
+    expect(store.getState().find.find.isLensRestored).toBe(true)
+  })
+
+  it('settles even when the read throws, so the surface never waits forever', async () => {
+    const base = makeInMemoryLocalStore()
+    const store = makeStore({
+      greetingService: stubbedGreetingService,
+      localStore: {
+        ...base,
+        lensSnapshots: {
+          ...base.lensSnapshots,
+          read: async () => {
+            throw new Error('corrupt')
+          },
+        },
+      },
+    })
+    await store.dispatch(restoreFindLensThunk({ surface: 'find', vistaId: 'find' }))
+    expect(store.getState().find.find.isLensRestored).toBe(true)
+  })
+
+  it('applies a saved lens onto the surface it belongs to', async () => {
+    const localStore = makeInMemoryLocalStore({ endeavors: recordsOf() })
+    await localStore.lensSnapshots.write('find', {
+      hiddenKinds: new Set([EndeavorKind.habit]),
+      hiddenHosts: new Set(),
+      hiddenStatuses: new Set(),
+      hiddenComputedStates: new Set(),
+      hiddenCalendarIds: new Set(),
+      searchQuery: 'slides',
+      showArchived: true,
+      grouping: 'status',
+    })
+    const store = makeStore({
+      greetingService: stubbedGreetingService,
+      localStore,
+    })
+    await store.dispatch(restoreFindLensThunk({ surface: 'find', vistaId: 'find' }))
+    const { lens } = store.getState().find.find
+    expect(lens.searchQuery).toBe('slides')
+    expect(lens.showArchived).toBe(true)
+  })
+})
+
+describe('the operation lifecycle is optimistic, then authoritative', () => {
+  it('removes a deleted row on .pending, before the write resolves', () => {
+    const pending = performEndeavorOperationThunk.pending('req', {
+      surface: 'find',
+      operation: EndeavorOperation.delete,
+      endeavorId: findEndeavorMocks.morningTask.id,
+      now: FIND_REFERENCE_NOW,
+    })
+    const next = reducer(findStateMocks.loaded, pending)
+    expect(
+      next.find.endeavors.some(
+        (row) => row.id === findEndeavorMocks.morningTask.id,
+      ),
+    ).toBe(false)
+  })
+
+  it('applies the same effect the Producer will persist, on .pending', () => {
+    const pending = performEndeavorOperationThunk.pending('req', {
+      surface: 'find',
+      operation: EndeavorOperation.archive,
+      endeavorId: findEndeavorMocks.morningTask.id,
+      now: FIND_REFERENCE_NOW,
+    })
+    const next = reducer(findStateMocks.loaded, pending)
+    const row = next.find.endeavors.find(
+      (candidate) => candidate.id === findEndeavorMocks.morningTask.id,
+    )
+    expect(row?.status).toBe(EndeavorStatus.closed)
+  })
+
+  it('parks an intent for an operation another feature owns', async () => {
+    const store = storeWith()
+    await store.dispatch(
+      fetchFindEndeavorsThunk({ surface: 'find', now: FIND_REFERENCE_NOW }),
+    )
+    await store.dispatch(
+      performEndeavorOperationThunk({
+        surface: 'find',
+        operation: EndeavorOperation.startSession,
+        endeavorId: findEndeavorMocks.morningTask.id,
+        now: FIND_REFERENCE_NOW,
+      }),
+    )
+    const { intents } = store.getState().find
+    expect(intents).toHaveLength(1)
+    expect(intents[0]?.operation).toBe(EndeavorOperation.startSession)
+  })
+
+  it('surfaces a stale tap as a typed exception', async () => {
+    const store = storeWith([])
+    await store.dispatch(
+      performEndeavorOperationThunk({
+        surface: 'find',
+        operation: EndeavorOperation.markComplete,
+        endeavorId: 'ghost',
+        now: FIND_REFERENCE_NOW,
+      }),
+    )
+    const { load } = store.getState().find.find
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') expect(load.exception.kind).toBe('endeavorNotFound')
+  })
+
+  it('installs the authoritative row on success', async () => {
+    const store = storeWith()
+    await store.dispatch(
+      fetchFindEndeavorsThunk({ surface: 'find', now: FIND_REFERENCE_NOW }),
+    )
+    await store.dispatch(
+      performEndeavorOperationThunk({
+        surface: 'find',
+        operation: EndeavorOperation.markComplete,
+        endeavorId: findEndeavorMocks.morningTask.id,
+        now: FIND_REFERENCE_NOW,
+      }),
+    )
+    const row = store
+      .getState()
+      .find.find.endeavors.find(
+        (candidate) => candidate.id === findEndeavorMocks.morningTask.id,
+      )
+    expect(row?.status).toBe(EndeavorStatus.closed)
+  })
+})
+
+describe('the bulk lifecycle applies to the whole visible set at once', () => {
+  it('removes every named row on .pending — canon has no confirm step', () => {
+    const pending = performBulkOperationThunk.pending('req', {
+      surface: 'find',
+      operation: 'delete',
+      endeavorIds: [
+        findEndeavorMocks.morningTask.id,
+        findEndeavorMocks.afternoonTask.id,
+      ],
+      now: FIND_REFERENCE_NOW,
+    })
+    expect(reducer(findStateMocks.loaded, pending).find.endeavors).toHaveLength(
+      allFindEndeavorMocks.length - 2,
+    )
+  })
+
+  it('closes every named row on an archive-all, in place', () => {
+    const pending = performBulkOperationThunk.pending('req', {
+      surface: 'find',
+      operation: 'archive',
+      endeavorIds: [findEndeavorMocks.morningTask.id],
+      now: FIND_REFERENCE_NOW,
+    })
+    const next = reducer(findStateMocks.loaded, pending)
+    expect(next.find.endeavors).toHaveLength(allFindEndeavorMocks.length)
+    expect(
+      next.find.endeavors.find(
+        (row) => row.id === findEndeavorMocks.morningTask.id,
+      )?.status,
+    ).toBe(EndeavorStatus.closed)
+  })
+
+  it('records a genuinely thrown bulk write on the defensive .rejected arm', () => {
+    const arg = {
+      surface: 'find' as const,
+      operation: 'archive' as const,
+      endeavorIds: [findEndeavorMocks.morningTask.id],
+      now: FIND_REFERENCE_NOW,
+    }
+    const rejected = {
+      ...performBulkOperationThunk.rejected(new Error('boom'), 'req', arg),
+      meta: {
+        arg,
+        requestId: 'req',
+        requestStatus: 'rejected' as const,
+        aborted: false,
+        condition: false,
+        rejectedWithValue: false,
+      },
+    }
+    const { load } = reducer(findStateMocks.loaded, rejected).find
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') expect(load.exception.kind).toBe('unknown')
+  })
+
+  it('records a genuinely thrown row write on the defensive .rejected arm', () => {
+    const arg = {
+      surface: 'find' as const,
+      operation: EndeavorOperation.markComplete,
+      endeavorId: findEndeavorMocks.morningTask.id,
+      now: FIND_REFERENCE_NOW,
+    }
+    const rejected = {
+      ...performEndeavorOperationThunk.rejected(new Error('boom'), 'req', arg),
+      meta: {
+        arg,
+        requestId: 'req',
+        requestStatus: 'rejected' as const,
+        aborted: false,
+        condition: false,
+        rejectedWithValue: false,
+      },
+    }
+    const { load } = reducer(findStateMocks.loaded, rejected).find
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') expect(load.exception.kind).toBe('unknown')
+  })
+
+  it('reports a partial batch as a failure', async () => {
+    const base = makeInMemoryLocalStore({ endeavors: recordsOf() })
+    const store = makeStore({
+      greetingService: stubbedGreetingService,
+      localStore: {
+        ...base,
+        endeavors: {
+          ...base.endeavors,
+          put: async () => {
+            throw new Error('disk gone')
+          },
+        },
+      },
+    })
+    await store.dispatch(
+      performBulkOperationThunk({
+        surface: 'find',
+        operation: 'archive',
+        endeavorIds: [findEndeavorMocks.morningTask.id],
+        now: FIND_REFERENCE_NOW,
+      }),
+    )
+    const { load } = store.getState().find.find
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') {
+      expect(load.exception.kind).toBe('bulkOperationFailed')
+    }
+  })
+})

--- a/packages/app/src/features/find/__tests__/FindGrouping.test.ts
+++ b/packages/app/src/features/find/__tests__/FindGrouping.test.ts
@@ -1,0 +1,254 @@
+/**
+ * The grouping engine, exercised as pure functions — no store, no clock
+ * (`RC-56`). The cases that matter are canon's own edge rules: the `anytime`
+ * band leading, a multi-host row landing in two groups, the chunked sort, and
+ * the seven-per-group display limit with its expand.
+ */
+import type { Endeavor } from '@kro/core'
+import {
+  EndeavorGroupingCriteria,
+  EndeavorHost,
+  EndeavorKind,
+  EndeavorStatus,
+  ascendingBy,
+  descendingBy,
+  EndeavorSortingCriteria,
+  makeEndeavor,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import type { EndeavorRowGroup } from '../FindGrouping'
+import {
+  DEFAULT_GROUP_SORTING,
+  DaySection,
+  EndeavorGroupDisplayState,
+  daySectionDisplayName,
+  daySectionFromRawValue,
+  daySectionOrderIndex,
+  dueSectionOf,
+  groupDisplayState,
+  groupEndeavors,
+  limitGroup,
+  limitGroups,
+  sortEndeavorsByParameters,
+} from '../FindGrouping'
+import { findAt, findEndeavorMocks, nineOpenTasks } from '../FindMocks'
+
+/** The first group, or a loud failure — `noUncheckedIndexedAccess` is on. */
+const firstGroup = (groups: readonly EndeavorRowGroup[]): EndeavorRowGroup => {
+  const group = groups[0]
+  if (group === undefined) throw new Error('expected at least one group')
+  return group
+}
+
+const taskDueAt = (id: string, due: Date | null): Endeavor =>
+  makeEndeavor({
+    id,
+    title: id,
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.pending,
+    due,
+    hostedBy: [EndeavorHost.local],
+  })
+
+describe('dueSectionOf maps a due time onto canon’s wall-clock bands', () => {
+  it('puts an 09:00 task in the morning band', () => {
+    expect(dueSectionOf(taskDueAt('a', findAt(9)))).toBe(DaySection.morning)
+  })
+
+  it('treats 12:00 as the afternoon boundary, not the morning one', () => {
+    expect(dueSectionOf(taskDueAt('b', findAt(12)))).toBe(DaySection.afternoon)
+  })
+
+  it('puts a 02:00 task in late night, not night', () => {
+    expect(dueSectionOf(taskDueAt('c', findAt(2)))).toBe(DaySection.lateNight)
+  })
+
+  it('answers anytime for an endeavor with no due date at all', () => {
+    expect(dueSectionOf(taskDueAt('d', null))).toBe(DaySection.anytime)
+  })
+
+  it('orders anytime BEFORE every clock band, as canon does', () => {
+    expect(daySectionOrderIndex(DaySection.anytime)).toBeLessThan(
+      daySectionOrderIndex(DaySection.earlyMorning),
+    )
+  })
+
+  it('round-trips a raw group key and labels it for the picker', () => {
+    expect(daySectionFromRawValue('evening')).toBe(DaySection.evening)
+    expect(daySectionFromRawValue('teatime')).toBeNull()
+    expect(daySectionDisplayName(DaySection.lateNight)).toBe('Late Night')
+  })
+})
+
+describe('sortEndeavorsByParameters walks the parameters in chunks', () => {
+  const withDue = taskDueAt('due', findAt(9))
+  const earlierDue = taskDueAt('earlier', findAt(7))
+  const undated = taskDueAt('undated', null)
+
+  it('orders the rows that have a value for the first parameter', () => {
+    const sorted = sortEndeavorsByParameters(
+      [withDue, earlierDue],
+      [ascendingBy(EndeavorSortingCriteria.due)],
+    )
+    expect(sorted.map((row) => row.id)).toEqual(['earlier', 'due'])
+  })
+
+  it('leaves rows with no value for any parameter in arrival order, at the end', () => {
+    const sorted = sortEndeavorsByParameters(
+      [undated, withDue, earlierDue],
+      [ascendingBy(EndeavorSortingCriteria.due)],
+    )
+    expect(sorted.map((row) => row.id)).toEqual(['earlier', 'due', 'undated'])
+  })
+
+  it('hands the value-less remainder to the next parameter', () => {
+    const created = makeEndeavor({
+      id: 'created',
+      title: 'created',
+      kind: EndeavorKind.task,
+      createdAt: findAt(5),
+    })
+    const sorted = sortEndeavorsByParameters(
+      [created, withDue],
+      [
+        ascendingBy(EndeavorSortingCriteria.due),
+        descendingBy(EndeavorSortingCriteria.createdAt),
+      ],
+    )
+    expect(sorted.map((row) => row.id)).toEqual(['due', 'created'])
+  })
+
+  it('puts the most recently completed first under the default parameters', () => {
+    const early = makeEndeavor({
+      id: 'early',
+      title: 'early',
+      kind: EndeavorKind.task,
+      completed: findAt(8),
+    })
+    const late = makeEndeavor({
+      id: 'late',
+      title: 'late',
+      kind: EndeavorKind.task,
+      completed: findAt(10),
+    })
+    const sorted = sortEndeavorsByParameters(
+      [early, late],
+      DEFAULT_GROUP_SORTING,
+    )
+    expect(sorted.map((row) => row.id)).toEqual(['late', 'early'])
+  })
+
+  it('returns an empty list untouched', () => {
+    expect(sortEndeavorsByParameters([])).toEqual([])
+  })
+})
+
+describe('groupEndeavors partitions by the lens criterion', () => {
+  it('groups by status and orders the groups by canon’s status order', () => {
+    const groups = groupEndeavors(
+      [findEndeavorMocks.afternoonTask, findEndeavorMocks.morningTask],
+      EndeavorGroupingCriteria.status,
+    )
+    expect(groups.map((group) => group.key)).toEqual(['ongoing', 'pending'])
+    expect(groups[0]?.title).toBe('Ongoing')
+  })
+
+  it('puts a multi-host row in EVERY one of its host groups', () => {
+    const groups = groupEndeavors(
+      [findEndeavorMocks.mirroredTask],
+      EndeavorGroupingCriteria.host,
+    )
+    expect(groups.map((group) => group.key).sort()).toEqual([
+      'appleReminders',
+      'local',
+    ])
+  })
+
+  it('leaves a host-less row in no group at all, as canon does', () => {
+    const orphan = makeEndeavor({
+      id: 'orphan',
+      title: 'orphan',
+      kind: EndeavorKind.task,
+    })
+    expect(groupEndeavors([orphan], EndeavorGroupingCriteria.host)).toEqual([])
+  })
+
+  it('groups by due section with anytime leading', () => {
+    const groups = groupEndeavors(
+      [taskDueAt('morning', findAt(9)), taskDueAt('undated', null)],
+      EndeavorGroupingCriteria.dueSection,
+    )
+    expect(groups.map((group) => group.key)).toEqual(['anytime', 'morning'])
+  })
+
+  it('groups by kind, one membership per row', () => {
+    const groups = groupEndeavors(
+      [findEndeavorMocks.morningTask, findEndeavorMocks.teamSync],
+      EndeavorGroupingCriteria.kind,
+    )
+    expect(groups.map((group) => group.key).sort()).toEqual([
+      'calendarEvent',
+      'task',
+    ])
+  })
+
+  it('reports the pre-limit size on every group', () => {
+    const group = firstGroup(
+      groupEndeavors(nineOpenTasks, EndeavorGroupingCriteria.status),
+    )
+    expect(group.totalCount).toBe(9)
+    expect(group.isTrimmed).toBe(false)
+  })
+})
+
+describe('the seven-item display limit and its expand', () => {
+  const pending = firstGroup(
+    groupEndeavors(nineOpenTasks, EndeavorGroupingCriteria.status),
+  )
+
+  it('trims a nine-row group to seven and says it was trimmed', () => {
+    const limited = limitGroup(pending, 7)
+    expect(limited.endeavors).toHaveLength(7)
+    expect(limited.isTrimmed).toBe(true)
+    expect(limited.totalCount).toBe(9)
+  })
+
+  it('leaves a group at or under the limit alone', () => {
+    const small = firstGroup(
+      groupEndeavors(
+        [findEndeavorMocks.morningTask],
+        EndeavorGroupingCriteria.status,
+      ),
+    )
+    expect(limitGroup(small, 7).isTrimmed).toBe(false)
+  })
+
+  it('applies no limit at all when the vista declares none', () => {
+    const limited = limitGroup(pending, null)
+    expect(limited.endeavors).toHaveLength(9)
+  })
+
+  it('lifts the limit from EVERY group once one is expanded', () => {
+    const groups = groupEndeavors(
+      [...nineOpenTasks, findEndeavorMocks.afternoonTask],
+      EndeavorGroupingCriteria.status,
+    )
+    const clipped = limitGroups(groups, 7, null)
+    const expanded = limitGroups(groups, 7, 'pending')
+    expect(clipped.find((group) => group.key === 'pending')?.endeavors).toHaveLength(7)
+    expect(expanded.find((group) => group.key === 'pending')?.endeavors).toHaveLength(9)
+    expect(expanded.every((group) => !group.isTrimmed)).toBe(true)
+  })
+
+  it('reports clipped, expanded and collapsed display states', () => {
+    expect(groupDisplayState(pending, null)).toBe(
+      EndeavorGroupDisplayState.clipped,
+    )
+    expect(groupDisplayState(pending, 'pending')).toBe(
+      EndeavorGroupDisplayState.expanded,
+    )
+    expect(groupDisplayState(pending, 'ongoing')).toBe(
+      EndeavorGroupDisplayState.collapsed,
+    )
+  })
+})

--- a/packages/app/src/features/find/__tests__/FindMocks.test.ts
+++ b/packages/app/src/features/find/__tests__/FindMocks.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The fixtures themselves.
+ *
+ * A mocks file that has quietly drifted is worse than none: every suite in this
+ * feature builds its assertions on these, so the axes they claim to span are
+ * asserted here rather than assumed.
+ */
+import { EndeavorKind, EndeavorStatus } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  FIND_REFERENCE_NOW,
+  allFindEndeavorMocks,
+  findAt,
+  findEndeavorMocks,
+  findStateMocks,
+  nineOpenTasks,
+} from '../FindMocks'
+
+describe('the endeavor fixtures span the axes the surfaces filter on', () => {
+  it('is built from a fixed instant, so nothing depends on when the suite runs', () => {
+    expect(FIND_REFERENCE_NOW.getFullYear()).toBe(2026)
+    expect(findAt(9, 30).getHours()).toBe(9)
+  })
+
+  it('covers three kinds — task, calendar event and habit', () => {
+    const kinds = new Set(allFindEndeavorMocks.map((row) => row.kind))
+    expect(kinds).toContain(EndeavorKind.task)
+    expect(kinds).toContain(EndeavorKind.calendarEvent)
+    expect(kinds).toContain(EndeavorKind.habit)
+  })
+
+  it('includes an archived row, so the Show Archived rule has something to reveal', () => {
+    expect(findEndeavorMocks.archivedTask.status).toBe(EndeavorStatus.closed)
+  })
+
+  it('includes a multi-host row, so the "hide only when every host is hidden" rule bites', () => {
+    expect(findEndeavorMocks.mirroredTask.hostedBy).toHaveLength(2)
+  })
+
+  it('includes an undated row, so the anytime band and the nil-last sort are exercised', () => {
+    expect(findEndeavorMocks.undatedTask.due).toBeNull()
+  })
+
+  it('gives every fixture a distinct id', () => {
+    const ids = allFindEndeavorMocks.map((row) => row.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe('nineOpenTasks exists to exercise the seven-per-group limit', () => {
+  it('is two rows past the limit — enough to prove both the cut and the count', () => {
+    expect(nineOpenTasks).toHaveLength(9)
+  })
+
+  it('shares one status, so they land in one group', () => {
+    expect(new Set(nineOpenTasks.map((row) => row.status)).size).toBe(1)
+  })
+
+  it('gives each row a distinct id and due time', () => {
+    expect(new Set(nineOpenTasks.map((row) => row.id)).size).toBe(9)
+    expect(new Set(nineOpenTasks.map((row) => row.due?.getTime())).size).toBe(9)
+  })
+})
+
+describe('the state variants describe real situations', () => {
+  it('has an idle variant with nothing installed', () => {
+    expect(findStateMocks.idle.find.endeavors).toEqual([])
+  })
+
+  it('anchors every loaded variant to the reference instant', () => {
+    expect(findStateMocks.loaded.find.clockAnchor).toEqual(FIND_REFERENCE_NOW)
+    expect(findStateMocks.tasksLoaded.tasks.clockAnchor).toEqual(
+      FIND_REFERENCE_NOW,
+    )
+  })
+
+  it('keeps the rows through the failed variant, as the surface does', () => {
+    expect(findStateMocks.failedAfterLoad.find.load.kind).toBe('failed')
+    expect(findStateMocks.failedAfterLoad.find.endeavors.length).toBeGreaterThan(
+      0,
+    )
+  })
+
+  it('hides every kind, host and status in the everythingHidden variant', () => {
+    const { lens } = findStateMocks.everythingHidden.find
+    expect(lens.hiddenKinds).toHaveLength(7)
+    expect(lens.hiddenHosts).toHaveLength(6)
+    expect(lens.hiddenStatuses).toHaveLength(10)
+  })
+
+  it('queues exactly one intent in the withPendingIntent variant', () => {
+    expect(findStateMocks.withPendingIntent.intents).toHaveLength(1)
+    expect(findStateMocks.withPendingIntent.nextIntentId).toBe(2)
+  })
+})

--- a/packages/app/src/features/find/__tests__/FindOperations.test.ts
+++ b/packages/app/src/features/find/__tests__/FindOperations.test.ts
@@ -1,0 +1,208 @@
+/**
+ * The **capability-coverage** suite (acceptance criterion 1) plus the operation
+ * catalog's own rules.
+ *
+ * The coverage assertion walks the vista registry — every fixed vista *and* the
+ * two parameterized ones — collects the operations they declare, and demands a
+ * binding for each. It is written against the registry rather than a hand-kept
+ * list precisely so that a capability added to a vista in `@kro/core` fails here
+ * rather than reaching a user as a dead gesture.
+ */
+import type { EndeavorsVista } from '@kro/core'
+import {
+  EndeavorKind,
+  EndeavorOperation,
+  EndeavorStatus,
+  EndeavorsVistas,
+  endeavorOperations,
+  fixedEndeavorsVistas,
+  makeEndeavor,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  OperationEffect,
+  OperationHandling,
+  endeavorAfterOperation,
+  findOperationBinding,
+  findOperationBindings,
+  isIntentOperation,
+  isLocallyHandledOperation,
+  isRemovingOperation,
+  unboundOperations,
+  unboundVistaOperations,
+  vistaDeclaredOperations,
+} from '../FindOperations'
+import { FIND_REFERENCE_NOW, findEndeavorMocks } from '../FindMocks'
+
+/** Every vista the app can install, including the two parameterized ones. */
+const everyVista: readonly EndeavorsVista[] = [
+  ...fixedEndeavorsVistas,
+  EndeavorsVistas.tasksForList('list-1'),
+  EndeavorsVistas.tasksForSearch('slides'),
+]
+
+describe('capability coverage — no vista-declared operation is unbound', () => {
+  it('binds every operation the whole vista registry declares', () => {
+    expect(unboundVistaOperations(everyVista)).toEqual([])
+  })
+
+  it('binds every operation in the closed catalog, not only the declared ones', () => {
+    expect(unboundOperations()).toEqual([])
+  })
+
+  it('reports the operations the registry actually declares, de-duplicated', () => {
+    const declared = vistaDeclaredOperations(everyVista)
+    expect(declared).toContain(EndeavorOperation.markComplete)
+    expect(declared).toContain(EndeavorOperation.viewDetail)
+    expect(new Set(declared).size).toBe(declared.length)
+  })
+
+  it('gives every declared operation a handling and a destination', () => {
+    for (const operation of vistaDeclaredOperations(everyVista)) {
+      const binding = findOperationBinding(operation)
+      if (binding.handling === OperationHandling.local) {
+        expect(binding.effect).not.toBeNull()
+      } else {
+        expect(binding.consumer).not.toBeNull()
+      }
+    }
+  })
+
+  it('covers the Find vista in particular — the surface that exercises them all', () => {
+    const declared = vistaDeclaredOperations([EndeavorsVistas.find])
+    expect(declared).toEqual([
+      EndeavorOperation.startSession,
+      EndeavorOperation.edit,
+      EndeavorOperation.delete,
+      EndeavorOperation.archive,
+      EndeavorOperation.viewDetail,
+    ])
+    expect(unboundVistaOperations([EndeavorsVistas.find])).toEqual([])
+  })
+})
+
+describe('the catalog splits local writes from cross-feature intents', () => {
+  it('persists the six row mutations itself', () => {
+    expect(isLocallyHandledOperation(EndeavorOperation.markComplete)).toBe(true)
+    expect(isLocallyHandledOperation(EndeavorOperation.delete)).toBe(true)
+    expect(isLocallyHandledOperation(EndeavorOperation.unarchive)).toBe(true)
+  })
+
+  it('hands a focus session, a triage and a detail tap to their owners', () => {
+    expect(isIntentOperation(EndeavorOperation.startSession)).toBe(true)
+    expect(isIntentOperation(EndeavorOperation.triage)).toBe(true)
+    expect(isIntentOperation(EndeavorOperation.viewDetail)).toBe(true)
+  })
+
+  it('names a consumer for every intent, so nothing is silently dropped', () => {
+    for (const operation of endeavorOperations) {
+      const binding = findOperationBindings[operation]
+      if (binding.handling !== OperationHandling.intent) continue
+      expect(binding.consumer?.length ?? 0).toBeGreaterThan(0)
+    }
+  })
+
+  it('marks only delete as the operation that removes the row', () => {
+    const removing = endeavorOperations.filter(isRemovingOperation)
+    expect(removing).toEqual([EndeavorOperation.delete])
+  })
+})
+
+describe('endeavorAfterOperation is the one definition of each local effect', () => {
+  const task = findEndeavorMocks.morningTask
+  const request = (
+    operation: EndeavorOperation,
+    extra: Record<string, unknown> = {},
+  ) =>
+    ({
+      surface: 'find' as const,
+      operation,
+      endeavorId: task.id,
+      now: FIND_REFERENCE_NOW,
+      ...extra,
+    }) as Parameters<typeof endeavorAfterOperation>[1]
+
+  it('closes the row and stamps the backdated completion the user chose', () => {
+    const backdated = new Date(2026, 5, 17, 22, 0, 0)
+    const done = endeavorAfterOperation(
+      task,
+      request(EndeavorOperation.markComplete, { completionDate: backdated }),
+    )
+    expect(done.status).toBe(EndeavorStatus.closed)
+    expect(done.completed).toEqual(backdated)
+  })
+
+  it('falls back to now when no backdate was given', () => {
+    const done = endeavorAfterOperation(
+      task,
+      request(EndeavorOperation.markComplete),
+    )
+    expect(done.completed).toEqual(FIND_REFERENCE_NOW)
+  })
+
+  it('archives by closing the row WITHOUT a completion stamp', () => {
+    const archived = endeavorAfterOperation(
+      task,
+      request(EndeavorOperation.archive),
+    )
+    expect(archived.status).toBe(EndeavorStatus.closed)
+    expect(archived.completed).toBeNull()
+  })
+
+  it('reopens a completed row and clears its completion timestamp', () => {
+    const closed = endeavorAfterOperation(
+      task,
+      request(EndeavorOperation.markComplete),
+    )
+    const reopened = endeavorAfterOperation(
+      closed,
+      request(EndeavorOperation.markIncomplete),
+    )
+    expect(reopened.status).toBe(EndeavorStatus.pending)
+    expect(reopened.completed).toBeNull()
+  })
+
+  it('defers a task by moving due and appending the audit entry', () => {
+    const target = new Date(2026, 5, 19, 9, 0, 0)
+    const deferred = endeavorAfterOperation(
+      task,
+      request(EndeavorOperation.defer, {
+        deferTarget: target,
+        deferReason: 'blocked on review',
+      }),
+    )
+    expect(deferred.due).toEqual(target)
+    expect(deferred.defers).toHaveLength(1)
+    expect(deferred.defers[0]?.reason).toBe('blocked on review')
+  })
+
+  it('refuses to defer a calendar event — the matrix says it has no due date', () => {
+    const event = makeEndeavor({
+      id: 'event-1',
+      title: 'Team sync',
+      kind: EndeavorKind.calendarEvent,
+      start: FIND_REFERENCE_NOW,
+    })
+    const attempted = endeavorAfterOperation(
+      event,
+      request(EndeavorOperation.defer, { deferTarget: FIND_REFERENCE_NOW }),
+    )
+    // The domain returns the very same object when the matrix refuses.
+    expect(attempted).toBe(event)
+  })
+
+  it('leaves the row untouched for an operation someone else owns', () => {
+    expect(
+      endeavorAfterOperation(task, request(EndeavorOperation.startSession)),
+    ).toBe(task)
+  })
+
+  it('leaves the row untouched for a delete — the row is removed, not rewritten', () => {
+    expect(endeavorAfterOperation(task, request(EndeavorOperation.delete))).toBe(
+      task,
+    )
+    expect(findOperationBinding(EndeavorOperation.delete).effect).toBe(
+      OperationEffect.softDelete,
+    )
+  })
+})

--- a/packages/app/src/features/find/__tests__/FindProducer.test.ts
+++ b/packages/app/src/features/find/__tests__/FindProducer.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Producers are dispatched for real against a stubbed `LocalStore` injected
+ * through `ThunkExtra` — never a mocked `fetch`, never the live bindings
+ * (`RC-54`, `RC-35`). The assertions are on the resolved `Result`, because a
+ * Producer's contract is what it resolves.
+ */
+import type { EndeavorRecord } from '@kro/core'
+import {
+  EndeavorOperation,
+  EndeavorStatus,
+  endeavorRecordFromEndeavor,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { makeStore } from '../../../library/store'
+import { stubbedGreetingService } from '../../../services/greeting/GreetingService'
+import { makeInMemoryLocalStore } from '../../../services/localStore/InMemoryLocalStore'
+import {
+  FIND_REFERENCE_NOW,
+  allFindEndeavorMocks,
+  findEndeavorMocks,
+} from '../FindMocks'
+import {
+  fetchFindEndeavorsThunk,
+  performBulkOperationThunk,
+  performEndeavorOperationThunk,
+  persistFindLensThunk,
+  restoreFindLensThunk,
+} from '../FindProducer'
+
+const recordsOf = (): readonly EndeavorRecord[] =>
+  allFindEndeavorMocks.map((endeavor) =>
+    endeavorRecordFromEndeavor(endeavor, { now: FIND_REFERENCE_NOW }),
+  )
+
+const storeWith = (records: readonly EndeavorRecord[] = recordsOf()) => {
+  const localStore = makeInMemoryLocalStore({ endeavors: records })
+  return {
+    localStore,
+    store: makeStore({ greetingService: stubbedGreetingService, localStore }),
+  }
+}
+
+const failingStore = (message: string) => {
+  const base = makeInMemoryLocalStore({ endeavors: recordsOf() })
+  return makeStore({
+    greetingService: stubbedGreetingService,
+    localStore: {
+      ...base,
+      endeavors: {
+        ...base.endeavors,
+        all: async () => {
+          throw new Error(message)
+        },
+        put: async () => {
+          throw new Error(message)
+        },
+      },
+    },
+  })
+}
+
+const request = (
+  operation: EndeavorOperation,
+  endeavorId: string,
+  extra: Record<string, unknown> = {},
+) => ({
+  surface: 'find' as const,
+  operation,
+  endeavorId,
+  now: FIND_REFERENCE_NOW,
+  ...extra,
+})
+
+describe('fetchFindEndeavorsThunk reads the whole surface, unnarrowed', () => {
+  it('resolves every stored row for the surface that asked', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(fetchFindEndeavorsThunk({ surface: 'find', now: FIND_REFERENCE_NOW }))
+      .unwrap()
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.surface).toBe('find')
+      expect(result.value.endeavors).toHaveLength(allFindEndeavorMocks.length)
+    }
+  })
+
+  it('hands the rows through RAW — reconciliation is the install shifter’s', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(fetchFindEndeavorsThunk({ surface: 'find', now: FIND_REFERENCE_NOW }))
+      .unwrap()
+    expect(result.ok && result.value.now).toEqual(FIND_REFERENCE_NOW)
+  })
+
+  it('resolves a typed failure rather than throwing when the store is broken', async () => {
+    const store = failingStore('disk gone')
+    const result = await store
+      .dispatch(fetchFindEndeavorsThunk({ surface: 'find', now: FIND_REFERENCE_NOW }))
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('fetchFailed')
+  })
+
+  it('answers an empty store with an empty list, not a failure', async () => {
+    const { store } = storeWith([])
+    const result = await store
+      .dispatch(fetchFindEndeavorsThunk({ surface: 'find', now: FIND_REFERENCE_NOW }))
+      .unwrap()
+    expect(result.ok && result.value.endeavors).toEqual([])
+  })
+})
+
+describe('the lens round-trip', () => {
+  it('persists a lens and reads it back', async () => {
+    const { store, localStore } = storeWith()
+    await store
+      .dispatch(
+        persistFindLensThunk({
+          surface: 'find',
+          vistaId: 'find',
+          lens: {
+            hiddenKinds: ['habit'],
+            hiddenHosts: [],
+            hiddenStatuses: [],
+            hiddenComputedStates: [],
+            hiddenCalendarIds: [],
+            searchQuery: 'slides',
+            showArchived: true,
+            grouping: 'status',
+          },
+        }),
+      )
+      .unwrap()
+
+    expect(await localStore.lensSnapshots.read('find')).not.toBeNull()
+
+    const restored = await store
+      .dispatch(restoreFindLensThunk({ surface: 'find', vistaId: 'find' }))
+      .unwrap()
+    expect(restored.ok).toBe(true)
+    if (restored.ok && restored.value !== null) {
+      expect(restored.value.searchQuery).toBe('slides')
+      expect(restored.value.showArchived).toBe(true)
+      expect(restored.value.hiddenKinds).toEqual(['habit'])
+    }
+  })
+
+  it('resolves null when nothing was ever saved for that vista', async () => {
+    const { store } = storeWith()
+    const restored = await store
+      .dispatch(restoreFindLensThunk({ surface: 'find', vistaId: 'find' }))
+      .unwrap()
+    expect(restored.ok && restored.value).toBeNull()
+  })
+
+  it('stays SILENT on a read failure — a filter preference is not an error', async () => {
+    const base = makeInMemoryLocalStore()
+    const store = makeStore({
+      greetingService: stubbedGreetingService,
+      localStore: {
+        ...base,
+        lensSnapshots: {
+          ...base.lensSnapshots,
+          read: async () => {
+            throw new Error('corrupt row')
+          },
+        },
+      },
+    })
+    const restored = await store
+      .dispatch(restoreFindLensThunk({ surface: 'find', vistaId: 'find' }))
+      .unwrap()
+    expect(restored.ok && restored.value).toBeNull()
+  })
+
+  it('swallows a write failure too — the session’s filters still work', async () => {
+    const base = makeInMemoryLocalStore()
+    const store = makeStore({
+      greetingService: stubbedGreetingService,
+      localStore: {
+        ...base,
+        lensSnapshots: {
+          ...base.lensSnapshots,
+          write: async () => {
+            throw new Error('quota exceeded')
+          },
+        },
+      },
+    })
+    const result = await store
+      .dispatch(
+        persistFindLensThunk({
+          surface: 'find',
+          vistaId: 'find',
+          lens: {
+            hiddenKinds: [],
+            hiddenHosts: [],
+            hiddenStatuses: [],
+            hiddenComputedStates: [],
+            hiddenCalendarIds: [],
+            searchQuery: '',
+            showArchived: false,
+            grouping: 'status',
+          },
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('performEndeavorOperationThunk wires every declared capability', () => {
+  it('completes a row and persists the backdated completion', async () => {
+    const { store, localStore } = storeWith()
+    const backdated = new Date(2026, 5, 17, 22, 0, 0)
+    const result = await store
+      .dispatch(
+        performEndeavorOperationThunk(
+          request(EndeavorOperation.markComplete, findEndeavorMocks.morningTask.id, {
+            completionDate: backdated,
+          }),
+        ),
+      )
+      .unwrap()
+
+    expect(result.ok && result.value.kind).toBe('mutated')
+    const stored = await localStore.endeavors.get(
+      findEndeavorMocks.morningTask.id,
+    )
+    expect(stored?.status).toBe(EndeavorStatus.closed)
+    expect(stored?.completed).toEqual(backdated)
+  })
+
+  it('soft-deletes a row rather than rewriting it', async () => {
+    const { store, localStore } = storeWith()
+    const result = await store
+      .dispatch(
+        performEndeavorOperationThunk(
+          request(EndeavorOperation.delete, findEndeavorMocks.morningTask.id),
+        ),
+      )
+      .unwrap()
+
+    expect(result.ok && result.value.kind).toBe('removed')
+    expect(
+      await localStore.endeavors.get(findEndeavorMocks.morningTask.id),
+    ).toBeNull()
+  })
+
+  it('archives by closing the row without stamping a completion', async () => {
+    const { store, localStore } = storeWith()
+    await store
+      .dispatch(
+        performEndeavorOperationThunk(
+          request(EndeavorOperation.archive, findEndeavorMocks.morningTask.id),
+        ),
+      )
+      .unwrap()
+    const stored = await localStore.endeavors.get(
+      findEndeavorMocks.morningTask.id,
+    )
+    expect(stored?.status).toBe(EndeavorStatus.closed)
+    expect(stored?.completed).toBeNull()
+  })
+
+  it('writes both rows of a defer: the moved due AND the audit entry', async () => {
+    const { store, localStore } = storeWith()
+    const target = new Date(2026, 5, 19, 9, 0, 0)
+    await store
+      .dispatch(
+        performEndeavorOperationThunk(
+          request(EndeavorOperation.defer, findEndeavorMocks.morningTask.id, {
+            deferTarget: target,
+            deferReason: 'blocked',
+          }),
+        ),
+      )
+      .unwrap()
+
+    const stored = await localStore.endeavors.get(
+      findEndeavorMocks.morningTask.id,
+    )
+    expect(stored?.due).toEqual(target)
+    const defers = await localStore.defers.forEndeavor(
+      findEndeavorMocks.morningTask.id,
+    )
+    expect(defers).toHaveLength(1)
+    expect(defers[0]?.reason).toBe('blocked')
+  })
+
+  it('writes NEITHER row when the matrix refuses the defer', async () => {
+    const { store, localStore } = storeWith()
+    await store
+      .dispatch(
+        performEndeavorOperationThunk(
+          request(EndeavorOperation.defer, findEndeavorMocks.teamSync.id, {
+            deferTarget: new Date(2026, 5, 19, 9, 0, 0),
+          }),
+        ),
+      )
+      .unwrap()
+    expect(
+      await localStore.defers.forEndeavor(findEndeavorMocks.teamSync.id),
+    ).toEqual([])
+  })
+
+  it('resolves an intent — not a failure — for an operation someone else owns', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(
+        performEndeavorOperationThunk(
+          request(EndeavorOperation.startSession, findEndeavorMocks.morningTask.id),
+        ),
+      )
+      .unwrap()
+    expect(result.ok && result.value.kind).toBe('intent')
+  })
+
+  it('reports a stale tap on a row that is no longer stored', async () => {
+    const { store } = storeWith([])
+    const result = await store
+      .dispatch(
+        performEndeavorOperationThunk(
+          request(EndeavorOperation.markComplete, 'ghost'),
+        ),
+      )
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('endeavorNotFound')
+  })
+
+  it('resolves a typed failure when the write itself throws', async () => {
+    const store = failingStore('disk gone')
+    const result = await store
+      .dispatch(
+        performEndeavorOperationThunk(
+          request(EndeavorOperation.markComplete, findEndeavorMocks.morningTask.id),
+        ),
+      )
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('operationFailed')
+  })
+})
+
+describe('performBulkOperationThunk applies to exactly the visible rows', () => {
+  it('deletes every id it was given', async () => {
+    const { store, localStore } = storeWith()
+    const ids = [
+      findEndeavorMocks.morningTask.id,
+      findEndeavorMocks.afternoonTask.id,
+    ]
+    const result = await store
+      .dispatch(
+        performBulkOperationThunk({
+          surface: 'find',
+          operation: 'delete',
+          endeavorIds: ids,
+          now: FIND_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(true)
+    for (const id of ids) {
+      expect(await localStore.endeavors.get(id)).toBeNull()
+    }
+  })
+
+  it('archives every id it was given, leaving the rest alone', async () => {
+    const { store, localStore } = storeWith()
+    await store
+      .dispatch(
+        performBulkOperationThunk({
+          surface: 'find',
+          operation: 'archive',
+          endeavorIds: [findEndeavorMocks.morningTask.id],
+          now: FIND_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(
+      (await localStore.endeavors.get(findEndeavorMocks.morningTask.id))?.status,
+    ).toBe(EndeavorStatus.closed)
+    expect(
+      (await localStore.endeavors.get(findEndeavorMocks.afternoonTask.id))
+        ?.status,
+    ).toBe(EndeavorStatus.ongoing)
+  })
+
+  it('skips an id that is no longer stored instead of failing the batch', async () => {
+    const { store } = storeWith()
+    const result = await store
+      .dispatch(
+        performBulkOperationThunk({
+          surface: 'find',
+          operation: 'archive',
+          endeavorIds: ['ghost', findEndeavorMocks.morningTask.id],
+          now: FIND_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(true)
+  })
+
+  it('reports a partial batch as a failure rather than claiming success', async () => {
+    const store = failingStore('disk gone')
+    const result = await store
+      .dispatch(
+        performBulkOperationThunk({
+          surface: 'find',
+          operation: 'archive',
+          endeavorIds: [findEndeavorMocks.morningTask.id],
+          now: FIND_REFERENCE_NOW,
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('bulkOperationFailed')
+  })
+})

--- a/packages/app/src/features/find/__tests__/FindSelectors.test.ts
+++ b/packages/app/src/features/find/__tests__/FindSelectors.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Selectors run against a hand-built root state, never a live store (`RC-55`).
+ * The other registered slices are filled from their own initial states only
+ * because `RootState` names every one of them; this suite asserts nothing about
+ * them.
+ *
+ * The cases here are the ones acceptance criterion 2 is about: canon's search,
+ * archived and filter rules, the four distinguishable empty states, and the
+ * seven-per-group limit with its expand.
+ */
+import { EndeavorKind, EndeavorStatus } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { initialDoState } from '../../do/DoFeature'
+import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
+import { initialGreetingState } from '../../greeting/GreetingFeature'
+import type { RootState } from '../../../library/store'
+import { initialPlanState } from '../../plan/PlanState'
+import {
+  FIND_REFERENCE_NOW,
+  allFindEndeavorMocks,
+  findEndeavorMocks,
+  findStateMocks,
+} from '../FindMocks'
+import type { FindState } from '../FindState'
+import { withFilterToggled, withSearchQuery, withShowArchivedToggled } from '../FindShifters'
+import {
+  selectFindAreAllKindsHidden,
+  selectFindCapabilities,
+  selectFindEmptyState,
+  selectFindException,
+  selectFindHasNoFiltersSelected,
+  selectFindNextIntent,
+  selectFindPendingIntents,
+  selectFindRowAdapters,
+  selectFindRows,
+  selectFindSelectedHosts,
+  selectFindSelectedKinds,
+  selectFindSelectedStatuses,
+  selectFindShowArchived,
+  selectFindVisibleCount,
+  selectFindVisibleIds,
+  selectFindVista,
+  selectIsFindLensLoading,
+  selectIsFindLoading,
+  selectTasksEmptyState,
+  selectTasksGroupAdapters,
+  selectTasksGroups,
+  selectTasksHeading,
+  selectTasksTitle,
+  selectTasksVista,
+} from '../FindSelectors'
+
+const rootWith = (find: FindState): RootState => ({
+  greeting: initialGreetingState,
+  // Present only because `RootState` names every registered slice; this suite
+  // asserts nothing about Do, Plan or Endeavor Detail.
+  do: initialDoState,
+  plan: initialPlanState,
+  find,
+  endeavorDetail: initialEndeavorDetailState,
+})
+
+const loaded = rootWith(findStateMocks.loaded)
+
+describe('the vista is materialised from the registry plus the stored lens', () => {
+  it('carries the user’s search into the Find vista’s lens', () => {
+    const typed = withSearchQuery(findStateMocks.loaded, {
+      surface: 'find',
+      query: 'slides',
+    })
+    expect(selectFindVista(rootWith(typed)).lens.searchQuery).toBe('slides')
+  })
+
+  it('keeps the registry’s exposes set, which a saved lens may never rewrite', () => {
+    expect([...selectFindVista(loaded).lens.exposes].sort()).toEqual([
+      'hosts',
+      'kinds',
+      'search',
+      'showArchived',
+      'statuses',
+    ])
+  })
+
+  it('picks the tasks vista the selection names', () => {
+    const today = {
+      ...findStateMocks.tasksLoaded,
+      tasksSelection: { kind: 'today' as const },
+    }
+    expect(selectTasksVista(rootWith(today)).id).toBe('tasks.today')
+  })
+})
+
+describe('capabilities resolve against the flags cached at install', () => {
+  it('drops the flag-gated View Detail tap while the flag is off', () => {
+    const operations = selectFindCapabilities(loaded).operations.map(
+      (binding) => binding.operation,
+    )
+    expect(operations).not.toContain('viewDetail')
+  })
+
+  it('keeps it once the flag was on at install', () => {
+    const withFlag = rootWith(findStateMocks.loadedWithDetailFlag)
+    const operations = selectFindCapabilities(withFlag).operations.map(
+      (binding) => binding.operation,
+    )
+    expect(operations).toContain('viewDetail')
+  })
+
+  it('feeds the adapters, so a gated tap simply does not exist on a row', () => {
+    expect(selectFindRowAdapters(loaded)[0]?.tapAction).toBeNull()
+    expect(
+      selectFindRowAdapters(rootWith(findStateMocks.loadedWithDetailFlag))[0]
+        ?.tapAction?.operation,
+    ).toBe('viewDetail')
+  })
+})
+
+describe('Find’s displayed rows follow canon’s lens and sort', () => {
+  it('hides closed rows until Show Archived is on', () => {
+    expect(
+      selectFindRows(loaded).some(
+        (row) => row.id === findEndeavorMocks.archivedTask.id,
+      ),
+    ).toBe(false)
+
+    const shown = withShowArchivedToggled(findStateMocks.loaded, {
+      surface: 'find',
+    })
+    expect(
+      selectFindRows(rootWith(shown)).some(
+        (row) => row.id === findEndeavorMocks.archivedTask.id,
+      ),
+    ).toBe(true)
+  })
+
+  it('matches the search case-insensitively against the title', () => {
+    const typed = withSearchQuery(findStateMocks.loaded, {
+      surface: 'find',
+      query: 'SLIDES',
+    })
+    expect(selectFindRows(rootWith(typed)).map((row) => row.id)).toEqual([
+      findEndeavorMocks.morningTask.id,
+    ])
+  })
+
+  it('sorts by start ?? due ascending, with undated rows trailing', () => {
+    const ids = selectFindRows(loaded).map((row) => row.id)
+    expect(ids[0]).toBe(findEndeavorMocks.morningTask.id)
+    expect(ids[ids.length - 1]).toMatch(/undated|habit/)
+  })
+
+  it('keeps a multi-host row while ONE of its hosts is still shown', () => {
+    const hidden = withFilterToggled(findStateMocks.loaded, {
+      surface: 'find',
+      toggle: { axis: 'host', value: 'local' },
+    })
+    expect(
+      selectFindRows(rootWith(hidden)).some(
+        (row) => row.id === findEndeavorMocks.mirroredTask.id,
+      ),
+    ).toBe(true)
+  })
+
+  it('short-circuits to empty when every filter is off', () => {
+    expect(selectFindRows(rootWith(findStateMocks.everythingHidden))).toEqual([])
+  })
+
+  it('reports the visible count and ids the bulk menu acts on', () => {
+    expect(selectFindVisibleCount(loaded)).toBe(selectFindRows(loaded).length)
+    expect(selectFindVisibleIds(loaded)).toEqual(
+      selectFindRows(loaded).map((row) => row.id),
+    )
+  })
+})
+
+describe('the filter chips read the complement of the hidden sets', () => {
+  it('shows every kind while nothing is hidden', () => {
+    expect(selectFindSelectedKinds(loaded)).toHaveLength(7)
+  })
+
+  it('drops the one the user deselected', () => {
+    const hidden = withFilterToggled(findStateMocks.loaded, {
+      surface: 'find',
+      toggle: { axis: 'kind', value: EndeavorKind.habit },
+    })
+    expect(selectFindSelectedKinds(rootWith(hidden))).not.toContain(
+      EndeavorKind.habit,
+    )
+  })
+
+  it('answers the same way for hosts and statuses', () => {
+    const hidden = withFilterToggled(findStateMocks.loaded, {
+      surface: 'find',
+      toggle: { axis: 'status', value: EndeavorStatus.qa },
+    })
+    expect(selectFindSelectedHosts(loaded)).toHaveLength(6)
+    expect(selectFindSelectedStatuses(rootWith(hidden))).not.toContain(
+      EndeavorStatus.qa,
+    )
+  })
+
+  it('reports "no filters selected" only when everything is off AND archived is hidden', () => {
+    expect(selectFindHasNoFiltersSelected(loaded)).toBe(false)
+    expect(
+      selectFindHasNoFiltersSelected(rootWith(findStateMocks.everythingHidden)),
+    ).toBe(true)
+  })
+
+  it('tells "all kinds hidden" apart from "no data"', () => {
+    expect(selectFindAreAllKindsHidden(loaded)).toBe(false)
+    expect(
+      selectFindAreAllKindsHidden(rootWith(findStateMocks.everythingHidden)),
+    ).toBe(true)
+  })
+
+  it('exposes the archived toggle as the chip renders it', () => {
+    expect(selectFindShowArchived(loaded)).toBe(false)
+  })
+})
+
+describe('the four empty states are told apart, in canon’s branch order', () => {
+  it('says "no data" when nothing was fetched at all', () => {
+    expect(selectFindEmptyState(rootWith(findStateMocks.idle))).toEqual({
+      kind: 'noData',
+    })
+  })
+
+  it('says "no filters" before it would say "no results"', () => {
+    expect(
+      selectFindEmptyState(rootWith(findStateMocks.everythingHidden)),
+    ).toEqual({ kind: 'noFilters' })
+  })
+
+  it('says "no results" when a search matched nothing', () => {
+    expect(
+      selectFindEmptyState(rootWith(findStateMocks.searchWithNoMatches)),
+    ).toEqual({ kind: 'noResults', query: 'zzzz' })
+  })
+
+  it('says "filtered out" when rows exist but filters hid all of them', () => {
+    const hidden = withFilterToggled(findStateMocks.loaded, {
+      surface: 'find',
+      toggle: { axis: 'status', value: EndeavorStatus.pending },
+    })
+    const alsoHidden = withFilterToggled(
+      withFilterToggled(hidden, {
+        surface: 'find',
+        toggle: { axis: 'status', value: EndeavorStatus.ongoing },
+      }),
+      { surface: 'find', toggle: { axis: 'status', value: EndeavorStatus.planned } },
+    )
+    expect(selectFindEmptyState(rootWith(alsoHidden))).toEqual({
+      kind: 'filteredOut',
+    })
+  })
+
+  it('answers null while there is something to show', () => {
+    expect(selectFindEmptyState(loaded)).toBeNull()
+  })
+})
+
+describe('All Tasks groups, limits and expands', () => {
+  const tasks = rootWith(findStateMocks.tasksLoaded)
+
+  it('clips every group to the vista’s seven-row limit', () => {
+    const [group] = selectTasksGroups(tasks)
+    expect(group?.endeavors).toHaveLength(7)
+    expect(group?.isTrimmed).toBe(true)
+    expect(group?.totalCount).toBe(9)
+  })
+
+  it('lifts the limit for the group the user expanded', () => {
+    const [group] = selectTasksGroups(rootWith(findStateMocks.tasksExpanded))
+    expect(group?.endeavors).toHaveLength(9)
+    expect(group?.isTrimmed).toBe(false)
+  })
+
+  it('narrows by the vista’s own kinds — All Tasks shows tasks only', () => {
+    const mixed = rootWith(findStateMocks.tasksMixed)
+    const kinds = new Set(
+      selectTasksGroups(mixed).flatMap((group) =>
+        group.endeavors.map((row) => row.kind),
+      ),
+    )
+    expect([...kinds]).toEqual([EndeavorKind.task])
+  })
+
+  it('adapts every visible row against the tasks capabilities', () => {
+    const [first] = selectTasksGroupAdapters(tasks)
+    expect(first?.rows).toHaveLength(7)
+    expect(first?.rows[0]?.trailingSwipeActions.map((a) => a.operation)).toEqual(
+      ['markComplete', 'delete'],
+    )
+  })
+
+  it('tells its own empty states apart', () => {
+    expect(selectTasksEmptyState(rootWith(findStateMocks.idle))).toEqual({
+      kind: 'noData',
+    })
+    expect(selectTasksEmptyState(tasks)).toBeNull()
+  })
+})
+
+describe('the All Tasks heading follows canon’s fallback ladder', () => {
+  it('prefers the caller’s override', () => {
+    const custom = {
+      ...findStateMocks.tasksLoaded,
+      tasksCustomTitle: 'Today’s work',
+    }
+    expect(selectTasksHeading(rootWith(custom))).toBe('Today’s work')
+  })
+
+  it('then the scoped list’s own title', () => {
+    const list = {
+      ...findStateMocks.tasksLoaded,
+      tasksSelection: {
+        kind: 'list' as const,
+        listId: 'l-1',
+        listTitle: 'Groceries',
+      },
+    }
+    expect(selectTasksHeading(rootWith(list))).toBe('Groceries')
+    expect(selectTasksTitle(rootWith(list))).toBe('List')
+  })
+
+  it('then the live search, then the generic label', () => {
+    const searching = withSearchQuery(findStateMocks.tasksLoaded, {
+      surface: 'tasks',
+      query: 'slides',
+    })
+    expect(selectTasksHeading(rootWith(searching))).toBe('Searching: "slides"')
+    expect(selectTasksTitle(rootWith(searching))).toBe('Search')
+    expect(selectTasksHeading(rootWith(findStateMocks.tasksLoaded))).toBe('Tasks')
+    expect(selectTasksTitle(rootWith(findStateMocks.tasksLoaded))).toBe('')
+  })
+
+  it('says "Tasks" as the subtitle for a predicate-scoped vista', () => {
+    const today = {
+      ...findStateMocks.tasksLoaded,
+      tasksSelection: { kind: 'today' as const },
+    }
+    expect(selectTasksTitle(rootWith(today))).toBe('Tasks')
+  })
+})
+
+describe('lifecycle and intents', () => {
+  it('reports the loading and failed lifecycles', () => {
+    expect(selectIsFindLoading(rootWith(findStateMocks.loading))).toBe(true)
+    expect(selectFindException(rootWith(findStateMocks.failedAfterLoad))?.kind).toBe(
+      'fetchFailed',
+    )
+  })
+
+  it('suppresses a filter-driven empty hint until the saved lens has landed', () => {
+    expect(selectIsFindLensLoading(rootWith(findStateMocks.idle))).toBe(true)
+    expect(selectIsFindLensLoading(loaded)).toBe(false)
+  })
+
+  it('hands the oldest parked intent over first', () => {
+    const withIntent = rootWith(findStateMocks.withPendingIntent)
+    expect(selectFindPendingIntents(withIntent)).toHaveLength(1)
+    expect(selectFindNextIntent(withIntent)?.operation).toBe('startSession')
+    expect(selectFindNextIntent(loaded)).toBeNull()
+  })
+
+  it('classifies against the anchored clock, never a live one', () => {
+    expect(findStateMocks.loaded.find.clockAnchor).toEqual(FIND_REFERENCE_NOW)
+    expect(selectFindRows(loaded)).toHaveLength(
+      allFindEndeavorMocks.length - 1, // the archived row is hidden
+    )
+  })
+})

--- a/packages/app/src/features/find/__tests__/FindSelectors.test.ts
+++ b/packages/app/src/features/find/__tests__/FindSelectors.test.ts
@@ -10,6 +10,7 @@
  */
 import { EndeavorKind, EndeavorStatus } from '@kro/core'
 import { describe, expect, it } from 'vitest'
+import { initialCaptureState } from '../../capture/CaptureFeature'
 import { initialDoState } from '../../do/DoFeature'
 import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
 import { initialGreetingState } from '../../greeting/GreetingFeature'
@@ -53,8 +54,9 @@ import {
 const rootWith = (find: FindState): RootState => ({
   greeting: initialGreetingState,
   // Present only because `RootState` names every registered slice; this suite
-  // asserts nothing about Do, Plan or Endeavor Detail.
+  // asserts nothing about Do, Capture, Plan or Endeavor Detail.
   do: initialDoState,
+  capture: initialCaptureState,
   plan: initialPlanState,
   find,
   endeavorDetail: initialEndeavorDetailState,

--- a/packages/app/src/features/find/__tests__/FindShifters.test.ts
+++ b/packages/app/src/features/find/__tests__/FindShifters.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Shifters are pure: no store, no dispatch, no clock (`RC-56`). Every case
+ * states the real situation it is about, and every `State` comes from
+ * `FindMocks` rather than being built inline (`RC-31`).
+ */
+import { EndeavorKind, EndeavorStatus } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  FIND_REFERENCE_NOW,
+  allFindEndeavorMocks,
+  findEndeavorMocks,
+  findStateMocks,
+} from '../FindMocks'
+import { FindExceptions } from '../FindException'
+import {
+  surfaceOf,
+  withEndeavorReplaced,
+  withEndeavorsInstalled,
+  withFetchStarted,
+  withFilterToggled,
+  withFindException,
+  withFindViewLoaded,
+  withGroupExpanded,
+  withGroupsCollapsed,
+  withGrouping,
+  withIntentConsumed,
+  withIntentEnqueued,
+  withLensSnapshotRestored,
+  withRowsArchived,
+  withRowsRemoved,
+  withSearchQuery,
+  withShowArchivedToggled,
+  withSurface,
+  withTasksVistaSelected,
+} from '../FindShifters'
+
+describe('withFindViewLoaded arms a surface for its first paint', () => {
+  it('stamps the clock the surface will classify against', () => {
+    const next = withFindViewLoaded(findStateMocks.idle, {
+      surface: 'find',
+      now: FIND_REFERENCE_NOW,
+      enabledFlags: [],
+    })
+    expect(next.find.clockAnchor).toEqual(FIND_REFERENCE_NOW)
+  })
+
+  it('caches the flags the capability gating will read', () => {
+    const next = withFindViewLoaded(findStateMocks.idle, {
+      surface: 'find',
+      now: FIND_REFERENCE_NOW,
+      enabledFlags: ['endeavorDetail'],
+    })
+    expect(next.find.enabledFlags).toEqual(['endeavorDetail'])
+  })
+
+  it('re-arms the lens restore on a remount, so saved filters are asked for again', () => {
+    const next = withFindViewLoaded(findStateMocks.loaded, {
+      surface: 'find',
+      now: FIND_REFERENCE_NOW,
+      enabledFlags: [],
+    })
+    expect(next.find.isLensRestored).toBe(false)
+  })
+
+  it('touches only the surface it names', () => {
+    const next = withFindViewLoaded(findStateMocks.idle, {
+      surface: 'tasks',
+      now: FIND_REFERENCE_NOW,
+      enabledFlags: [],
+    })
+    expect(next.find.clockAnchor).toBeNull()
+    expect(next.tasks.clockAnchor).toEqual(FIND_REFERENCE_NOW)
+  })
+})
+
+describe('withLensSnapshotRestored settles the saved-filter race', () => {
+  const armed = withFindViewLoaded(findStateMocks.idle, {
+    surface: 'find',
+    now: FIND_REFERENCE_NOW,
+    enabledFlags: [],
+  })
+
+  it('applies the snapshot when the user has touched nothing', () => {
+    const next = withLensSnapshotRestored(armed, {
+      surface: 'find',
+      lens: { ...armed.find.lens, searchQuery: 'slides' },
+    })
+    expect(next.find.lens.searchQuery).toBe('slides')
+    expect(next.find.isLensRestored).toBe(true)
+  })
+
+  it('settles with the vista defaults when nothing was ever saved', () => {
+    const next = withLensSnapshotRestored(armed, { surface: 'find', lens: null })
+    expect(next.find.lens).toEqual(armed.find.lens)
+    expect(next.find.isLensRestored).toBe(true)
+  })
+
+  it('loses to a filter the user has already touched — their live choice wins', () => {
+    const typed = withSearchQuery(armed, { surface: 'find', query: 'live' })
+    const late = withLensSnapshotRestored(typed, {
+      surface: 'find',
+      lens: { ...armed.find.lens, searchQuery: 'stale' },
+    })
+    expect(late.find.lens.searchQuery).toBe('live')
+  })
+})
+
+describe('withEndeavorsInstalled installs one snapshot atomically', () => {
+  it('replaces the pool and marks the surface loaded', () => {
+    const next = withEndeavorsInstalled(findStateMocks.idle, {
+      surface: 'find',
+      endeavors: allFindEndeavorMocks,
+      now: FIND_REFERENCE_NOW,
+    })
+    expect(next.find.load).toEqual({ kind: 'loaded' })
+    expect(next.find.endeavors).toHaveLength(allFindEndeavorMocks.length)
+  })
+
+  it('moves the clock anchor with the install, so the two never disagree', () => {
+    const later = new Date(2026, 5, 18, 18, 0, 0)
+    const next = withEndeavorsInstalled(findStateMocks.loaded, {
+      surface: 'find',
+      endeavors: allFindEndeavorMocks,
+      now: later,
+    })
+    expect(next.find.clockAnchor).toEqual(later)
+  })
+
+  it('installs an empty day without complaint', () => {
+    const next = withEndeavorsInstalled(findStateMocks.loaded, {
+      surface: 'find',
+      endeavors: [],
+      now: FIND_REFERENCE_NOW,
+    })
+    expect(next.find.endeavors).toEqual([])
+    expect(next.find.load).toEqual({ kind: 'loaded' })
+  })
+})
+
+describe('withFetchStarted / withFindException keep the last good list', () => {
+  it('raises the loading lifecycle', () => {
+    expect(withFetchStarted(findStateMocks.idle, { surface: 'find' }).find.load)
+      .toEqual({ kind: 'loading' })
+  })
+
+  it('keeps the installed rows through a failed refresh', () => {
+    const next = withFindException(findStateMocks.loaded, {
+      surface: 'find',
+      exception: FindExceptions.fetchFailed('offline'),
+    })
+    expect(next.find.endeavors).toHaveLength(allFindEndeavorMocks.length)
+    expect(next.find.load.kind).toBe('failed')
+  })
+
+  it('reports the failure on the surface that asked, not the other one', () => {
+    const next = withFindException(findStateMocks.loaded, {
+      surface: 'tasks',
+      exception: FindExceptions.fetchFailed('offline'),
+    })
+    expect(next.find.load.kind).toBe('loaded')
+    expect(next.tasks.load.kind).toBe('failed')
+  })
+})
+
+describe('the lens toggles', () => {
+  it('hides a kind the user deselected', () => {
+    const next = withFilterToggled(findStateMocks.loaded, {
+      surface: 'find',
+      toggle: { axis: 'kind', value: EndeavorKind.habit },
+    })
+    expect(next.find.lens.hiddenKinds).toEqual([EndeavorKind.habit])
+  })
+
+  it('shows it again on a second tap', () => {
+    const hidden = withFilterToggled(findStateMocks.loaded, {
+      surface: 'find',
+      toggle: { axis: 'kind', value: EndeavorKind.habit },
+    })
+    const shown = withFilterToggled(hidden, {
+      surface: 'find',
+      toggle: { axis: 'kind', value: EndeavorKind.habit },
+    })
+    expect(shown.find.lens.hiddenKinds).toEqual([])
+  })
+
+  it('toggles a host and a status on their own axes', () => {
+    const next = withFilterToggled(
+      withFilterToggled(findStateMocks.loaded, {
+        surface: 'find',
+        toggle: { axis: 'host', value: 'local' },
+      }),
+      { surface: 'find', toggle: { axis: 'status', value: EndeavorStatus.qa } },
+    )
+    expect(next.find.lens.hiddenHosts).toEqual(['local'])
+    expect(next.find.lens.hiddenStatuses).toEqual([EndeavorStatus.qa])
+  })
+
+  it('toggles a computed state, the axis Do’s lens uses', () => {
+    const next = withFilterToggled(findStateMocks.loaded, {
+      surface: 'find',
+      toggle: { axis: 'computedState', value: 'overdue' },
+    })
+    expect(next.find.lens.hiddenComputedStates).toEqual(['overdue'])
+  })
+
+  it('toggles a calendar id, which the lens carries but never filters on', () => {
+    const next = withFilterToggled(findStateMocks.loaded, {
+      surface: 'find',
+      toggle: { axis: 'calendar', value: 'cal-1' },
+    })
+    expect(next.find.lens.hiddenCalendarIds).toEqual(['cal-1'])
+    // Canon's `apply` has no calendar term — the choice only persists.
+    expect(next.find.endeavors).toHaveLength(
+      findStateMocks.loaded.find.endeavors.length,
+    )
+  })
+
+  it('flips show-archived', () => {
+    const next = withShowArchivedToggled(findStateMocks.loaded, {
+      surface: 'find',
+    })
+    expect(next.find.lens.showArchived).toBe(true)
+  })
+
+  it('stores the search query verbatim, folding case only at comparison time', () => {
+    const next = withSearchQuery(findStateMocks.loaded, {
+      surface: 'find',
+      query: 'Slides',
+    })
+    expect(next.find.lens.searchQuery).toBe('Slides')
+  })
+
+  it('releases the expanded group when the grouping criterion changes', () => {
+    const expanded = withGroupExpanded(findStateMocks.tasksLoaded, {
+      surface: 'tasks',
+      groupKey: 'pending',
+    })
+    const regrouped = withGrouping(expanded, {
+      surface: 'tasks',
+      grouping: 'dueSection',
+    })
+    expect(regrouped.tasks.expandedGroupKey).toBeNull()
+    expect(regrouped.tasks.lens.grouping).toBe('dueSection')
+  })
+})
+
+describe('the group focus', () => {
+  it('opens one group', () => {
+    const next = withGroupExpanded(findStateMocks.tasksLoaded, {
+      surface: 'tasks',
+      groupKey: 'pending',
+    })
+    expect(next.tasks.expandedGroupKey).toBe('pending')
+  })
+
+  it('replaces the focus rather than accumulating one', () => {
+    const next = withGroupExpanded(
+      withGroupExpanded(findStateMocks.tasksLoaded, {
+        surface: 'tasks',
+        groupKey: 'pending',
+      }),
+      { surface: 'tasks', groupKey: 'ongoing' },
+    )
+    expect(next.tasks.expandedGroupKey).toBe('ongoing')
+  })
+
+  it('releases it', () => {
+    const next = withGroupsCollapsed(findStateMocks.tasksExpanded, {
+      surface: 'tasks',
+    })
+    expect(next.tasks.expandedGroupKey).toBeNull()
+  })
+})
+
+describe('withTasksVistaSelected re-points All Tasks', () => {
+  it('installs the selection and its own lens defaults', () => {
+    const next = withTasksVistaSelected(findStateMocks.tasksLoaded, {
+      selection: { kind: 'today' },
+    })
+    expect(next.tasksSelection).toEqual({ kind: 'today' })
+    expect(next.tasks.lens.grouping).toBe('dueSection')
+  })
+
+  it('carries a caller-supplied heading override', () => {
+    const next = withTasksVistaSelected(findStateMocks.tasksLoaded, {
+      selection: { kind: 'list', listId: 'l-1', listTitle: 'Groceries' },
+      customTitle: 'Shopping',
+    })
+    expect(next.tasksCustomTitle).toBe('Shopping')
+  })
+
+  it('re-arms the lens restore and drops the previous focus', () => {
+    const next = withTasksVistaSelected(findStateMocks.tasksExpanded, {
+      selection: { kind: 'search', query: 'slides' },
+    })
+    expect(next.tasks.isLensRestored).toBe(false)
+    expect(next.tasks.expandedGroupKey).toBeNull()
+  })
+})
+
+describe('the optimistic row mutations', () => {
+  it('removes a deleted row before the write resolves', () => {
+    const next = withRowsRemoved(findStateMocks.loaded, {
+      surface: 'find',
+      endeavorIds: [findEndeavorMocks.morningTask.id],
+    })
+    expect(
+      next.find.endeavors.some(
+        (row) => row.id === findEndeavorMocks.morningTask.id,
+      ),
+    ).toBe(false)
+  })
+
+  it('closes an archived row IN PLACE, so Show Archived reveals it again', () => {
+    const next = withRowsArchived(findStateMocks.loaded, {
+      surface: 'find',
+      endeavorIds: [findEndeavorMocks.morningTask.id],
+    })
+    const row = next.find.endeavors.find(
+      (candidate) => candidate.id === findEndeavorMocks.morningTask.id,
+    )
+    expect(row?.status).toBe(EndeavorStatus.closed)
+  })
+
+  it('replaces a row the write rewrote', () => {
+    const rewritten = {
+      ...findEndeavorMocks.morningTask,
+      title: 'Prepare the deck',
+    }
+    const next = withEndeavorReplaced(findStateMocks.loaded, {
+      surface: 'find',
+      endeavor: rewritten,
+    })
+    expect(
+      next.find.endeavors.find((row) => row.id === rewritten.id)?.title,
+    ).toBe('Prepare the deck')
+  })
+
+  it('does NOT resurrect a row that already left the pool', () => {
+    const removed = withRowsRemoved(findStateMocks.loaded, {
+      surface: 'find',
+      endeavorIds: [findEndeavorMocks.morningTask.id],
+    })
+    const next = withEndeavorReplaced(removed, {
+      surface: 'find',
+      endeavor: findEndeavorMocks.morningTask,
+    })
+    expect(next.find.endeavors).toHaveLength(allFindEndeavorMocks.length - 1)
+  })
+})
+
+describe('the intent queue', () => {
+  it('parks a request with the surface it came from', () => {
+    const next = withIntentEnqueued(findStateMocks.loaded, {
+      surface: 'find',
+      operation: 'startSession',
+      endeavorId: findEndeavorMocks.morningTask.id,
+    })
+    expect(next.intents).toHaveLength(1)
+    expect(next.intents[0]?.surface).toBe('find')
+  })
+
+  it('issues a fresh id per request, so two taps are two intents', () => {
+    const twice = withIntentEnqueued(
+      withIntentEnqueued(findStateMocks.loaded, {
+        surface: 'find',
+        operation: 'startSession',
+        endeavorId: 'a',
+      }),
+      { surface: 'find', operation: 'startSession', endeavorId: 'b' },
+    )
+    expect(twice.intents.map((entry) => entry.id)).toEqual([1, 2])
+    expect(twice.nextIntentId).toBe(3)
+  })
+
+  it('drains by id, never by position', () => {
+    const next = withIntentConsumed(findStateMocks.withPendingIntent, {
+      intentId: 1,
+    })
+    expect(next.intents).toEqual([])
+  })
+
+  it('ignores an unknown id, so a double acknowledgement is harmless', () => {
+    const next = withIntentConsumed(findStateMocks.withPendingIntent, {
+      intentId: 99,
+    })
+    expect(next.intents).toHaveLength(1)
+  })
+})
+
+describe('withSurface and surfaceOf are the one lift and read', () => {
+  it('writes the Find surface back', () => {
+    const next = withSurface(findStateMocks.idle, 'find', {
+      ...findStateMocks.idle.find,
+      expandedGroupKey: 'pending',
+    })
+    expect(next.find.expandedGroupKey).toBe('pending')
+    expect(next.tasks.expandedGroupKey).toBeNull()
+  })
+
+  it('writes the Tasks surface back', () => {
+    const next = withSurface(findStateMocks.idle, 'tasks', {
+      ...findStateMocks.idle.tasks,
+      expandedGroupKey: 'ongoing',
+    })
+    expect(next.tasks.expandedGroupKey).toBe('ongoing')
+  })
+
+  it('reads whichever surface is named', () => {
+    expect(surfaceOf(findStateMocks.loaded, 'find').endeavors).toHaveLength(
+      allFindEndeavorMocks.length,
+    )
+    expect(surfaceOf(findStateMocks.loaded, 'tasks').endeavors).toEqual([])
+  })
+})

--- a/packages/app/src/features/find/__tests__/FindState.test.ts
+++ b/packages/app/src/features/find/__tests__/FindState.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The initial state and the vista-selection helpers.
+ *
+ * The point of these cases is that nothing here is restated: the lens defaults
+ * are read from the registry, so a registry edit shows up as a failure here
+ * rather than as a surface that quietly disagrees with its own vista.
+ */
+import { EndeavorsVistas } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  initialFindLens,
+  initialFindState,
+  initialTasksLens,
+  lensDefaultsForTasksSelection,
+  tasksVistaIdFor,
+} from '../FindState'
+
+describe('the initial state mirrors the registry, never a copy of it', () => {
+  it('starts Find on the `.find` vista’s own lens defaults', () => {
+    expect(initialFindLens.grouping).toBe(EndeavorsVistas.find.lens.grouping)
+    expect(initialFindLens.showArchived).toBe(
+      EndeavorsVistas.find.lens.showArchived,
+    )
+  })
+
+  it('starts All Tasks on `.tasksDefault`’s lens defaults', () => {
+    expect(initialTasksLens.grouping).toBe(
+      EndeavorsVistas.tasksDefault.lens.grouping,
+    )
+  })
+
+  it('starts both surfaces idle, with nothing installed and no intent queued', () => {
+    expect(initialFindState.find.load).toEqual({ kind: 'idle' })
+    expect(initialFindState.tasks.endeavors).toEqual([])
+    expect(initialFindState.intents).toEqual([])
+    expect(initialFindState.nextIntentId).toBe(1)
+  })
+
+  it('starts All Tasks on the default selection, with no heading override', () => {
+    expect(initialFindState.tasksSelection).toEqual({ kind: 'default' })
+    expect(initialFindState.tasksCustomTitle).toBeNull()
+  })
+})
+
+describe('a tasks selection carries its vista’s own defaults and id', () => {
+  it('groups Today by due section, as that vista declares', () => {
+    expect(lensDefaultsForTasksSelection({ kind: 'today' }).grouping).toBe(
+      'dueSection',
+    )
+  })
+
+  it('seeds the search vista’s lens with the query it was opened for', () => {
+    expect(
+      lensDefaultsForTasksSelection({ kind: 'search', query: 'slides' })
+        .searchQuery,
+    ).toBe('slides')
+  })
+
+  it('scopes a list vista’s id to the list, so each list saves its own lens', () => {
+    expect(tasksVistaIdFor({ kind: 'list', listId: 'l-1', listTitle: null })).toBe(
+      'tasks.list.l-1',
+    )
+    expect(tasksVistaIdFor({ kind: 'list', listId: 'l-2', listTitle: null })).toBe(
+      'tasks.list.l-2',
+    )
+  })
+
+  it('names the fixed vistas’ own ids for the other selections', () => {
+    expect(tasksVistaIdFor({ kind: 'default' })).toBe('tasks.default')
+    expect(tasksVistaIdFor({ kind: 'today' })).toBe('tasks.today')
+    expect(tasksVistaIdFor({ kind: 'search', query: 'x' })).toBe('tasks.search')
+  })
+
+  it('stores the lens as plain arrays, so the store’s serializable check passes', () => {
+    expect(Array.isArray(initialFindLens.hiddenKinds)).toBe(true)
+    expect(Array.isArray(initialFindLens.hiddenStatuses)).toBe(true)
+  })
+})

--- a/packages/app/src/features/find/index.ts
+++ b/packages/app/src/features/find/index.ts
@@ -1,0 +1,17 @@
+/**
+ * The Find/Tasks feature's public surface — a pure re-export barrel.
+ *
+ * `#30` (Find, All Tasks and Detail UI) imports from here rather than reaching
+ * into individual modules, so the boundary between the logic tier and the
+ * render tier is one line to read.
+ */
+export * from './FindAdapters'
+export * from './FindException'
+export * from './FindFeature'
+export * from './FindGrouping'
+export * from './FindMocks'
+export * from './FindOperations'
+export * from './FindProducer'
+export * from './FindSelectors'
+export * from './FindShifters'
+export * from './FindState'

--- a/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
+++ b/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
@@ -2,6 +2,8 @@ import { greetingMocks } from '@kro/core/mocks'
 import { describe, expect, it } from 'vitest'
 import { initialCaptureState } from '../../capture/CaptureFeature'
 import { initialDoState } from '../../do/DoFeature'
+import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
+import { initialFindState } from '../../find/FindState'
 import type { RootState } from '../../../library/store'
 import { initialPlanState } from '../../plan/PlanState'
 import type { GreetingState } from '../GreetingFeature'
@@ -16,15 +18,17 @@ import {
 
 /**
  * Selectors are exercised against a hand-built root state, never a live store.
- * `do` (#16), `plan` (#18) and `capture` (#23) are filled from their own initial
- * states only because `RootState` names every registered slice; this suite
- * asserts nothing about any of them.
+ * `do` (#16), `plan` (#18), `capture` (#23), `find` and `endeavorDetail` (#29)
+ * are filled from their own initial states only because `RootState` names every
+ * registered slice; this suite asserts nothing about any of them.
  */
 const rootWith = (greeting: GreetingState): RootState => ({
   greeting,
   do: initialDoState,
   plan: initialPlanState,
   capture: initialCaptureState,
+  find: initialFindState,
+  endeavorDetail: initialEndeavorDetailState,
 })
 
 describe('selectGreeting', () => {

--- a/packages/app/src/features/plan/__tests__/PlanSelectors.test.ts
+++ b/packages/app/src/features/plan/__tests__/PlanSelectors.test.ts
@@ -13,6 +13,8 @@ import {
 import { describe, expect, it } from 'vitest'
 import { initialCaptureState } from '../../capture/CaptureFeature'
 import { initialDoState } from '../../do/DoFeature'
+import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
+import { initialFindState } from '../../find/FindState'
 import { initialGreetingState } from '../../greeting/GreetingFeature'
 import type { RootState } from '../../../library/store'
 import { addingPlanDays, planDayKey, startOfPlanDay } from '../PlanCalendar'
@@ -56,11 +58,13 @@ const tomorrow = addingPlanDays(today, 1)
 
 const rootWith = (plan: PlanState): RootState => ({
   greeting: initialGreetingState,
-  // Present only because `RootState` names every registered slice (#16, #23);
-  // this suite asserts nothing about Do or Capture.
+  // Present only because `RootState` names every registered slice (#16, #23,
+  // #29); this suite asserts nothing about Do, Capture, Find or Detail.
   do: initialDoState,
   capture: initialCaptureState,
   plan,
+  find: initialFindState,
+  endeavorDetail: initialEndeavorDetailState,
 })
 
 describe('selectPlanViewMode and the FAB rules', () => {

--- a/packages/app/src/library/store.ts
+++ b/packages/app/src/library/store.ts
@@ -18,6 +18,8 @@ import type { LocalStore } from '@kro/core'
 import { configureStore, isPlain } from '@reduxjs/toolkit'
 import { captureSlice } from '../features/capture/CaptureFeature'
 import { doSlice } from '../features/do/DoFeature'
+import { endeavorDetailSlice } from '../features/endeavorDetail/EndeavorDetailFeature'
+import { findSlice } from '../features/find/FindFeature'
 import { greetingSlice } from '../features/greeting/GreetingFeature'
 import { planSlice } from '../features/plan/PlanFeature'
 import {
@@ -70,6 +72,8 @@ export const makeStore = (extra: ThunkExtra = liveThunkExtra) =>
       do: doSlice.reducer,
       capture: captureSlice.reducer,
       plan: planSlice.reducer,
+      find: findSlice.reducer,
+      endeavorDetail: endeavorDetailSlice.reducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({


### PR DESCRIPTION
> 🟥 **Ichigo · Substitute** — the local plane, entire · *local, on your creds · I open PRs for **you** to merge (I never merge `main`, never review my own work)*
>
> Authored locally (Claude Code session, on behalf of @zheref) — no CI run.
> `Bankai-Agent: ichigo`

# What this changes for you

Find, All Tasks and Endeavor Detail now have their **logic tier**. Nothing renders yet — `#30` owns every pixel — but from this branch on, the two vista-browsing surfaces and the whole Detail/Edit/Duration/relations stack are answerable as pure functions and reducer arms.

Concretely:

- **Find** browses the `.find` vista: live search, kind/host/status chips, show-archived, the four distinguishable empty states, and the ellipsis bulk operations (Delete-all-visible / Archive-all-visible).
- **All Tasks** browses `.tasksDefault` / `.tasksToday` / `.tasksForList(id)` / `.tasksForSearch(q)`: grouping by status, due section, kind or host, with the seven-rows-per-group display limit and its expand.
- **Every capability the vista registry declares is bound.** A row's gestures come from one Adapter, and each operation resolves either to a local write this feature persists or to a cross-feature **intent** parked for its owner. A test walks the registry and asserts nothing is unbound.
- **Endeavor Detail** presents the grouped cards, the kind + state badges, and the four relation cards with their per-kind manageability. **Edit** honours the kind-relevance matrix end to end. **Duration** carries the three authored bounds over a read-only observed focus time. **Relations** list performances / defers / hosts / shadows with add-forms and a stated reason wherever a relation is read-only.

Closes #29.

## Canon

Ported from `zheref/KroApple@2c1ee45` — re-fetched `origin/main` at build time and it is **the same commit** as the epic's pin, so there is no canon drift to report. Sources: `Kro/Application/Find/*`, `KroUI/Find/FindAdapters.swift` + `FindView.swift`, `Kro/Application/Tasks/*`, `Kro/Application/EndeavorDetail/*`, `Kro/Application/EndeavorEdit/*`, and the four relation features (`EndeavorPerformances` / `EndeavorDefers` / `EndeavorHosts` / `EndeavorShadows`) with their Views' empty/read-only copy.

## How to verify

Everything below is local. `make typecheck && make test && make lint && make build` are green on this branch (2054 tests, 62 files).

### AC 1 — every capability the vistas declare maps to a working operation, with its flag gating

```bash
pnpm --filter @kro/app exec vitest run src/features/find/__tests__/FindOperations.test.ts
```

- `unboundVistaOperations(everyVista)` is `[]` for **all six fixed vistas plus both parameterized ones** — the assertion reads the registry, so a capability added in `@kro/core` fails here rather than becoming a dead gesture.
- `unboundOperations()` is `[]` for the whole closed `EndeavorOperation` catalog, not just the currently-declared subset.
- Flag gating: `FindSelectors.test.ts` → *"drops the flag-gated View Detail tap while the flag is off"* / *"keeps it once the flag was on at install"*, and `FindAdapters.test.ts` → *"offers NO tap action while the endeavorDetail flag is off"*. The gate is `resolveEndeavorCapabilities` (#9) against the flags cached at `onViewLoaded`.
- Each operation actually **runs**: `FindProducer.test.ts` completes with a backdate, soft-deletes, archives without a completion stamp, writes both rows of a defer, and resolves an intent for `startSession`.

### AC 2 — grouping / search / archived match canon; 7-item limits enforced with expand

```bash
pnpm --filter @kro/app exec vitest run src/features/find/__tests__/FindGrouping.test.ts src/features/find/__tests__/FindSelectors.test.ts
```

- **Archived**: *"hides closed rows until Show Archived is on"*.
- **Search**: *"matches the search case-insensitively against the title"*; the query is stored verbatim and folded only at comparison time.
- **Hosts**: *"keeps a multi-host row while ONE of its hosts is still shown"* — canon's rule that a row is hidden only when *every* host is hidden.
- **Sort**: *"sorts by start ?? due ascending, with undated rows trailing"* (canon's `FindSelectors`).
- **Grouping**: by status ordered by canon's status index; by host with a row in **each** of its host groups and a host-less row in none; by due section with `anytime` **leading**; by kind.
- **The 7-item limit**: *"clips every group to the vista's seven-row limit"*, *"lifts the limit for the group the user expanded"* — and `limitGroups` lifts it from **every** group once one has focus, which is canon's `applyReprocess` skipping `limited(by:)` entirely.
- **The four empty states** are told apart in canon's branch order: `noData` → `noFilters` → `noResults` → `filteredOut`.

### AC 3 — Edit refuses kind-irrelevant fields identically to the domain matrix

```bash
pnpm --filter @kro/app exec vitest run src/features/endeavorDetail/__tests__/EndeavorDetailEditing.test.ts
```

- **The truth table** is one test per kind (`background`, `behavior`, `blueprint`, `calendarEvent`, `habit`, `reminder`, `task`) with literal expectations — the **only** restatement of the matrix in the app tier, so a change to `EndeavorFieldRelevance` in `@kro/core` breaks exactly that block and nothing else. Two derived tests then assert the offered set never diverges from `isFieldEditable` in either direction.
- **A forbidden edit is not expressible, only refused.** `applyFieldChange` routes every change through the domain's guarded `with…` helper, which returns **the identical object**: `expect(applyFieldChange(event, { field: 'due', … })).toBe(event)`. There is no per-kind `if` anywhere in this feature that could drift.
- **The surface can tell in advance**, so `#30` renders a field disabled or absent rather than offering a dead control: `editableFieldsBySection` / `editableSections` derive from the same matrix (`"drops a matrix-refused field out of its section"`).
- The refusal holds at the **write** too: `FindProducer.test.ts` → *"writes NEITHER row when the matrix refuses the defer"*; `EndeavorDetailProducer.test.ts` → *"writes NOTHING when the matrix refuses sessions for the kind"*.

### Duration profile and observed focus time

```bash
pnpm --filter @kro/app exec vitest run src/features/endeavorDetail/__tests__/EndeavorDuration.test.ts
```

- Averages three qualifying sessions to 30 min; stays `null` below `EMPIRICAL_SAMPLE_MINIMUM`; excludes an aborted attempt and a quick complete.
- Prefills the dials from the observed average **without** enabling the switch — canon's *"the user must explicitly enable Preferred to freeze that recommendation"*.
- Canon's one validation rule (`minimum > maximum`) blocks Save via `selectIsSaveEnabled`.

### Dirty tracking, save and dismiss

```bash
pnpm --filter @kro/app exec vitest run src/features/endeavorDetail/__tests__/EndeavorDetailFeature.test.ts
```

- Clean on open → dirty after a real edit → clean again once the save lands.
- **Still clean after an edit the matrix refused** — nothing changed, so Save stays disabled.
- A failed save leaves the edit dirty for a retry; a dismiss discards the working copy and leaves the presented row untouched.
- A newer edit that raced ahead of an in-flight save is kept, not silently discarded (canon's `applySaveSucceeded`).

### Relations, and their read-only reasons

```bash
pnpm --filter @kro/app exec vitest run src/features/endeavorDetail/__tests__/EndeavorRelations.test.ts
```

Each read-only relation states **why**, verbatim from canon's info banner — e.g. `"This endeavor's kind can't record sessions."` — and a parametrised case asserts a reason exists for exactly the relations `isRelationEditable` refuses, across four kinds.

### The whole thing at once

```bash
make typecheck && make test && make lint && make build
```

## Notes

### Canon divergences (code wins), and why

1. **One slice, two surfaces.** Canon has `FindFeature` and `TasksFeature`; after the vista migration they differ only in which vista is installed, so they are one slice with two independent instances of the same surface state. Two slices would have been two copies of the fetch, the lens, the grouping and the adapter — the `RC-32` failure read backwards. Each surface keeps its own lens and persists under its own vista id.
2. **"Group by list" is not a canon grouping.** The issue text says *by status / due section / list*; canon's `EndeavorGroupingCriteria` is **status / host / kind / dueSection**, and its Tasks picker offers exactly those four. Scoping to a list is a *query* (`.tasksForList(id)`), not a grouping. Ported as canon has it.
3. **The bulk operations have no confirmation step.** Canon's ellipsis menu fires `Delete all visible (N)` straight from a `Button(role: .destructive)` — the destructive role is the whole affordance, and both apply optimistically. Adding a confirm would be a new business rule and would put the two platforms' Find menus out of step, so it is not here. `#30` should render the destructive role, not a dialog.
4. **The grouping engine lives in the feature lane.** `@kro/core`'s `EndeavorCriteria.ts` ported the *declaration* of the four criteria and said the engine *"belongs to whichever child first renders a grouped list (#16 / #29)"*. #16 built Do's lanes instead, so it lands here in `FindGrouping.ts` (including `DaySection`, which `EndeavorComputed.ts` also deferred). Moving it down into `@kro/core` later is an import change and nothing else.
5. **In-memory narrowing uses the lens, not `applyQuery`.** Find applies the **lens only** (canon's `displayedEndeavorsSelector`), and All Tasks applies the query's kinds/lists/predicates then the lens (canon's `applyReprocess` steps 2–3). `@kro/core`'s `applyQuery` also applies `includeArchived`, which would strip closed rows *before* Show Archived could reveal them — it is the fetch-side filter, and this is the in-memory one. Documented at the call site.
6. **Cross-feature actions are intents, not delegates.** Canon sends `.delegate(.startSession(…))` up to `MainFeature`. There is no parent store here and `RC-20` forbids a slice importing a sibling, so `startSession` / `execute` / `edit` / `viewDetail` / `triage` / `share` / `dismissSuggestion` resolve into an **intent queue** drained by `childIntentDelegatedConsumed`. They still resolve `ok` — an operation handled elsewhere has not failed — and the coverage test proves each one lands.
7. **Optimism is uniform.** Canon's Find removes/closes rows optimistically while canon's Tasks additionally flips a per-row `inActivity` spinner. Every local operation here applies its effect in `.pending` through the *same* `endeavorAfterOperation` the Producer persists, so the row the user sees and the row on disk cannot drift.
8. **Dirty tracking compares by value.** Canon compares two Swift structs (`endeavor == saved`). A reference comparison would leave a just-saved form permanently dirty, so `endeavorsEqual` does a normalised structural compare (Dates → epoch, keys sorted) with the reference check as the fast path.
9. **No `ownerUserId`, no host write-back fan-out.** Canon threads an owner into every upsert and fans out one write-back per external host after a save. There is no auth session (`#31`) and no provider adapter (`#33`) in this build; inventing a field nothing can fill, or a fan-out with nothing to fan out to, would be a lie in `State`. Correspondingly, `EndeavorDetailException` has **no** `remoteSyncFailed` / `hostWriteBackFailed` case — an unreachable case is worse than an absent one.

### Capabilities canon declares that have no sensible web binding — named, not dropped

- **`share`** — canon's operation has no binding here. `navigator.share` exists on the web, but a platform capability is a Service behind `ThunkExtra` (`RC-6`) and none is wired. It resolves to an intent whose consumer is recorded as *"share Service (not wired yet)"*.
- **Host attach / detach** — canon routes these through `EndeavorMutationHostClient`, which creates or deletes the endeavor's copy **on the provider**. This build has no adapter: Apple Calendar and Apple Reminders are impossible on the web at all (out of scope per the epic), Google Calendar arrives with `#33`, Outlook is off in `statusQuoSet`. So every candidate is listed with `isAttachable: false` and a reason the surface can show, and both thunks refuse with a typed `hostAdapterUnavailable`. Recording a host locally without the provider call would claim a mirror that does not exist; dropping one locally would orphan the provider-side record.
- **`dismissSuggestion`** — Do owns the suggestion lane's state, so from Find it can only be an intent.

### Deviations from the repo's own Definition of Done

- **Coverage is not measurable through `make test`.** `@vitest/coverage-v8` is declared only in `apps/web`; `packages/app` has no coverage provider, and adding one is a new dependency this issue's lane forbids. Measured out-of-tree against `apps/web`'s copy: **95.7 %** statements across the two lanes, every touched file **≥ 81.6 %** — above the `UZF-19` floor. The missing devDependency in `packages/app` / `packages/core` is a pre-existing repo gap worth its own issue.
- **`docs/Features/<Feature>.md` (UZF-21) is not written.** This repo has no `docs/Features` tree at all — neither #16, #18 nor #23 created one — and standing one up is a repo-wide convention decision outside this issue's exclusive file lane. The behaviour specs remain canon in `zheref/KroApple@docs/Features`. Worth a follow-up that creates the tree once, for the whole parity epic.
- **UZF-26 visual evidence: exempt.** Logic-only child; no Page, Fragment or Component is added or changed. `#30` carries the screenshots.
- **Biome does not lint `packages/**`.** The root `biome.json` excludes `packages` from its `files.includes`, so `make lint` checks the logic tier's *structure* (`check-uzf-boundaries.mjs`) but never its formatting. Files here follow the neighbouring style by hand. Also pre-existing, also outside this lane, and also worth an issue.

### File lane

`packages/app/src/features/find/**`, `packages/app/src/features/endeavorDetail/**`, two lines in `packages/app/src/library/store.ts`, and one-line `RootState` fixups in four sibling suites (the `#48` precedent). Nothing else is touched. No new dependencies.

Capture (`#23`) merged onto `main` mid-flight, as anticipated: this branch is rebased on it, and the store's reducer map now reads `greeting · do · capture · plan · find · endeavorDetail`.
