### PR TITLE
feat(earn): reward catalog partition, claim flow, points balance

### DIFF
--- a/packages/app/src/features/capture/__tests__/CaptureSelectors.test.ts
+++ b/packages/app/src/features/capture/__tests__/CaptureSelectors.test.ts
@@ -2,6 +2,7 @@ import { EndeavorOperation, EndeavorsVistas } from '@kro/core'
 import { describe, expect, it } from 'vitest'
 import type { RootState } from '../../../library/store'
 import { initialDoState } from '../../do/DoFeature'
+import { initialEarnState } from '../../earn/EarnFeature'
 import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
 import { initialFindState } from '../../find/FindState'
 import { greetingStateMocks } from '../../greeting/GreetingMocks'
@@ -54,6 +55,7 @@ const rootWith = (slice: CaptureState): RootState => ({
   capture: slice,
   find: initialFindState,
   endeavorDetail: initialEndeavorDetailState,
+  earn: initialEarnState,
 })
 
 const loaded = rootWith(captureStateMocks.loadedPool)

--- a/packages/app/src/features/do/__tests__/DoSelectors.test.ts
+++ b/packages/app/src/features/do/__tests__/DoSelectors.test.ts
@@ -23,6 +23,7 @@ import {
   selectIsDoLoading,
 } from '../DoSelectors'
 import { withVisibilityApplied } from '../DoShifters'
+import { initialEarnState } from '../../earn/EarnFeature'
 import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
 import { initialFindState } from '../../find/FindState'
 import { initialPlanState } from '../../plan/PlanState'
@@ -37,6 +38,7 @@ const rootWith = (slice: DoState): RootState => ({
   capture: initialCaptureState,
   find: initialFindState,
   endeavorDetail: initialEndeavorDetailState,
+  earn: initialEarnState,
 })
 
 const loaded = rootWith(doStateMocks.loadedTypicalDay)

--- a/packages/app/src/features/earn/EarnException.ts
+++ b/packages/app/src/features/earn/EarnException.ts
@@ -23,6 +23,8 @@ export type EarnException =
   | Exception<'deleteRewardFailed'>
   /** Persisting a claim failed. */
   | Exception<'claimRewardFailed'>
+  /** A claim was requested for an id absent from the persisted catalog. */
+  | Exception<'rewardNotFound'>
   /** The defensive `.rejected` fallback's landing shape (`RC-26`). */
   | Exception<'unknown'>
 
@@ -48,6 +50,13 @@ export const EarnExceptions = {
 
   claimRewardFailed: (reason: string): EarnException =>
     exception('claimRewardFailed', `Couldn't claim that reward: ${reason}`, true),
+
+  rewardNotFound: (id: string): EarnException =>
+    exception(
+      'rewardNotFound',
+      `No reward with id '${id}' is in your catalog.`,
+      false,
+    ),
 
   unknown: (message: string): EarnException => exception('unknown', message, true),
 } as const

--- a/packages/app/src/features/earn/EarnException.ts
+++ b/packages/app/src/features/earn/EarnException.ts
@@ -1,0 +1,53 @@
+/**
+ * The Earn surface's typed failure union (`RC-8`, `UZF-8`).
+ *
+ * One `kind` per failure the catalog load or a mutation can report. `blankTitle`
+ * is a validation failure rather than an I/O one — it never reaches storage —
+ * and is still modelled here rather than as a silent no-op so a caller can
+ * surface *why* nothing happened, matching canon's own guard
+ * (`guard !trimmed.isEmpty else return .none`) with a typed reason instead of a
+ * quiet return.
+ */
+import { type Exception, exception } from '@kro/core'
+
+export type EarnException =
+  /** Reading `earn.pointsFormula` / `earn.defaultRewardThreshold` failed. */
+  | Exception<'preferencesLoadFailed'>
+  /** Reading the reward catalog, the claimed set or the performances failed. */
+  | Exception<'catalogLoadFailed'>
+  /** The add-reward draft's title was blank after trimming. */
+  | Exception<'blankTitle'>
+  /** Persisting a new reward (typed or from a suggestion) failed. */
+  | Exception<'addRewardFailed'>
+  /** Persisting a reward removal failed. */
+  | Exception<'deleteRewardFailed'>
+  /** Persisting a claim failed. */
+  | Exception<'claimRewardFailed'>
+  /** The defensive `.rejected` fallback's landing shape (`RC-26`). */
+  | Exception<'unknown'>
+
+export const EarnExceptions = {
+  preferencesLoadFailed: (reason: string): EarnException =>
+    exception(
+      'preferencesLoadFailed',
+      `Couldn't load your Earn preferences: ${reason}`,
+      true,
+    ),
+
+  catalogLoadFailed: (reason: string): EarnException =>
+    exception('catalogLoadFailed', `Couldn't load your rewards: ${reason}`, true),
+
+  blankTitle: (): EarnException =>
+    exception('blankTitle', 'Give the reward a title before adding it.', true),
+
+  addRewardFailed: (reason: string): EarnException =>
+    exception('addRewardFailed', `Couldn't save that reward: ${reason}`, true),
+
+  deleteRewardFailed: (reason: string): EarnException =>
+    exception('deleteRewardFailed', `Couldn't remove that reward: ${reason}`, true),
+
+  claimRewardFailed: (reason: string): EarnException =>
+    exception('claimRewardFailed', `Couldn't claim that reward: ${reason}`, true),
+
+  unknown: (message: string): EarnException => exception('unknown', message, true),
+} as const

--- a/packages/app/src/features/earn/EarnFeature.ts
+++ b/packages/app/src/features/earn/EarnFeature.ts
@@ -1,0 +1,339 @@
+/**
+ * The Earn surface's slice (`RC-1`, `RC-2`, `RC-24`, `RC-36`) — the port of
+ * `EarnFeature.swift`: the reward catalog, the claim flow, the Add-Reward
+ * draft and the two `earn.*` preferences the surface reads (`#27`).
+ *
+ * `State` holds domain types only (`Reward[]`, `Perform[]`) and never a
+ * derived total — `EarnRules.ts` computes the balance and the partition fresh
+ * from `performances` + `rewards` + `claimedRewardIds` on every read, so there
+ * is no shadow counter to drift (see that file's header for the one
+ * deliberate divergence from canon's own selector).
+ *
+ * ## Why every catalog mutation is a Producer, never an optimistic reducer arm
+ *
+ * Canon mutates `state.rewards`/`state.claimedIDs` synchronously in the
+ * reducer and fires the persist effect afterwards, fire-and-forget — if the
+ * `UserDefaults` write somehow fails, the in-memory catalog has already
+ * diverged from disk and nothing ever reconciles it. The issue's acceptance
+ * criteria are explicit that this port must not do that for claiming
+ * ("claim flow … atomically"; "a failed claim leaves balance and catalog
+ * untouched"), and the same reasoning applies identically to add/delete/add-
+ * suggestion — a catalog write that silently fails should never look like it
+ * succeeded. So **every** mutation here is persist-then-apply: `EarnProducer`
+ * reads the current catalog fresh from storage, writes the new one, and only
+ * on that write's success does the reducer's `.fulfilled` arm touch `State`.
+ * On failure only `load` moves to `failed`; `rewards`/`claimedRewardIds` are
+ * never touched, which is what makes the balance and the partition provably
+ * unaffected by a failed write. Named as a flagged divergence from canon in
+ * the PR, applied uniformly rather than only where the issue tested it.
+ */
+import type { Perform, PointsFormula, Reward } from '@kro/core'
+import { PointsFormula as PointsFormulas } from '@kro/core'
+import { type PayloadAction, createSlice } from '@reduxjs/toolkit'
+import { type EarnException, EarnExceptions } from './EarnException'
+import type { EarnCatalogSnapshot } from './EarnProducer'
+import {
+  addRewardThunk,
+  addSuggestionThunk,
+  claimRewardThunk,
+  deleteRewardThunk,
+  loadEarnCatalogThunk,
+  loadEarnPreferencesThunk,
+} from './EarnProducer'
+import {
+  withCatalogInstalled,
+  withCatalogLoadStarted,
+  withClaimApplied,
+  withClaimCancelled,
+  withClaimRequested,
+  withDraftGlyphChanged,
+  withDraftNotesChanged,
+  withDraftPointsChanged,
+  withDraftTitleChanged,
+  withException,
+  withPreferencesApplied,
+  withRewardAdded,
+  withRewardDraftClosed,
+  withRewardDraftOpened,
+  withRewardRemoved,
+} from './EarnShifters'
+
+/** The one lifecycle field (`RC-24`, `UZF-9`) — the catalog read only. */
+export type EarnLoadState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'loaded' }
+  | { readonly kind: 'failed'; readonly exception: EarnException }
+
+/** The two `earn.*` preferences this surface reads (`#11`'s settings). */
+export interface EarnPreferences {
+  /** `earn.defaultRewardThreshold` — the Add-Reward cost prefill. Default 100. */
+  readonly defaultRewardThreshold: number
+  /**
+   * `earn.pointsFormula`, surfaced read-only. The formula math itself lives in
+   * `domain/session/RewardCalculator` (`#8`) and is awarded by Session (`#21`)
+   * — this feature never recomputes it, only reads which one is active.
+   */
+  readonly pointsFormula: PointsFormula
+}
+
+export const defaultEarnPreferences: EarnPreferences = {
+  defaultRewardThreshold: 100,
+  pointsFormula: PointsFormulas.slidingScale,
+}
+
+/** The Add-Reward sheet's in-progress form. Canon's `Reward.blankDraft`. */
+export interface EarnRewardDraft {
+  readonly title: string
+  readonly glyph: string
+  readonly pointsRequired: number
+  readonly notes: string | null
+}
+
+export const blankEarnRewardDraft: EarnRewardDraft = {
+  title: '',
+  glyph: '🎁',
+  pointsRequired: 100,
+  notes: null,
+}
+
+export interface EarnState {
+  readonly load: EarnLoadState
+
+  /** The user's reward catalog. */
+  readonly rewards: readonly Reward[]
+  /** Ids of rewards already claimed — canon's `claimedIDs: Set<String>`. */
+  readonly claimedRewardIds: readonly string[]
+  /**
+   * Every recorded performance, the balance's one source (`EarnRules.ts`).
+   * Raw pass-through from `#10`'s store — no reconciliation needed, since
+   * award points are stamped once at completion and never re-derived here.
+   */
+  readonly performances: readonly Perform[]
+
+  readonly preferences: EarnPreferences
+
+  readonly isAddingReward: boolean
+  readonly addRewardDraft: EarnRewardDraft
+
+  /** The reward the confirm-claim sheet is open on, or `null`. */
+  readonly claimingRewardId: string | null
+}
+
+export const initialEarnState: EarnState = {
+  load: { kind: 'idle' },
+  rewards: [],
+  claimedRewardIds: [],
+  performances: [],
+  preferences: defaultEarnPreferences,
+  isAddingReward: false,
+  addRewardDraft: blankEarnRewardDraft,
+  claimingRewardId: null,
+}
+
+export type { EarnCatalogSnapshot } from './EarnProducer'
+
+export const earnSlice = createSlice({
+  name: 'earn',
+  initialState: initialEarnState,
+  reducers: {
+    // --- Add Reward sheet -------------------------------------------------
+
+    /**
+     * User intent: the FAB. Prefills the cost from the already-loaded
+     * `earn.defaultRewardThreshold` preference — synchronous, since the
+     * preference was read once by `loadEarnPreferencesThunk` and lives in
+     * `state.preferences` (`RC-3`: no service call belongs in a reducer).
+     */
+    userDidTapAddReward(state) {
+      Object.assign(state, withRewardDraftOpened(state))
+    },
+
+    userDidChangeDraftTitle(state, action: PayloadAction<{ title: string }>) {
+      Object.assign(state, withDraftTitleChanged(state, action.payload.title))
+    },
+
+    /** User intent: the emoji field. Truncated to two code points, canon's cap. */
+    userDidChangeDraftGlyph(state, action: PayloadAction<{ glyph: string }>) {
+      Object.assign(state, withDraftGlyphChanged(state, action.payload.glyph))
+    },
+
+    userDidChangeDraftPoints(
+      state,
+      action: PayloadAction<{ pointsRequired: number }>,
+    ) {
+      Object.assign(
+        state,
+        withDraftPointsChanged(state, action.payload.pointsRequired),
+      )
+    },
+
+    userDidChangeDraftNotes(state, action: PayloadAction<{ notes: string }>) {
+      Object.assign(state, withDraftNotesChanged(state, action.payload.notes))
+    },
+
+    /** User intent: Cancel. The draft is dropped whole; nothing is kept. */
+    userDidCancelAddReward(state) {
+      Object.assign(state, withRewardDraftClosed(state))
+    },
+
+    // --- Claim flow ---------------------------------------------------------
+
+    /** User intent: the Claim button. Opens the confirm sheet. */
+    userDidTapClaim(state, action: PayloadAction<{ rewardId: string }>) {
+      Object.assign(state, withClaimRequested(state, action.payload.rewardId))
+    },
+
+    /** User intent: Cancel on the confirm sheet. */
+    userDidCancelClaim(state) {
+      Object.assign(state, withClaimCancelled(state))
+    },
+  },
+
+  extraReducers: (builder) => {
+    builder
+      // --- earn.* preferences --------------------------------------------
+      // No `.pending`/`load` transition here — `load` is the catalog read's
+      // own field; a preferences-load failure still reports through it
+      // (canon shares one lifecycle signal across both loads too), but a
+      // preferences-load success never claims the catalog is ready.
+      .addCase(loadEarnPreferencesThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(state, withPreferencesApplied(state, result.value))
+        } else {
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      .addCase(loadEarnPreferencesThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withException(
+            state,
+            EarnExceptions.unknown(action.error.message ?? 'Unknown error'),
+          ),
+        )
+      })
+
+      // --- the catalog: rewards + claimed ids + performances --------------
+      .addCase(loadEarnCatalogThunk.pending, (state) => {
+        Object.assign(state, withCatalogLoadStarted(state))
+      })
+      .addCase(loadEarnCatalogThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(state, withCatalogInstalled(state, result.value))
+        } else {
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      .addCase(loadEarnCatalogThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withException(
+            state,
+            EarnExceptions.unknown(action.error.message ?? 'Unknown error'),
+          ),
+        )
+      })
+
+      // --- add a typed reward ----------------------------------------------
+      // No `.pending` arm: the sheet stays exactly as the user left it until
+      // the write lands, so a failed add can be retried without re-typing
+      // (mirrors Capture's `submitCaptureThunk`).
+      .addCase(addRewardThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(state, withRewardAdded(state, result.value.reward))
+        } else {
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      .addCase(addRewardThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withException(
+            state,
+            EarnExceptions.unknown(action.error.message ?? 'Unknown error'),
+          ),
+        )
+      })
+
+      // --- add a suggestion --------------------------------------------------
+      .addCase(addSuggestionThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(state, withRewardAdded(state, result.value.reward))
+        } else {
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      .addCase(addSuggestionThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withException(
+            state,
+            EarnExceptions.unknown(action.error.message ?? 'Unknown error'),
+          ),
+        )
+      })
+
+      // --- delete a reward (context menu) ------------------------------------
+      .addCase(deleteRewardThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(state, withRewardRemoved(state, result.value.id))
+        } else {
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      .addCase(deleteRewardThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withException(
+            state,
+            EarnExceptions.unknown(action.error.message ?? 'Unknown error'),
+          ),
+        )
+      })
+
+      // --- claim: the atomic one -------------------------------------------
+      // On failure `claimingRewardId` is left exactly as it was, so the
+      // confirm sheet stays open and the same claim can be retried; the
+      // catalog and the claimed set are untouched either way until `ok`.
+      .addCase(claimRewardThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          Object.assign(state, withClaimApplied(state, result.value.id))
+        } else {
+          Object.assign(state, withException(state, result.error))
+        }
+      })
+      .addCase(claimRewardThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withException(
+            state,
+            EarnExceptions.unknown(action.error.message ?? 'Unknown error'),
+          ),
+        )
+      })
+  },
+})
+
+export const {
+  userDidCancelAddReward,
+  userDidCancelClaim,
+  userDidChangeDraftGlyph,
+  userDidChangeDraftNotes,
+  userDidChangeDraftPoints,
+  userDidChangeDraftTitle,
+  userDidTapAddReward,
+  userDidTapClaim,
+} = earnSlice.actions

--- a/packages/app/src/features/earn/EarnFeature.ts
+++ b/packages/app/src/features/earn/EarnFeature.ts
@@ -58,7 +58,14 @@ import {
   withRewardRemoved,
 } from './EarnShifters'
 
-/** The one lifecycle field (`RC-24`, `UZF-9`) — the catalog read only. */
+/**
+ * The one lifecycle field (`RC-24`, `UZF-9`). `loading`/`loaded` describe only
+ * the catalog read (`loadEarnCatalogThunk`'s `.pending`/`.fulfilled`); `failed`
+ * is shared more widely — every load (including `loadEarnPreferencesThunk`)
+ * and every mutation (add/delete/claim) lands here on its own failure too, via
+ * the single `withException` Shifter (`EarnShifters.ts`). There is no second
+ * lifecycle field for those; `load` is Earn's one advisory signal.
+ */
 export type EarnLoadState =
   | { readonly kind: 'idle' }
   | { readonly kind: 'loading' }

--- a/packages/app/src/features/earn/EarnMocks.ts
+++ b/packages/app/src/features/earn/EarnMocks.ts
@@ -1,0 +1,101 @@
+/**
+ * The Earn feature's canned fixtures (`RC-31`, `UZF-18`).
+ *
+ * `earnPerformanceFixtures` supplies the balance's only input; the reward
+ * catalog itself is `@kro/core/mocks`' `rewardMocks` (`#7`'s seven variants —
+ * already satisfying `UZF-18`'s per-model minimum, so this file does not
+ * duplicate them). `earnStateMocks` runs the real Shifters over both, so a
+ * variant here is by construction a state the reducer can actually reach.
+ */
+import { PerformResolution, makePerform } from '@kro/core'
+import { rewardMocks } from '@kro/core/mocks'
+import { EarnExceptions } from './EarnException'
+import { type EarnState, initialEarnState } from './EarnFeature'
+import {
+  withCatalogInstalled,
+  withClaimRequested,
+  withException,
+  withRewardDraftOpened,
+} from './EarnShifters'
+
+/** Tuesday 17 March 2026, 10:00 local — arbitrary, fixed, and irrelevant. */
+export const EARN_MOCK_NOW = new Date(2026, 2, 17, 10, 0, 0)
+
+const perform = (rewardPoints: number, daysAgo: number) =>
+  makePerform({
+    date: new Date(2026, 2, 17 - daysAgo, 9, 0, 0),
+    duration: 1500,
+    resolution: PerformResolution.finished,
+    rewardPoints,
+    completedAt: new Date(2026, 2, 17 - daysAgo, 9, 25, 0),
+    wasCompletedInSession: true,
+  })
+
+/** Three recorded performances, summing to 130 points. */
+export const earnPerformanceFixtures = {
+  first: perform(30, 3),
+  second: perform(50, 2),
+  third: perform(50, 1),
+} as const
+
+export const earnFixturePerformances = Object.values(earnPerformanceFixtures)
+
+/**
+ * `rewardMocks.bobaTea` (80) and `.plain` (200) straddle the fixture balance
+ * of 130 — one claimable, one locked, without hand-building a new reward.
+ */
+export const earnCatalogFixture = [
+  rewardMocks.bobaTea,
+  rewardMocks.plain,
+  rewardMocks.weekendTrip,
+]
+
+const loadedCatalog = withCatalogInstalled(initialEarnState, {
+  rewards: earnCatalogFixture,
+  claimedRewardIds: [],
+  performances: earnFixturePerformances,
+})
+
+/** The states the Earn surface claims to support. */
+export const earnStateMocks = {
+  /** Nothing asked for yet — first paint before the surface mounts. */
+  idle: initialEarnState,
+
+  /** A read is in flight and nothing has landed. */
+  loading: {
+    ...initialEarnState,
+    load: { kind: 'loading' },
+  } satisfies EarnState,
+
+  /** The ordinary catalog: one claimable, one locked, one out of reach. */
+  loadedTypical: loadedCatalog,
+
+  /** A catalog with nothing in it — the true empty state. */
+  loadedEmpty: withCatalogInstalled(initialEarnState, {
+    rewards: [],
+    claimedRewardIds: [],
+    performances: [],
+  }),
+
+  /** `bobaTea` already claimed — it leaves the claimable lane entirely. */
+  loadedWithClaim: withCatalogInstalled(initialEarnState, {
+    rewards: earnCatalogFixture,
+    claimedRewardIds: [rewardMocks.bobaTea.id],
+    performances: earnFixturePerformances,
+  }),
+
+  /**
+   * A refresh failed after a good catalog was already showing — the catalog
+   * is untouched, which is the whole point of `withException` (`EarnShifters.ts`).
+   */
+  failedRefreshKeepingCatalog: withException(
+    loadedCatalog,
+    EarnExceptions.catalogLoadFailed('the store is unavailable'),
+  ),
+
+  /** The Add-Reward sheet open, prefilled from the default-threshold preference. */
+  addingReward: withRewardDraftOpened(loadedCatalog),
+
+  /** The confirm-claim sheet open on the affordable reward. */
+  claimingReward: withClaimRequested(loadedCatalog, rewardMocks.bobaTea.id),
+}

--- a/packages/app/src/features/earn/EarnProducer.ts
+++ b/packages/app/src/features/earn/EarnProducer.ts
@@ -82,6 +82,16 @@ export const loadEarnPreferencesThunk = createAsyncThunk<
  * balance's one source (`EarnRules.ts`). `performances.all()` already excludes
  * soft-deleted/pending-deletion rows (`#10`'s `livingChildRecords`), so a
  * removed performance can never inflate the balance.
+ *
+ * The claimed-id set is **filtered to ids present in the loaded catalog**
+ * before it is installed. The two are persisted independently, and
+ * `addRewardThunk` never checks a new id against the claimed-id history — so
+ * without this, a reward deleted after being claimed, followed by a
+ * *coincidentally* id-colliding new reward, would install as pre-claimed. The
+ * filter is defensive only: it changes nothing about the ordinary "delete a
+ * claimed reward and its cost stops counting as spent" behaviour
+ * (`EarnRules.ts`'s `spentPoints` already derives that from the same
+ * intersection on every read).
  */
 export const loadEarnCatalogThunk = createAsyncThunk<
   Result<EarnCatalogSnapshot, EarnException>,
@@ -90,7 +100,10 @@ export const loadEarnCatalogThunk = createAsyncThunk<
 >('earn/onEarnCatalogLoadCompleted', async (_arg, { extra }) => {
   try {
     const rewards = readRewardsCatalog(extra.localStore.preferences)
-    const claimedRewardIds = readClaimedRewardIds(extra.localStore.preferences)
+    const rewardIds = new Set(rewards.map((reward) => reward.id))
+    const claimedRewardIds = readClaimedRewardIds(
+      extra.localStore.preferences,
+    ).filter((id) => rewardIds.has(id))
     const performanceRecords = await extra.localStore.performances.all()
     return ok({
       rewards,

--- a/packages/app/src/features/earn/EarnProducer.ts
+++ b/packages/app/src/features/earn/EarnProducer.ts
@@ -1,0 +1,196 @@
+/**
+ * The Earn surface's Producers (`RC-3`, `RC-6`, `RC-7`, `RC-25`) — canon's
+ * `RewardsStore.liveValue` reads/writes plus `EarnProducer.swift`'s two
+ * persistence effects, folded into one atomic shape per operation.
+ *
+ * Every thunk here reads its own fresh state from `extra.localStore` rather
+ * than trusting whatever the caller's copy of Redux state currently holds —
+ * the same reason `DoProducer.ts`'s `markEndeavorCompleteThunk` re-reads
+ * storage instead of taking the target as an argument: a snapshot that went
+ * stale between the tap and the dispatch must never overwrite storage with a
+ * write built from that stale snapshot. None of them reads a clock — `now`
+ * and `id` are always caller-supplied arguments (`RC-4`; ids are minted by the
+ * UI, exactly as `CaptureProducer.ts`'s `submitCaptureThunk` documents for
+ * itself: "none mints an id").
+ */
+import {
+  type Reward,
+  type Result,
+  earnDefaultRewardThresholdOption,
+  earnPointsFormulaOption,
+  err,
+  makePreferences,
+  makeReward,
+  ok,
+  performFromRecord,
+  pointsFormulaFromRawValue,
+  preferenceInt,
+  preferencePick,
+  rewardForInsertion,
+} from '@kro/core'
+import type { Perform } from '@kro/core'
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import type { ThunkExtra } from '../../library/store'
+import { type EarnException, EarnExceptions } from './EarnException'
+import type { EarnPreferences, EarnRewardDraft } from './EarnFeature'
+import {
+  readClaimedRewardIds,
+  readRewardsCatalog,
+  writeClaimedRewardIds,
+  writeRewardsCatalog,
+} from './EarnRewardsStorage'
+
+const messageOf = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+/** What `loadEarnCatalogThunk` installs in one pass. */
+export interface EarnCatalogSnapshot {
+  readonly rewards: readonly Reward[]
+  readonly claimedRewardIds: readonly string[]
+  readonly performances: readonly Perform[]
+}
+
+/**
+ * `earn.pointsFormula` + `earn.defaultRewardThreshold`, read in one pass.
+ * Independent of the catalog read below — either can succeed while the other
+ * fails, exactly as `DoProducer.ts`'s `loadDoPreferencesThunk` /
+ * `fetchDoEndeavorsThunk` split does for the same reason.
+ */
+export const loadEarnPreferencesThunk = createAsyncThunk<
+  Result<EarnPreferences, EarnException>,
+  void,
+  { extra: ThunkExtra }
+>('earn/onEarnPreferencesLoadCompleted', async (_arg, { extra }) => {
+  try {
+    const preferences = makePreferences(extra.localStore.preferences)
+    return ok({
+      defaultRewardThreshold: preferenceInt(
+        preferences,
+        earnDefaultRewardThresholdOption,
+      ),
+      pointsFormula: pointsFormulaFromRawValue(
+        preferencePick(preferences, earnPointsFormulaOption),
+      ),
+    })
+  } catch (error) {
+    return err(EarnExceptions.preferencesLoadFailed(messageOf(error)))
+  }
+})
+
+/**
+ * The reward catalog, the claimed-id set and every recorded performance — the
+ * balance's one source (`EarnRules.ts`). `performances.all()` already excludes
+ * soft-deleted/pending-deletion rows (`#10`'s `livingChildRecords`), so a
+ * removed performance can never inflate the balance.
+ */
+export const loadEarnCatalogThunk = createAsyncThunk<
+  Result<EarnCatalogSnapshot, EarnException>,
+  void,
+  { extra: ThunkExtra }
+>('earn/onEarnCatalogLoadCompleted', async (_arg, { extra }) => {
+  try {
+    const rewards = readRewardsCatalog(extra.localStore.preferences)
+    const claimedRewardIds = readClaimedRewardIds(extra.localStore.preferences)
+    const performanceRecords = await extra.localStore.performances.all()
+    return ok({
+      rewards,
+      claimedRewardIds,
+      performances: performanceRecords.map(performFromRecord),
+    })
+  } catch (error) {
+    return err(EarnExceptions.catalogLoadFailed(messageOf(error)))
+  }
+})
+
+/**
+ * A typed Add-Reward confirm. Validated **before** any storage touch — a
+ * blank title never reaches `readRewardsCatalog`/`writeRewardsCatalog`, so a
+ * rejected draft can never partially write.
+ */
+export const addRewardThunk = createAsyncThunk<
+  Result<{ reward: Reward }, EarnException>,
+  { draft: EarnRewardDraft; id: string; now: Date },
+  { extra: ThunkExtra }
+>('earn/onRewardAddCompleted', async ({ draft, id, now }, { extra }) => {
+  const title = draft.title.trim()
+  if (title.length === 0) return err(EarnExceptions.blankTitle())
+
+  try {
+    const store = extra.localStore.preferences
+    const reward = makeReward({
+      id,
+      title,
+      glyph: draft.glyph.length === 0 ? '🎁' : draft.glyph,
+      pointsRequired: Math.max(0, draft.pointsRequired),
+      notes: draft.notes,
+      dateAdded: now,
+    })
+    const catalog = readRewardsCatalog(store)
+    writeRewardsCatalog(store, [reward, ...catalog])
+    return ok({ reward })
+  } catch (error) {
+    return err(EarnExceptions.addRewardFailed(messageOf(error)))
+  }
+})
+
+/** Quick-add from a suggestion card — canon's `Reward.copyForInsertion()`. */
+export const addSuggestionThunk = createAsyncThunk<
+  Result<{ reward: Reward }, EarnException>,
+  { suggestion: Reward; id: string; now: Date },
+  { extra: ThunkExtra }
+>('earn/onSuggestionAddCompleted', async ({ suggestion, id, now }, { extra }) => {
+  try {
+    const store = extra.localStore.preferences
+    const reward = rewardForInsertion(suggestion, { id, dateAdded: now })
+    const catalog = readRewardsCatalog(store)
+    writeRewardsCatalog(store, [reward, ...catalog])
+    return ok({ reward })
+  } catch (error) {
+    return err(EarnExceptions.addRewardFailed(messageOf(error)))
+  }
+})
+
+/** Context-menu delete — persists the catalog with the row removed. */
+export const deleteRewardThunk = createAsyncThunk<
+  Result<{ id: string }, EarnException>,
+  { id: string },
+  { extra: ThunkExtra }
+>('earn/onRewardDeleteCompleted', async ({ id }, { extra }) => {
+  try {
+    const store = extra.localStore.preferences
+    const catalog = readRewardsCatalog(store)
+    writeRewardsCatalog(
+      store,
+      catalog.filter((reward) => reward.id !== id),
+    )
+    return ok({ id })
+  } catch (error) {
+    return err(EarnExceptions.deleteRewardFailed(messageOf(error)))
+  }
+})
+
+/**
+ * The atomic claim. The write happens **before** anything is returned, and
+ * the reducer only ever applies the id on `ok` (`EarnFeature.ts`'s header) —
+ * a stubbed store whose `set` throws leaves both the persisted and the
+ * in-memory claimed set exactly as they were.
+ *
+ * Idempotent on the already-claimed case, matching canon's
+ * `guard !stored.contains(id) else return`.
+ */
+export const claimRewardThunk = createAsyncThunk<
+  Result<{ id: string }, EarnException>,
+  { id: string },
+  { extra: ThunkExtra }
+>('earn/onRewardClaimCompleted', async ({ id }, { extra }) => {
+  try {
+    const store = extra.localStore.preferences
+    const claimedRewardIds = readClaimedRewardIds(store)
+    if (!claimedRewardIds.includes(id)) {
+      writeClaimedRewardIds(store, [...claimedRewardIds, id])
+    }
+    return ok({ id })
+  } catch (error) {
+    return err(EarnExceptions.claimRewardFailed(messageOf(error)))
+  }
+})

--- a/packages/app/src/features/earn/EarnProducer.ts
+++ b/packages/app/src/features/earn/EarnProducer.ts
@@ -190,6 +190,14 @@ export const deleteRewardThunk = createAsyncThunk<
  *
  * Idempotent on the already-claimed case, matching canon's
  * `guard !stored.contains(id) else return`.
+ *
+ * **Refuses to claim an id absent from the persisted catalog** (a second
+ * Copilot round, against this fix's own first head). Without this, a claim
+ * dispatched for a stale/deleted id would still write a "ghost" entry into
+ * the claimed set — and because `loadEarnCatalogThunk` (above) only checks
+ * "does *some* current reward have this id", a later reward that happened to
+ * mint the same id would load as pre-claimed. Checking existence here, not
+ * only at load, closes that the whole way rather than only after the fact.
  */
 export const claimRewardThunk = createAsyncThunk<
   Result<{ id: string }, EarnException>,
@@ -198,6 +206,10 @@ export const claimRewardThunk = createAsyncThunk<
 >('earn/onRewardClaimCompleted', async ({ id }, { extra }) => {
   try {
     const store = extra.localStore.preferences
+    const rewards = readRewardsCatalog(store)
+    if (!rewards.some((reward) => reward.id === id)) {
+      return err(EarnExceptions.rewardNotFound(id))
+    }
     const claimedRewardIds = readClaimedRewardIds(store)
     if (!claimedRewardIds.includes(id)) {
       writeClaimedRewardIds(store, [...claimedRewardIds, id])

--- a/packages/app/src/features/earn/EarnRewardsStorage.ts
+++ b/packages/app/src/features/earn/EarnRewardsStorage.ts
@@ -63,7 +63,18 @@ const toStoredReward = (reward: Reward): StoredReward => ({
   dateAddedEpochMillis: reward.dateAdded.getTime(),
 })
 
-/** `null` on anything that isn't a well-formed row — never thrown. */
+/**
+ * `null` on anything that isn't a well-formed row — never thrown.
+ *
+ * Every numeric field is required to be **finite** (rules out `NaN`/
+ * `Infinity`/`-Infinity`, which `typeof` alone would let through) and
+ * `pointsRequired` additionally non-negative; `notes` is required to already
+ * be `string | null | undefined`, never coerced from some other truthy value.
+ * A row failing any of these degrades to "skip this row" (its caller filters
+ * `null`s out), matching #10's own record-store posture: a malformed row
+ * yields a smaller catalog, never a `Reward` carrying an invalid `Date` or a
+ * non-finite number into selectors' sort/partition math.
+ */
 const fromStoredReward = (value: unknown): Reward | null => {
   if (typeof value !== 'object' || value === null) return null
   const candidate = value as Partial<StoredReward>
@@ -72,7 +83,15 @@ const fromStoredReward = (value: unknown): Reward | null => {
     typeof candidate.title !== 'string' ||
     typeof candidate.glyph !== 'string' ||
     typeof candidate.pointsRequired !== 'number' ||
-    typeof candidate.dateAddedEpochMillis !== 'number'
+    !Number.isFinite(candidate.pointsRequired) ||
+    candidate.pointsRequired < 0 ||
+    typeof candidate.dateAddedEpochMillis !== 'number' ||
+    !Number.isFinite(candidate.dateAddedEpochMillis) ||
+    !(
+      candidate.notes === undefined ||
+      candidate.notes === null ||
+      typeof candidate.notes === 'string'
+    )
   ) {
     return null
   }

--- a/packages/app/src/features/earn/EarnRewardsStorage.ts
+++ b/packages/app/src/features/earn/EarnRewardsStorage.ts
@@ -1,0 +1,138 @@
+/**
+ * Where the reward catalog and the claimed-reward set live on disk.
+ *
+ * ## The discovery (stated here so the choice below is traceable)
+ *
+ * `zheref/KroApple@2c1ee45`'s `Kro/Application/Earn/EarnFeature.swift` declares
+ * a `RewardsStore` dependency whose `liveValue` is backed by **`UserDefaults`**
+ * — two keys, `io.zheref.kro.rewards.catalog.v1` (the whole `[Reward]` array,
+ * JSON-encoded) and `io.zheref.kro.rewards.claimed.v1` (a bare `[String]` of
+ * claimed ids). There is **no** `RewardRecord` in `KroDatabase`/SwiftData, no
+ * Supabase table, and nothing else in the app touches `rewardsStore` — Earn is
+ * this dependency's only consumer. So canon's answer is: preferences-shaped
+ * storage, not a full record store.
+ *
+ * ## The port, mirrored rather than re-invented
+ *
+ * `#10`'s `KeyValueStore` (`packages/core/src/settings/KeyValueStore.ts`) is
+ * exactly `UserDefaults`'s shape on this stack — synchronous, key/value,
+ * already namespaced under `kro:` by convention. This file reads/writes through
+ * it (`extra.localStore.preferences`) rather than adding a new persistence
+ * port: no `RewardStore` interface, no IndexedDB binding, nothing new in
+ * `packages/core/src/persistence/` or `packages/app/src/services/localStore/`.
+ * A `SettingOption` cannot carry an array, so the two keys below bypass
+ * `Preferences`/`SettingOption` and call `KeyValueStore.get`/`set` directly,
+ * with a small JSON **codec** in place of `SettingsCodec`'s scalar one — which
+ * is the literal shape the issue asked for ("use #10's PreferenceStorage port
+ * under a `kro:` key with a codec").
+ *
+ * **One behavioural divergence, flagged rather than silent.** Canon's two
+ * `UserDefaults` keys sit outside `Preferences`'s `kro:` namespace, so nothing
+ * wipes them on sign-out. These two keys are deliberately placed *inside* that
+ * namespace (`kro:earn.rewards.catalog`, `kro:earn.rewards.claimed`), so they
+ * participate in the existing, generic, prefix-based sign-out sweep
+ * (`packages/app/src/services/localStore/signOutWipe.ts`) automatically — no
+ * change to that file was needed or made. A reward catalog surviving sign-out
+ * on a shared device is the one thing canon's own preferences-wipe rule
+ * (`docs/Features/Preferences.md` § *Account lifecycle*) says every other piece
+ * of device-stored state must not do; this port closes that gap rather than
+ * reproducing it.
+ */
+import { PREFERENCES_NAMESPACE, type KeyValueStore, type Reward } from '@kro/core'
+import { makeReward } from '@kro/core'
+
+const REWARDS_CATALOG_KEY = `${PREFERENCES_NAMESPACE}earn.rewards.catalog`
+const REWARDS_CLAIMED_KEY = `${PREFERENCES_NAMESPACE}earn.rewards.claimed`
+
+/** The wire shape one `Reward` round-trips through `JSON.stringify`. */
+interface StoredReward {
+  readonly id: string
+  readonly title: string
+  readonly glyph: string
+  readonly pointsRequired: number
+  readonly notes: string | null
+  readonly dateAddedEpochMillis: number
+}
+
+const toStoredReward = (reward: Reward): StoredReward => ({
+  id: reward.id,
+  title: reward.title,
+  glyph: reward.glyph,
+  pointsRequired: reward.pointsRequired,
+  notes: reward.notes,
+  dateAddedEpochMillis: reward.dateAdded.getTime(),
+})
+
+/** `null` on anything that isn't a well-formed row — never thrown. */
+const fromStoredReward = (value: unknown): Reward | null => {
+  if (typeof value !== 'object' || value === null) return null
+  const candidate = value as Partial<StoredReward>
+  if (
+    typeof candidate.id !== 'string' ||
+    typeof candidate.title !== 'string' ||
+    typeof candidate.glyph !== 'string' ||
+    typeof candidate.pointsRequired !== 'number' ||
+    typeof candidate.dateAddedEpochMillis !== 'number'
+  ) {
+    return null
+  }
+  return makeReward({
+    id: candidate.id,
+    title: candidate.title,
+    glyph: candidate.glyph,
+    pointsRequired: candidate.pointsRequired,
+    notes: candidate.notes ?? null,
+    dateAdded: new Date(candidate.dateAddedEpochMillis),
+  })
+}
+
+/**
+ * The stored catalog, or `[]` for an unset/corrupt key — corrupt is treated as
+ * empty rather than fatal, the same "skip, never blank the surface" posture
+ * `#10`'s own record stores take for a malformed row.
+ */
+export const readRewardsCatalog = (store: KeyValueStore): readonly Reward[] => {
+  const raw = store.get(REWARDS_CATALOG_KEY)
+  if (typeof raw !== 'string') return []
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .map(fromStoredReward)
+      .filter((reward): reward is Reward => reward !== null)
+  } catch {
+    return []
+  }
+}
+
+/** Replaces the whole catalog — canon's `saveCatalog`, whole-array semantics. */
+export const writeRewardsCatalog = (
+  store: KeyValueStore,
+  rewards: readonly Reward[],
+): void => {
+  store.set(REWARDS_CATALOG_KEY, JSON.stringify(rewards.map(toStoredReward)))
+}
+
+/** The claimed-id set, or `[]` for an unset/corrupt key. */
+export const readClaimedRewardIds = (
+  store: KeyValueStore,
+): readonly string[] => {
+  const raw = store.get(REWARDS_CLAIMED_KEY)
+  if (typeof raw !== 'string') return []
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === 'string')
+      : []
+  } catch {
+    return []
+  }
+}
+
+/** Replaces the whole claimed-id set. */
+export const writeClaimedRewardIds = (
+  store: KeyValueStore,
+  claimedRewardIds: readonly string[],
+): void => {
+  store.set(REWARDS_CLAIMED_KEY, JSON.stringify(claimedRewardIds))
+}

--- a/packages/app/src/features/earn/EarnRules.ts
+++ b/packages/app/src/features/earn/EarnRules.ts
@@ -99,13 +99,19 @@ export const availableSuggestions = (
 }
 
 /**
- * `isCatalogEmptySelector` — canon's `didLoadCatalog && rewards.isEmpty`. This
- * port has no boolean of its own for "did the load run"; the one `load`
- * lifecycle field already answers it — `idle`/`loading` means "not yet", and
- * `loaded`/`failed` both mean the attempt happened (`RC-24`).
+ * `isCatalogEmptySelector` — canon's `didLoadCatalog && rewards.isEmpty`.
+ *
+ * Canon's storage read never throws — `RewardsStore.loadCatalog` degrades a
+ * missing/corrupt row to `[]` rather than failing — so `didLoadCatalog` alone
+ * (set unconditionally in `onViewAppearing`) is enough to mean "the read
+ * happened, trust `rewards.isEmpty`". This port's read genuinely *can* fail
+ * (`EarnException`), including the earn.pointsFormula/defaultRewardThreshold
+ * preferences read that runs before the catalog is ever fetched — so `failed`
+ * must **not** count as "loaded", or the surface would render the empty-state
+ * copy ("add a reward") over what is actually an error it should retry. Only
+ * `loaded` counts.
  */
 export const isCatalogEmpty = (
   loadKind: 'idle' | 'loading' | 'loaded' | 'failed',
   rewards: readonly Reward[],
-): boolean =>
-  loadKind !== 'idle' && loadKind !== 'loading' && rewards.length === 0
+): boolean => loadKind === 'loaded' && rewards.length === 0

--- a/packages/app/src/features/earn/EarnRules.ts
+++ b/packages/app/src/features/earn/EarnRules.ts
@@ -1,0 +1,111 @@
+/**
+ * The Earn surface's pure math — canon's `EarnSelectors.swift`, ported as
+ * framework-free functions of `(performances, rewards, claimedRewardIds)`
+ * rather than computed properties on a TCA `State` (`UZF-10`, `UZF-11`).
+ *
+ * ## The one deliberate divergence from canon, and why
+ *
+ * Canon's `totalEarnedPointsSelector` sums `endeavor.sessionPoints ?? 10` over
+ * every completed endeavor — a coarse, per-endeavor estimate. This port sums
+ * `performance.rewardPoints` instead: the ported domain (`#8`) already carries
+ * the *exact* points a completion earned, computed once at award time by
+ * `RewardCalculator.awardRewardPoints` and stamped onto the `Perform` record.
+ * Re-deriving a second, coarser number here would be the "shadow counter" the
+ * issue's acceptance criteria explicitly rule out — the balance has exactly one
+ * source, the recorded performances, and this is it. Named in the PR as the
+ * issue's own stated acceptance criterion, not an unstated choice.
+ *
+ * `currentPoints` never goes negative — canon's `max(0, …)`, preserved exactly.
+ */
+import type { Perform, Reward } from '@kro/core'
+import { rewardSuggestions } from '@kro/core'
+
+/** `totalEarnedPointsSelector`, sourced from performances (see header). */
+export const totalEarnedPoints = (
+  performances: readonly Perform[],
+): number => performances.reduce((sum, perform) => sum + perform.rewardPoints, 0)
+
+/** `spentPointsSelector` — claimed rewards, read against the LIVE catalog. */
+export const spentPoints = (
+  rewards: readonly Reward[],
+  claimedRewardIds: readonly string[],
+): number =>
+  rewards
+    .filter((reward) => claimedRewardIds.includes(reward.id))
+    .reduce((sum, reward) => sum + reward.pointsRequired, 0)
+
+/**
+ * `currentPointsSelector` — the whole balance, in one pass over the two inputs
+ * above. No stored total is ever read; every call recomputes from scratch.
+ */
+export const currentPoints = (
+  performances: readonly Perform[],
+  rewards: readonly Reward[],
+  claimedRewardIds: readonly string[],
+): number =>
+  Math.max(0, totalEarnedPoints(performances) - spentPoints(rewards, claimedRewardIds))
+
+/** `RewardListRow.pointsRemaining` — "N to go", never negative. */
+export const pointsToGo = (reward: Reward, points: number): number =>
+  Math.max(0, reward.pointsRequired - points)
+
+/**
+ * `RewardListRow.progress` — `0`…`1`. A free reward (`pointsRequired <= 0`) is
+ * always "full", matching canon's `guard reward.pointsRequired > 0 else
+ * return 1`.
+ */
+export const claimProgress = (reward: Reward, points: number): number =>
+  reward.pointsRequired <= 0 ? 1 : Math.min(1, points / reward.pointsRequired)
+
+export interface EarnPartition {
+  /** Unclaimed, affordable now — sorted most-expensive first (canon's order). */
+  readonly claimable: readonly Reward[]
+  /** Unclaimed, still out of reach — sorted cheapest first (canon's order). */
+  readonly locked: readonly Reward[]
+}
+
+/** `claimableRewardsSelector` + `lockedRewardsSelector`, computed together. */
+export const partitionRewards = (
+  rewards: readonly Reward[],
+  claimedRewardIds: readonly string[],
+  points: number,
+): EarnPartition => {
+  const unclaimed = rewards.filter(
+    (reward) => !claimedRewardIds.includes(reward.id),
+  )
+  return {
+    claimable: unclaimed
+      .filter((reward) => points >= reward.pointsRequired)
+      .sort((a, b) => b.pointsRequired - a.pointsRequired),
+    locked: unclaimed
+      .filter((reward) => points < reward.pointsRequired)
+      .sort((a, b) => a.pointsRequired - b.pointsRequired),
+  }
+}
+
+/**
+ * `availableSuggestionsSelector` — the starter catalog, minus anything the
+ * user's own catalog already has by title (case-insensitive, canon's rule).
+ */
+export const availableSuggestions = (
+  rewards: readonly Reward[],
+): readonly Reward[] => {
+  const existingTitles = new Set(
+    rewards.map((reward) => reward.title.toLowerCase()),
+  )
+  return rewardSuggestions.filter(
+    (suggestion) => !existingTitles.has(suggestion.title.toLowerCase()),
+  )
+}
+
+/**
+ * `isCatalogEmptySelector` — canon's `didLoadCatalog && rewards.isEmpty`. This
+ * port has no boolean of its own for "did the load run"; the one `load`
+ * lifecycle field already answers it — `idle`/`loading` means "not yet", and
+ * `loaded`/`failed` both mean the attempt happened (`RC-24`).
+ */
+export const isCatalogEmpty = (
+  loadKind: 'idle' | 'loading' | 'loaded' | 'failed',
+  rewards: readonly Reward[],
+): boolean =>
+  loadKind !== 'idle' && loadKind !== 'loading' && rewards.length === 0

--- a/packages/app/src/features/earn/EarnSelectors.ts
+++ b/packages/app/src/features/earn/EarnSelectors.ts
@@ -1,0 +1,133 @@
+/**
+ * The Earn surface's Selectors (`RC-5`, `RC-20`) — canon's `EarnSelectors.swift`,
+ * built with `createSelector` over `RootState` and composed from the pure
+ * functions in `EarnRules.ts`. No selector here stores its own total: every
+ * balance/partition read recomputes from `performances` + `rewards` +
+ * `claimedRewardIds` on each call (`EarnRules.ts`'s header states why).
+ */
+import { createSelector } from '@reduxjs/toolkit'
+import type { Reward } from '@kro/core'
+import type { RootState } from '../../library/store'
+import type { EarnException } from './EarnException'
+import type { EarnPreferences, EarnRewardDraft, EarnState } from './EarnFeature'
+import {
+  type EarnPartition,
+  availableSuggestions,
+  currentPoints,
+  isCatalogEmpty,
+  partitionRewards,
+  spentPoints,
+  totalEarnedPoints,
+} from './EarnRules'
+
+const selectEarnSlice = (state: RootState): EarnState => state.earn
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+export const selectIsEarnLoading = createSelector(
+  [selectEarnSlice],
+  (slice) => slice.load.kind === 'loading',
+)
+
+export const selectEarnException = createSelector(
+  [selectEarnSlice],
+  (slice): EarnException | null =>
+    slice.load.kind === 'failed' ? slice.load.exception : null,
+)
+
+// ---------------------------------------------------------------------------
+// Balance
+// ---------------------------------------------------------------------------
+
+export const selectTotalEarnedPoints = createSelector([selectEarnSlice], (slice) =>
+  totalEarnedPoints(slice.performances),
+)
+
+export const selectSpentPoints = createSelector([selectEarnSlice], (slice) =>
+  spentPoints(slice.rewards, slice.claimedRewardIds),
+)
+
+export const selectCurrentPoints = createSelector([selectEarnSlice], (slice) =>
+  currentPoints(slice.performances, slice.rewards, slice.claimedRewardIds),
+)
+
+// ---------------------------------------------------------------------------
+// Catalog partition
+// ---------------------------------------------------------------------------
+
+const selectEarnPartition = createSelector(
+  [selectEarnSlice, selectCurrentPoints],
+  (slice, points): EarnPartition =>
+    partitionRewards(slice.rewards, slice.claimedRewardIds, points),
+)
+
+export const selectClaimableRewards = createSelector(
+  [selectEarnPartition],
+  (partition) => partition.claimable,
+)
+
+export const selectLockedRewards = createSelector(
+  [selectEarnPartition],
+  (partition) => partition.locked,
+)
+
+export const selectAvailableSuggestions = createSelector(
+  [selectEarnSlice],
+  (slice) => availableSuggestions(slice.rewards),
+)
+
+export const selectIsEarnCatalogEmpty = createSelector([selectEarnSlice], (slice) =>
+  isCatalogEmpty(slice.load.kind, slice.rewards),
+)
+
+// ---------------------------------------------------------------------------
+// Preferences
+// ---------------------------------------------------------------------------
+
+export const selectEarnPreferences = createSelector(
+  [selectEarnSlice],
+  (slice): EarnPreferences => slice.preferences,
+)
+
+export const selectDefaultRewardThreshold = createSelector(
+  [selectEarnPreferences],
+  (preferences) => preferences.defaultRewardThreshold,
+)
+
+/** The active `earn.pointsFormula`, surfaced read-only (`#27`). */
+export const selectPointsFormula = createSelector(
+  [selectEarnPreferences],
+  (preferences) => preferences.pointsFormula,
+)
+
+// ---------------------------------------------------------------------------
+// Add Reward sheet
+// ---------------------------------------------------------------------------
+
+export const selectIsAddingReward = createSelector(
+  [selectEarnSlice],
+  (slice) => slice.isAddingReward,
+)
+
+export const selectAddRewardDraft = createSelector(
+  [selectEarnSlice],
+  (slice): EarnRewardDraft => slice.addRewardDraft,
+)
+
+// ---------------------------------------------------------------------------
+// Claim flow
+// ---------------------------------------------------------------------------
+
+export const selectClaimingRewardId = createSelector(
+  [selectEarnSlice],
+  (slice) => slice.claimingRewardId,
+)
+
+/** The reward the confirm sheet is open on, resolved from the catalog. */
+export const selectClaimingReward = createSelector(
+  [selectEarnSlice],
+  (slice): Reward | null =>
+    slice.rewards.find((reward) => reward.id === slice.claimingRewardId) ?? null,
+)

--- a/packages/app/src/features/earn/EarnShifters.ts
+++ b/packages/app/src/features/earn/EarnShifters.ts
@@ -1,0 +1,169 @@
+/**
+ * The Earn surface's Shifters (`RC-4`, `RC-19`) — canon's `EarnShifters.swift`,
+ * plus the load/exception transitions canon leaves to TCA's reducer body.
+ *
+ * Every one returns a brand-new plain object; none reads a clock, a service or
+ * a random source — `now`/`id` arrive as arguments wherever a caller needs one
+ * (`UZF-10`).
+ */
+import type { Reward } from '@kro/core'
+import type { EarnException } from './EarnException'
+import type { EarnPreferences, EarnState } from './EarnFeature'
+import { blankEarnRewardDraft } from './EarnFeature'
+import type { EarnCatalogSnapshot } from './EarnProducer'
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+export const withCatalogLoadStarted = (state: EarnState): EarnState => ({
+  ...state,
+  load: { kind: 'loading' },
+})
+
+export const withCatalogInstalled = (
+  state: EarnState,
+  snapshot: EarnCatalogSnapshot,
+): EarnState => ({
+  ...state,
+  load: { kind: 'loaded' },
+  rewards: snapshot.rewards,
+  claimedRewardIds: snapshot.claimedRewardIds,
+  performances: snapshot.performances,
+})
+
+export const withPreferencesApplied = (
+  state: EarnState,
+  preferences: EarnPreferences,
+): EarnState => ({ ...state, preferences })
+
+/**
+ * The shared failure landing spot for every load and every mutation. Never
+ * touches `rewards`/`claimedRewardIds`/`performances`/`preferences` — that is
+ * what makes a failed write leave the catalog and the balance untouched
+ * (`EarnFeature.ts`'s header; the issue's atomicity acceptance criterion).
+ */
+export const withException = (
+  state: EarnState,
+  exception: EarnException,
+): EarnState => ({ ...state, load: { kind: 'failed', exception } })
+
+// ---------------------------------------------------------------------------
+// Add Reward sheet
+// ---------------------------------------------------------------------------
+
+/**
+ * `applyRewardDraftOpened` — always resets the form and presents the sheet.
+ * The cost is pre-filled from the already-loaded `earn.defaultRewardThreshold`
+ * preference (`#11`).
+ */
+export const withRewardDraftOpened = (state: EarnState): EarnState => ({
+  ...state,
+  isAddingReward: true,
+  addRewardDraft: {
+    ...blankEarnRewardDraft,
+    pointsRequired: state.preferences.defaultRewardThreshold,
+  },
+})
+
+/** `applyRewardDraftClosed` — always hides the sheet and resets the form. */
+export const withRewardDraftClosed = (state: EarnState): EarnState => ({
+  ...state,
+  isAddingReward: false,
+  addRewardDraft: blankEarnRewardDraft,
+})
+
+export const withDraftTitleChanged = (
+  state: EarnState,
+  title: string,
+): EarnState => ({
+  ...state,
+  addRewardDraft: { ...state.addRewardDraft, title },
+})
+
+/** Canon's `String(glyph.prefix(2))` — capped at two code points. */
+export const withDraftGlyphChanged = (
+  state: EarnState,
+  glyph: string,
+): EarnState => ({
+  ...state,
+  addRewardDraft: {
+    ...state.addRewardDraft,
+    glyph: [...glyph].slice(0, 2).join(''),
+  },
+})
+
+/** Canon's `max(0, points)` — never negative. */
+export const withDraftPointsChanged = (
+  state: EarnState,
+  pointsRequired: number,
+): EarnState => ({
+  ...state,
+  addRewardDraft: {
+    ...state.addRewardDraft,
+    pointsRequired: Math.max(0, pointsRequired),
+  },
+})
+
+/** Canon's `notes.isEmpty ? nil : notes`. */
+export const withDraftNotesChanged = (
+  state: EarnState,
+  notes: string,
+): EarnState => ({
+  ...state,
+  addRewardDraft: {
+    ...state.addRewardDraft,
+    notes: notes.length === 0 ? null : notes,
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Catalog mutations — applied only after the persist succeeds
+// ---------------------------------------------------------------------------
+
+/**
+ * A typed add and a suggestion-add land here identically: both insert at the
+ * top (canon's `rewards.insert(_, at: 0)`), close the sheet and clear the
+ * draft — harmless when the sheet was never open (the suggestion path).
+ */
+export const withRewardAdded = (state: EarnState, reward: Reward): EarnState => ({
+  ...state,
+  load: { kind: 'loaded' },
+  rewards: [reward, ...state.rewards],
+  isAddingReward: false,
+  addRewardDraft: blankEarnRewardDraft,
+})
+
+/** `userDidTapDeleteReward` — context-menu delete, by id. */
+export const withRewardRemoved = (state: EarnState, id: string): EarnState => ({
+  ...state,
+  load: { kind: 'loaded' },
+  rewards: state.rewards.filter((reward) => reward.id !== id),
+})
+
+// ---------------------------------------------------------------------------
+// Claim flow
+// ---------------------------------------------------------------------------
+
+export const withClaimRequested = (
+  state: EarnState,
+  rewardId: string,
+): EarnState => ({ ...state, claimingRewardId: rewardId })
+
+export const withClaimCancelled = (state: EarnState): EarnState => ({
+  ...state,
+  claimingRewardId: null,
+})
+
+/**
+ * `applyClaimConfirmed` — marks the id claimed (idempotent: claiming an
+ * already-claimed id is a no-op on the set) and clears the confirm sheet.
+ */
+export const withClaimApplied = (state: EarnState, id: string): EarnState => ({
+  ...state,
+  load: { kind: 'loaded' },
+  claimedRewardIds: state.claimedRewardIds.includes(id)
+    ? state.claimedRewardIds
+    : [...state.claimedRewardIds, id],
+  claimingRewardId: null,
+})

--- a/packages/app/src/features/earn/__tests__/EarnException.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnException.test.ts
@@ -20,6 +20,13 @@ describe('EarnExceptions', () => {
     expect(EarnExceptions.claimRewardFailed('x').kind).toBe('claimRewardFailed')
   })
 
+  it('marks a claim on a missing reward unrecoverable — retrying the same stale id cannot help', () => {
+    const exception = EarnExceptions.rewardNotFound('ghost-id')
+    expect(exception.kind).toBe('rewardNotFound')
+    expect(exception.recoverable).toBe(false)
+    expect(exception.message).toContain('ghost-id')
+  })
+
   it('marks every mutation failure recoverable — a retry can succeed', () => {
     expect(EarnExceptions.addRewardFailed('x').recoverable).toBe(true)
     expect(EarnExceptions.deleteRewardFailed('x').recoverable).toBe(true)
@@ -41,6 +48,7 @@ describe('EarnExceptions', () => {
         case 'addRewardFailed':
         case 'deleteRewardFailed':
         case 'claimRewardFailed':
+        case 'rewardNotFound':
         case 'unknown':
           return exception.kind
       }

--- a/packages/app/src/features/earn/__tests__/EarnException.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnException.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { type EarnException, EarnExceptions } from '../EarnException'
+
+describe('EarnExceptions', () => {
+  it('marks a blank-title guard recoverable — the user can just type a title', () => {
+    const exception = EarnExceptions.blankTitle()
+    expect(exception.kind).toBe('blankTitle')
+    expect(exception.recoverable).toBe(true)
+  })
+
+  it('folds the developer-facing cause into the message, never into the kind', () => {
+    const exception = EarnExceptions.catalogLoadFailed('storage is gone')
+    expect(exception.kind).toBe('catalogLoadFailed')
+    expect(exception.message).toContain('storage is gone')
+  })
+
+  it('keeps the three mutation failures apart, because they mean different things', () => {
+    expect(EarnExceptions.addRewardFailed('x').kind).toBe('addRewardFailed')
+    expect(EarnExceptions.deleteRewardFailed('x').kind).toBe('deleteRewardFailed')
+    expect(EarnExceptions.claimRewardFailed('x').kind).toBe('claimRewardFailed')
+  })
+
+  it('marks every mutation failure recoverable — a retry can succeed', () => {
+    expect(EarnExceptions.addRewardFailed('x').recoverable).toBe(true)
+    expect(EarnExceptions.deleteRewardFailed('x').recoverable).toBe(true)
+    expect(EarnExceptions.claimRewardFailed('x').recoverable).toBe(true)
+  })
+
+  it('offers the generic fallback a defensive rejected arm can land in', () => {
+    const exception: EarnException = EarnExceptions.unknown('kaboom')
+    expect(exception.kind).toBe('unknown')
+    expect(exception.recoverable).toBe(true)
+  })
+
+  it('narrows exhaustively on kind — the discriminant is the whole contract', () => {
+    const copyFor = (exception: EarnException): string => {
+      switch (exception.kind) {
+        case 'preferencesLoadFailed':
+        case 'catalogLoadFailed':
+        case 'blankTitle':
+        case 'addRewardFailed':
+        case 'deleteRewardFailed':
+        case 'claimRewardFailed':
+        case 'unknown':
+          return exception.kind
+      }
+    }
+    expect(copyFor(EarnExceptions.preferencesLoadFailed('offline'))).toBe(
+      'preferencesLoadFailed',
+    )
+  })
+})

--- a/packages/app/src/features/earn/__tests__/EarnFeature.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnFeature.test.ts
@@ -1,0 +1,345 @@
+import { rewardMocks } from '@kro/core/mocks'
+import { describe, expect, it } from 'vitest'
+import {
+  type EarnState,
+  earnSlice,
+  initialEarnState,
+  userDidCancelAddReward,
+  userDidCancelClaim,
+  userDidChangeDraftGlyph,
+  userDidChangeDraftNotes,
+  userDidChangeDraftPoints,
+  userDidChangeDraftTitle,
+  userDidTapAddReward,
+  userDidTapClaim,
+} from '../EarnFeature'
+import { earnStateMocks } from '../EarnMocks'
+import {
+  addRewardThunk,
+  addSuggestionThunk,
+  claimRewardThunk,
+  deleteRewardThunk,
+  loadEarnCatalogThunk,
+  loadEarnPreferencesThunk,
+} from '../EarnProducer'
+
+const reduce = (state: EarnState, action: Parameters<typeof earnSlice.reducer>[1]) =>
+  earnSlice.reducer(state, action)
+
+const loaded = earnStateMocks.loadedTypical
+
+const abortError = () => {
+  const error = new Error('Aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+// ---------------------------------------------------------------------------
+// The Add-Reward sheet
+// ---------------------------------------------------------------------------
+
+describe('userDidTapAddReward', () => {
+  it('opens the sheet', () => {
+    expect(reduce(loaded, userDidTapAddReward()).isAddingReward).toBe(true)
+  })
+
+  it('prefills the cost from the loaded preference', () => {
+    const withPrefs = {
+      ...loaded,
+      preferences: { ...loaded.preferences, defaultRewardThreshold: 250 },
+    }
+    expect(
+      reduce(withPrefs, userDidTapAddReward()).addRewardDraft.pointsRequired,
+    ).toBe(250)
+  })
+
+  it('falls back to 100 when the preference has not loaded yet', () => {
+    expect(
+      reduce(initialEarnState, userDidTapAddReward()).addRewardDraft.pointsRequired,
+    ).toBe(100)
+  })
+})
+
+describe('draft field edits', () => {
+  it('userDidChangeDraftTitle sets the title', () => {
+    expect(
+      reduce(loaded, userDidChangeDraftTitle({ title: 'Boba Tea' })).addRewardDraft.title,
+    ).toBe('Boba Tea')
+  })
+
+  it('userDidChangeDraftGlyph truncates to two code points', () => {
+    expect(
+      reduce(loaded, userDidChangeDraftGlyph({ glyph: 'xyz' })).addRewardDraft.glyph,
+    ).toBe('xy')
+  })
+
+  it('userDidChangeDraftPoints clamps to zero', () => {
+    expect(
+      reduce(loaded, userDidChangeDraftPoints({ pointsRequired: -10 })).addRewardDraft
+        .pointsRequired,
+    ).toBe(0)
+  })
+
+  it('userDidChangeDraftNotes maps empty to null', () => {
+    expect(
+      reduce(loaded, userDidChangeDraftNotes({ notes: '' })).addRewardDraft.notes,
+    ).toBeNull()
+  })
+})
+
+describe('userDidCancelAddReward', () => {
+  it('closes the sheet', () => {
+    const open = reduce(loaded, userDidTapAddReward())
+    expect(reduce(open, userDidCancelAddReward()).isAddingReward).toBe(false)
+  })
+
+  it('resets the draft', () => {
+    const dirty = reduce(loaded, userDidChangeDraftTitle({ title: 'x' }))
+    expect(reduce(dirty, userDidCancelAddReward()).addRewardDraft.title).toBe('')
+  })
+
+  it('is safe to call when the sheet was never open', () => {
+    expect(reduce(loaded, userDidCancelAddReward()).isAddingReward).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The claim flow
+// ---------------------------------------------------------------------------
+
+describe('userDidTapClaim / userDidCancelClaim', () => {
+  it('opens the confirm sheet on the tapped reward', () => {
+    expect(
+      reduce(loaded, userDidTapClaim({ rewardId: rewardMocks.bobaTea.id }))
+        .claimingRewardId,
+    ).toBe(rewardMocks.bobaTea.id)
+  })
+
+  it('cancel clears the confirm sheet', () => {
+    const opened = reduce(loaded, userDidTapClaim({ rewardId: rewardMocks.bobaTea.id }))
+    expect(reduce(opened, userDidCancelClaim()).claimingRewardId).toBeNull()
+  })
+
+  it('re-tapping a different reward replaces the pointer', () => {
+    const first = reduce(loaded, userDidTapClaim({ rewardId: rewardMocks.bobaTea.id }))
+    const second = reduce(first, userDidTapClaim({ rewardId: rewardMocks.plain.id }))
+    expect(second.claimingRewardId).toBe(rewardMocks.plain.id)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Thunk lifecycle arms
+// ---------------------------------------------------------------------------
+
+describe('loadEarnPreferencesThunk lifecycle', () => {
+  it('applies the loaded preferences on success', () => {
+    const next = reduce(
+      initialEarnState,
+      loadEarnPreferencesThunk.fulfilled(
+        { ok: true, value: { defaultRewardThreshold: 300, pointsFormula: 'legacy' } },
+        'req',
+        undefined,
+      ),
+    )
+    expect(next.preferences.defaultRewardThreshold).toBe(300)
+    expect(next.preferences.pointsFormula).toBe('legacy')
+  })
+
+  it('reports the typed failure on a domain error, leaving preferences untouched', () => {
+    const next = reduce(
+      initialEarnState,
+      loadEarnPreferencesThunk.fulfilled(
+        { ok: false, error: { kind: 'preferencesLoadFailed', message: 'x', recoverable: true } },
+        'req',
+        undefined,
+      ),
+    )
+    expect(next.load.kind).toBe('failed')
+    expect(next.preferences).toBe(initialEarnState.preferences)
+  })
+
+  it('degrades an unexpected rejection to the generic exception', () => {
+    const next = reduce(
+      initialEarnState,
+      loadEarnPreferencesThunk.rejected(new Error('kaboom'), 'req', undefined),
+    )
+    expect(next.load.kind).toBe('failed')
+  })
+
+  it('stays silent on an aborted read', () => {
+    const next = reduce(
+      loaded,
+      loadEarnPreferencesThunk.rejected(abortError(), 'req', undefined),
+    )
+    expect(next.load).toEqual(loaded.load)
+  })
+})
+
+describe('loadEarnCatalogThunk lifecycle', () => {
+  it('shows the spinner on pending, clearing any prior exception', () => {
+    const failed = { ...loaded, load: earnStateMocks.failedRefreshKeepingCatalog.load }
+    expect(reduce(failed, loadEarnCatalogThunk.pending('req', undefined)).load).toEqual({
+      kind: 'loading',
+    })
+  })
+
+  it('installs the whole snapshot on success', () => {
+    const snapshot = { rewards: [rewardMocks.movieNight], claimedRewardIds: [], performances: [] }
+    const next = reduce(
+      initialEarnState,
+      loadEarnCatalogThunk.fulfilled({ ok: true, value: snapshot }, 'req', undefined),
+    )
+    expect(next.load).toEqual({ kind: 'loaded' })
+    expect(next.rewards).toEqual([rewardMocks.movieNight])
+  })
+
+  it('reports the typed failure, keeping the retained catalog (canon: never blank the surface)', () => {
+    const next = reduce(
+      loaded,
+      loadEarnCatalogThunk.fulfilled(
+        { ok: false, error: { kind: 'catalogLoadFailed', message: 'x', recoverable: true } },
+        'req',
+        undefined,
+      ),
+    )
+    expect(next.load.kind).toBe('failed')
+    expect(next.rewards).toBe(loaded.rewards)
+  })
+
+  it('stays silent on an aborted read', () => {
+    const next = reduce(loaded, loadEarnCatalogThunk.rejected(abortError(), 'req', undefined))
+    expect(next.load).toEqual(loaded.load)
+  })
+})
+
+describe('addRewardThunk lifecycle', () => {
+  const arg = {
+    draft: { title: 'Boba Tea', glyph: '🧋', pointsRequired: 80, notes: null },
+    id: 'new-1',
+    now: new Date(2026, 2, 17),
+  }
+
+  it('prepends the new reward on success', () => {
+    const next = reduce(
+      loaded,
+      addRewardThunk.fulfilled({ ok: true, value: { reward: rewardMocks.movieNight } }, 'req', arg),
+    )
+    expect(next.rewards[0]?.id).toBe(rewardMocks.movieNight.id)
+  })
+
+  it('reports the typed failure and leaves the sheet open for a retry', () => {
+    const open = { ...loaded, isAddingReward: true }
+    const next = reduce(
+      open,
+      addRewardThunk.fulfilled(
+        { ok: false, error: { kind: 'addRewardFailed', message: 'x', recoverable: true } },
+        'req',
+        arg,
+      ),
+    )
+    expect(next.load.kind).toBe('failed')
+    expect(next.isAddingReward).toBe(true)
+    expect(next.rewards).toBe(loaded.rewards)
+  })
+
+  it('degrades an unexpected rejection to the generic exception', () => {
+    const next = reduce(loaded, addRewardThunk.rejected(new Error('kaboom'), 'req', arg))
+    expect(next.load.kind).toBe('failed')
+  })
+})
+
+describe('addSuggestionThunk lifecycle', () => {
+  const arg = { suggestion: rewardMocks.bobaTea, id: 'new-2', now: new Date(2026, 2, 17) }
+
+  it('prepends the inserted suggestion on success', () => {
+    const next = reduce(
+      loaded,
+      addSuggestionThunk.fulfilled(
+        { ok: true, value: { reward: { ...rewardMocks.bobaTea, id: 'new-2' } } },
+        'req',
+        arg,
+      ),
+    )
+    expect(next.rewards[0]?.id).toBe('new-2')
+  })
+
+  it('reports the typed failure, leaving the catalog untouched', () => {
+    const next = reduce(
+      loaded,
+      addSuggestionThunk.fulfilled(
+        { ok: false, error: { kind: 'addRewardFailed', message: 'x', recoverable: true } },
+        'req',
+        arg,
+      ),
+    )
+    expect(next.rewards).toBe(loaded.rewards)
+  })
+
+  it('degrades an unexpected rejection to the generic exception', () => {
+    const next = reduce(loaded, addSuggestionThunk.rejected(new Error('kaboom'), 'req', arg))
+    expect(next.load.kind).toBe('failed')
+  })
+})
+
+describe('deleteRewardThunk lifecycle', () => {
+  const arg = { id: rewardMocks.bobaTea.id }
+
+  it('removes the reward on success', () => {
+    const next = reduce(
+      loaded,
+      deleteRewardThunk.fulfilled({ ok: true, value: { id: rewardMocks.bobaTea.id } }, 'req', arg),
+    )
+    expect(next.rewards.some((r) => r.id === rewardMocks.bobaTea.id)).toBe(false)
+  })
+
+  it('reports the typed failure, leaving the catalog untouched', () => {
+    const next = reduce(
+      loaded,
+      deleteRewardThunk.fulfilled(
+        { ok: false, error: { kind: 'deleteRewardFailed', message: 'x', recoverable: true } },
+        'req',
+        arg,
+      ),
+    )
+    expect(next.rewards).toBe(loaded.rewards)
+  })
+
+  it('degrades an unexpected rejection to the generic exception', () => {
+    const next = reduce(loaded, deleteRewardThunk.rejected(new Error('kaboom'), 'req', arg))
+    expect(next.load.kind).toBe('failed')
+  })
+})
+
+describe('claimRewardThunk lifecycle — the atomic one', () => {
+  const arg = { id: rewardMocks.bobaTea.id }
+
+  it('adds the id to the claimed set and clears the confirm sheet on success', () => {
+    const claiming = { ...loaded, claimingRewardId: rewardMocks.bobaTea.id }
+    const next = reduce(
+      claiming,
+      claimRewardThunk.fulfilled({ ok: true, value: { id: rewardMocks.bobaTea.id } }, 'req', arg),
+    )
+    expect(next.claimedRewardIds).toContain(rewardMocks.bobaTea.id)
+    expect(next.claimingRewardId).toBeNull()
+  })
+
+  it('leaves the claimed set and the confirm sheet untouched on a typed failure — atomicity', () => {
+    const claiming = { ...loaded, claimingRewardId: rewardMocks.bobaTea.id }
+    const next = reduce(
+      claiming,
+      claimRewardThunk.fulfilled(
+        { ok: false, error: { kind: 'claimRewardFailed', message: 'x', recoverable: true } },
+        'req',
+        arg,
+      ),
+    )
+    expect(next.claimedRewardIds).toEqual(claiming.claimedRewardIds)
+    expect(next.claimingRewardId).toBe(rewardMocks.bobaTea.id)
+    expect(next.load.kind).toBe('failed')
+  })
+
+  it('stays silent on an aborted claim', () => {
+    const next = reduce(loaded, claimRewardThunk.rejected(abortError(), 'req', arg))
+    expect(next.load).toEqual(loaded.load)
+  })
+})

--- a/packages/app/src/features/earn/__tests__/EarnMocks.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnMocks.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EARN_MOCK_NOW,
+  earnCatalogFixture,
+  earnFixturePerformances,
+  earnStateMocks,
+} from '../EarnMocks'
+import { currentPoints } from '../EarnRules'
+
+/**
+ * The fixtures are load-bearing: every other suite in this folder asserts
+ * against them, so a fixture that quietly stopped meaning what its name says
+ * would turn a real regression into a green run.
+ */
+
+describe('EARN_MOCK_NOW', () => {
+  it('is a fixed instant, not a clock reading', () => {
+    expect(EARN_MOCK_NOW).toEqual(new Date(2026, 2, 17, 10, 0, 0))
+  })
+
+  it('is the same on every read', () => {
+    expect(EARN_MOCK_NOW.getTime()).toBe(new Date(2026, 2, 17, 10, 0, 0).getTime())
+  })
+})
+
+describe('earnFixturePerformances', () => {
+  it('sums to exactly 130 points — the balance every selector suite assumes', () => {
+    expect(currentPoints(earnFixturePerformances, [], [])).toBe(130)
+  })
+
+  it('holds three distinct performances', () => {
+    expect(earnFixturePerformances).toHaveLength(3)
+  })
+})
+
+describe('earnCatalogFixture', () => {
+  it('straddles the fixture balance — one affordable, two not', () => {
+    const balance = currentPoints(earnFixturePerformances, [], [])
+    const affordable = earnCatalogFixture.filter((r) => r.pointsRequired <= balance)
+    const unaffordable = earnCatalogFixture.filter((r) => r.pointsRequired > balance)
+    expect(affordable.length).toBeGreaterThan(0)
+    expect(unaffordable.length).toBeGreaterThan(0)
+  })
+
+  it('gives every fixture reward a distinct id', () => {
+    const ids = earnCatalogFixture.map((r) => r.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe('earnStateMocks', () => {
+  it('covers idle, loading, loaded and failed lifecycle states', () => {
+    expect(earnStateMocks.idle.load.kind).toBe('idle')
+    expect(earnStateMocks.loading.load.kind).toBe('loading')
+    expect(earnStateMocks.loadedTypical.load.kind).toBe('loaded')
+    expect(earnStateMocks.failedRefreshKeepingCatalog.load.kind).toBe('failed')
+  })
+
+  it('keeps the catalog on a failed refresh, never blanking it', () => {
+    expect(earnStateMocks.failedRefreshKeepingCatalog.rewards).toEqual(
+      earnStateMocks.loadedTypical.rewards,
+    )
+  })
+
+  it('opens the Add-Reward sheet prefilled from the default threshold', () => {
+    expect(earnStateMocks.addingReward.isAddingReward).toBe(true)
+    expect(earnStateMocks.addingReward.addRewardDraft.pointsRequired).toBe(
+      earnStateMocks.addingReward.preferences.defaultRewardThreshold,
+    )
+  })
+
+  it('opens the claim confirm sheet on a reward actually in the catalog', () => {
+    const { claimingRewardId, rewards } = earnStateMocks.claimingReward
+    expect(rewards.some((r) => r.id === claimingRewardId)).toBe(true)
+  })
+})

--- a/packages/app/src/features/earn/__tests__/EarnProducer.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnProducer.test.ts
@@ -1,0 +1,331 @@
+import {
+  type KeyValueStore,
+  type LocalStore,
+  type PerformanceRecord,
+  performanceRecordFromPerform,
+} from '@kro/core'
+import { rewardMocks } from '@kro/core/mocks'
+import { describe, expect, it } from 'vitest'
+import { makeInMemoryLocalStore } from '../../../services/localStore/InMemoryLocalStore'
+import { type AppStore, makeStore, stubbedThunkExtra } from '../../../library/store'
+import { userDidTapClaim } from '../EarnFeature'
+import { earnFixturePerformances } from '../EarnMocks'
+import {
+  addRewardThunk,
+  addSuggestionThunk,
+  claimRewardThunk,
+  deleteRewardThunk,
+  loadEarnCatalogThunk,
+  loadEarnPreferencesThunk,
+} from '../EarnProducer'
+import {
+  readClaimedRewardIds,
+  readRewardsCatalog,
+  writeClaimedRewardIds,
+  writeRewardsCatalog,
+} from '../EarnRewardsStorage'
+import { selectCurrentPoints, selectLockedRewards } from '../EarnSelectors'
+
+const storeWith = (localStore: LocalStore): AppStore =>
+  makeStore({ ...stubbedThunkExtra, localStore })
+
+/** Wraps a `KeyValueStore` so a suite can make `set` fail after N successful calls. */
+const instrumentPreferences = (
+  preferences: KeyValueStore,
+  failSetAfter: number,
+): KeyValueStore => {
+  let sets = 0
+  return {
+    ...preferences,
+    set: (key, value) => {
+      sets += 1
+      if (sets > failSetAfter) throw new Error('disk full')
+      preferences.set(key, value)
+    },
+  }
+}
+
+const performanceRecords = (): readonly PerformanceRecord[] =>
+  earnFixturePerformances.map((perform) =>
+    performanceRecordFromPerform(perform, { endeavorId: 'e-1', nowMillis: 0 }),
+  )
+
+describe('loadEarnPreferencesThunk', () => {
+  it('reads the declared defaults when nothing is stored', async () => {
+    const store = storeWith(makeInMemoryLocalStore())
+    const result = await store.dispatch(loadEarnPreferencesThunk()).unwrap()
+    expect(result).toEqual({
+      ok: true,
+      value: { defaultRewardThreshold: 100, pointsFormula: 'slidingScale' },
+    })
+  })
+
+  it('reads a seeded threshold and formula', async () => {
+    const store = storeWith(
+      makeInMemoryLocalStore({
+        preferences: {
+          'kro:earn.defaultRewardThreshold': 250,
+          'kro:earn.pointsFormula': 'legacy',
+        },
+      }),
+    )
+    const result = await store.dispatch(loadEarnPreferencesThunk()).unwrap()
+    expect(result).toEqual({
+      ok: true,
+      value: { defaultRewardThreshold: 250, pointsFormula: 'legacy' },
+    })
+  })
+
+  it('reports a typed failure when the store cannot be read', async () => {
+    const localStore = makeInMemoryLocalStore()
+    const broken: LocalStore = {
+      ...localStore,
+      preferences: {
+        ...localStore.preferences,
+        get: () => {
+          throw new Error('unavailable')
+        },
+      },
+    }
+    const result = await storeWith(broken).dispatch(loadEarnPreferencesThunk()).unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('preferencesLoadFailed')
+  })
+})
+
+describe('loadEarnCatalogThunk', () => {
+  it('reads an empty snapshot with nothing seeded', async () => {
+    const result = await storeWith(makeInMemoryLocalStore())
+      .dispatch(loadEarnCatalogThunk())
+      .unwrap()
+    expect(result).toEqual({
+      ok: true,
+      value: { rewards: [], claimedRewardIds: [], performances: [] },
+    })
+  })
+
+  it('reads the seeded catalog, claimed set and performances together', async () => {
+    const localStore = makeInMemoryLocalStore({ performances: performanceRecords() })
+    writeRewardsCatalog(localStore.preferences, [rewardMocks.bobaTea])
+    writeClaimedRewardIds(localStore.preferences, [rewardMocks.bobaTea.id])
+
+    const result = await storeWith(localStore).dispatch(loadEarnCatalogThunk()).unwrap()
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.rewards).toEqual([rewardMocks.bobaTea])
+      expect(result.value.claimedRewardIds).toEqual([rewardMocks.bobaTea.id])
+      expect(result.value.performances).toHaveLength(earnFixturePerformances.length)
+    }
+  })
+
+  it('reports a typed failure when the performances read fails', async () => {
+    const localStore = makeInMemoryLocalStore()
+    const broken: LocalStore = {
+      ...localStore,
+      performances: {
+        ...localStore.performances,
+        all: async () => {
+          throw new Error('database unavailable')
+        },
+      },
+    }
+    const result = await storeWith(broken).dispatch(loadEarnCatalogThunk()).unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('catalogLoadFailed')
+  })
+})
+
+describe('addRewardThunk', () => {
+  const draft = { title: 'Boba Tea', glyph: '🧋', pointsRequired: 80, notes: null }
+
+  it('persists the new reward under a caller-minted id', async () => {
+    const localStore = makeInMemoryLocalStore()
+    const result = await storeWith(localStore)
+      .dispatch(addRewardThunk({ draft, id: 'new-1', now: new Date(2026, 2, 17) }))
+      .unwrap()
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value.reward.id).toBe('new-1')
+    expect(readRewardsCatalog(localStore.preferences).map((r) => r.id)).toEqual(['new-1'])
+  })
+
+  it('rejects a blank title without touching storage', async () => {
+    const localStore = makeInMemoryLocalStore()
+    const result = await storeWith(localStore)
+      .dispatch(
+        addRewardThunk({
+          draft: { ...draft, title: '   ' },
+          id: 'new-1',
+          now: new Date(2026, 2, 17),
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('blankTitle')
+    expect(readRewardsCatalog(localStore.preferences)).toEqual([])
+  })
+
+  it('reports a typed failure and leaves the catalog untouched when the write fails', async () => {
+    const localStore = makeInMemoryLocalStore()
+    const broken: LocalStore = {
+      ...localStore,
+      preferences: instrumentPreferences(localStore.preferences, 0),
+    }
+    const result = await storeWith(broken)
+      .dispatch(addRewardThunk({ draft, id: 'new-1', now: new Date(2026, 2, 17) }))
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('addRewardFailed')
+    expect(readRewardsCatalog(broken.preferences)).toEqual([])
+  })
+})
+
+describe('addSuggestionThunk', () => {
+  it('persists the suggestion under a fresh id and timestamp', async () => {
+    const localStore = makeInMemoryLocalStore()
+    const now = new Date(2026, 2, 17)
+    const result = await storeWith(localStore)
+      .dispatch(addSuggestionThunk({ suggestion: rewardMocks.bobaTea, id: 'copy-1', now }))
+      .unwrap()
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.reward.id).toBe('copy-1')
+      expect(result.value.reward.dateAdded).toEqual(now)
+      expect(result.value.reward.title).toBe(rewardMocks.bobaTea.title)
+    }
+  })
+
+  it('prepends ahead of any existing catalog rows', async () => {
+    const localStore = makeInMemoryLocalStore()
+    writeRewardsCatalog(localStore.preferences, [rewardMocks.movieNight])
+    await storeWith(localStore)
+      .dispatch(
+        addSuggestionThunk({
+          suggestion: rewardMocks.bobaTea,
+          id: 'copy-1',
+          now: new Date(2026, 2, 17),
+        }),
+      )
+      .unwrap()
+    expect(readRewardsCatalog(localStore.preferences).map((r) => r.id)).toEqual([
+      'copy-1',
+      rewardMocks.movieNight.id,
+    ])
+  })
+
+  it('reports a typed failure when the write fails', async () => {
+    const localStore = makeInMemoryLocalStore()
+    const broken: LocalStore = {
+      ...localStore,
+      preferences: instrumentPreferences(localStore.preferences, 0),
+    }
+    const result = await storeWith(broken)
+      .dispatch(
+        addSuggestionThunk({
+          suggestion: rewardMocks.bobaTea,
+          id: 'copy-1',
+          now: new Date(2026, 2, 17),
+        }),
+      )
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('addRewardFailed')
+  })
+})
+
+describe('deleteRewardThunk', () => {
+  it('removes the matching row from storage', async () => {
+    const localStore = makeInMemoryLocalStore()
+    writeRewardsCatalog(localStore.preferences, [rewardMocks.bobaTea, rewardMocks.movieNight])
+    const result = await storeWith(localStore)
+      .dispatch(deleteRewardThunk({ id: rewardMocks.bobaTea.id }))
+      .unwrap()
+    expect(result).toEqual({ ok: true, value: { id: rewardMocks.bobaTea.id } })
+    expect(readRewardsCatalog(localStore.preferences)).toEqual([rewardMocks.movieNight])
+  })
+
+  it('succeeds as a no-op for an id not in the catalog', async () => {
+    const localStore = makeInMemoryLocalStore()
+    writeRewardsCatalog(localStore.preferences, [rewardMocks.bobaTea])
+    const result = await storeWith(localStore).dispatch(deleteRewardThunk({ id: 'ghost' })).unwrap()
+    expect(result.ok).toBe(true)
+    expect(readRewardsCatalog(localStore.preferences)).toEqual([rewardMocks.bobaTea])
+  })
+
+  it('reports a typed failure and leaves storage untouched when the write fails', async () => {
+    const localStore = makeInMemoryLocalStore()
+    writeRewardsCatalog(localStore.preferences, [rewardMocks.bobaTea])
+    const broken: LocalStore = {
+      ...localStore,
+      preferences: instrumentPreferences(localStore.preferences, 0),
+    }
+    const result = await storeWith(broken)
+      .dispatch(deleteRewardThunk({ id: rewardMocks.bobaTea.id }))
+      .unwrap()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('deleteRewardFailed')
+    expect(readRewardsCatalog(broken.preferences)).toEqual([rewardMocks.bobaTea])
+  })
+})
+
+describe('claimRewardThunk — the atomic one', () => {
+  it('persists the claimed id', async () => {
+    const localStore = makeInMemoryLocalStore()
+    const result = await storeWith(localStore)
+      .dispatch(claimRewardThunk({ id: rewardMocks.bobaTea.id }))
+      .unwrap()
+    expect(result).toEqual({ ok: true, value: { id: rewardMocks.bobaTea.id } })
+    expect(readClaimedRewardIds(localStore.preferences)).toEqual([rewardMocks.bobaTea.id])
+  })
+
+  it('is idempotent — claiming an already-claimed id does not duplicate it', async () => {
+    const localStore = makeInMemoryLocalStore()
+    writeClaimedRewardIds(localStore.preferences, [rewardMocks.bobaTea.id])
+    await storeWith(localStore).dispatch(claimRewardThunk({ id: rewardMocks.bobaTea.id })).unwrap()
+    expect(readClaimedRewardIds(localStore.preferences)).toEqual([rewardMocks.bobaTea.id])
+  })
+
+  it(
+    'a failed persist leaves the stored claimed set untouched (producer-level atomicity)',
+    async () => {
+      const localStore = makeInMemoryLocalStore()
+      const broken: LocalStore = {
+        ...localStore,
+        preferences: instrumentPreferences(localStore.preferences, 0),
+      }
+      const result = await storeWith(broken)
+        .dispatch(claimRewardThunk({ id: rewardMocks.bobaTea.id }))
+        .unwrap()
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error.kind).toBe('claimRewardFailed')
+      expect(readClaimedRewardIds(broken.preferences)).toEqual([])
+    },
+  )
+
+  it(
+    'end-to-end: a failed claim leaves the balance and the catalog partition untouched ' +
+      '(acceptance criterion 1 — atomically)',
+    async () => {
+      const localStore = makeInMemoryLocalStore({ performances: performanceRecords() })
+      writeRewardsCatalog(localStore.preferences, [rewardMocks.bobaTea, rewardMocks.movieNight])
+      const broken: LocalStore = {
+        ...localStore,
+        preferences: instrumentPreferences(localStore.preferences, 0),
+      }
+      const store = storeWith(broken)
+
+      await store.dispatch(loadEarnCatalogThunk()).unwrap()
+      const before = {
+        balance: selectCurrentPoints(store.getState()),
+        locked: selectLockedRewards(store.getState()).map((r) => r.id),
+      }
+
+      store.dispatch(userDidTapClaim({ rewardId: rewardMocks.bobaTea.id }))
+      await store.dispatch(claimRewardThunk({ id: rewardMocks.bobaTea.id }))
+
+      expect(selectCurrentPoints(store.getState())).toBe(before.balance)
+      expect(selectLockedRewards(store.getState()).map((r) => r.id)).toEqual(before.locked)
+      // The confirm sheet stays open on the same reward, so the user can retry.
+      expect(store.getState().earn.claimingRewardId).toBe(rewardMocks.bobaTea.id)
+    },
+  )
+})

--- a/packages/app/src/features/earn/__tests__/EarnProducer.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnProducer.test.ts
@@ -290,6 +290,7 @@ describe('deleteRewardThunk', () => {
 describe('claimRewardThunk — the atomic one', () => {
   it('persists the claimed id', async () => {
     const localStore = makeInMemoryLocalStore()
+    writeRewardsCatalog(localStore.preferences, [rewardMocks.bobaTea])
     const result = await storeWith(localStore)
       .dispatch(claimRewardThunk({ id: rewardMocks.bobaTea.id }))
       .unwrap()
@@ -299,15 +300,31 @@ describe('claimRewardThunk — the atomic one', () => {
 
   it('is idempotent — claiming an already-claimed id does not duplicate it', async () => {
     const localStore = makeInMemoryLocalStore()
+    writeRewardsCatalog(localStore.preferences, [rewardMocks.bobaTea])
     writeClaimedRewardIds(localStore.preferences, [rewardMocks.bobaTea.id])
     await storeWith(localStore).dispatch(claimRewardThunk({ id: rewardMocks.bobaTea.id })).unwrap()
     expect(readClaimedRewardIds(localStore.preferences)).toEqual([rewardMocks.bobaTea.id])
   })
 
   it(
+    'refuses to claim an id absent from the persisted catalog — the "ghost claim" ' +
+      'a second Copilot round flagged',
+    async () => {
+      const localStore = makeInMemoryLocalStore()
+      const result = await storeWith(localStore)
+        .dispatch(claimRewardThunk({ id: 'ghost-id' }))
+        .unwrap()
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error.kind).toBe('rewardNotFound')
+      expect(readClaimedRewardIds(localStore.preferences)).toEqual([])
+    },
+  )
+
+  it(
     'a failed persist leaves the stored claimed set untouched (producer-level atomicity)',
     async () => {
       const localStore = makeInMemoryLocalStore()
+      writeRewardsCatalog(localStore.preferences, [rewardMocks.bobaTea])
       const broken: LocalStore = {
         ...localStore,
         preferences: instrumentPreferences(localStore.preferences, 0),

--- a/packages/app/src/features/earn/__tests__/EarnProducer.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnProducer.test.ts
@@ -133,6 +133,26 @@ describe('loadEarnCatalogThunk', () => {
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.error.kind).toBe('catalogLoadFailed')
   })
+
+  it(
+    'drops a claimed id that no longer names a reward in the catalog — the id-reuse ' +
+      'hazard a Copilot round flagged (a later reward minted with a stale claimed id ' +
+      'must not install as pre-claimed)',
+    async () => {
+      const localStore = makeInMemoryLocalStore()
+      writeRewardsCatalog(localStore.preferences, [rewardMocks.movieNight])
+      writeClaimedRewardIds(localStore.preferences, [
+        rewardMocks.bobaTea.id,
+        rewardMocks.movieNight.id,
+      ])
+
+      const result = await storeWith(localStore).dispatch(loadEarnCatalogThunk()).unwrap()
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value.claimedRewardIds).toEqual([rewardMocks.movieNight.id])
+      }
+    },
+  )
 })
 
 describe('addRewardThunk', () => {

--- a/packages/app/src/features/earn/__tests__/EarnRewardsStorage.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnRewardsStorage.test.ts
@@ -35,6 +35,57 @@ describe('readRewardsCatalog / writeRewardsCatalog', () => {
     writeRewardsCatalog(store, [rewardMocks.plain])
     expect(readRewardsCatalog(store)).toEqual([rewardMocks.plain])
   })
+
+  it('skips a row whose pointsRequired overflows to a non-finite number', () => {
+    // `1e400` is a syntactically valid JSON number that overflows to
+    // `Infinity` on parse — the one way a non-finite value can genuinely
+    // arrive through `JSON.parse` rather than `JSON.stringify` (which would
+    // have already turned a real `NaN`/`Infinity` into `null`).
+    const store = makeInMemoryKeyValueStore({
+      'kro:earn.rewards.catalog':
+        '[{"id":"r1","title":"x","glyph":"🎁","pointsRequired":1e400,"notes":null,"dateAddedEpochMillis":1000}]',
+    })
+    expect(readRewardsCatalog(store)).toEqual([])
+  })
+
+  it('skips a row with a negative pointsRequired', () => {
+    const store = makeInMemoryKeyValueStore({
+      'kro:earn.rewards.catalog':
+        '[{"id":"r1","title":"x","glyph":"🎁","pointsRequired":-50,"notes":null,"dateAddedEpochMillis":1000}]',
+    })
+    expect(readRewardsCatalog(store)).toEqual([])
+  })
+
+  it('skips a row whose dateAddedEpochMillis overflows to a non-finite number', () => {
+    const store = makeInMemoryKeyValueStore({
+      'kro:earn.rewards.catalog':
+        '[{"id":"r1","title":"x","glyph":"🎁","pointsRequired":100,"notes":null,"dateAddedEpochMillis":1e400}]',
+    })
+    expect(readRewardsCatalog(store)).toEqual([])
+  })
+
+  it('skips a row whose notes is neither a string nor null', () => {
+    const store = makeInMemoryKeyValueStore({
+      'kro:earn.rewards.catalog':
+        '[{"id":"r1","title":"x","glyph":"🎁","pointsRequired":100,"notes":42,"dateAddedEpochMillis":1000}]',
+    })
+    expect(readRewardsCatalog(store)).toEqual([])
+  })
+
+  it('keeps every well-formed row alongside one malformed one, rather than blanking the whole catalog', () => {
+    const good = JSON.stringify({
+      id: rewardMocks.bobaTea.id,
+      title: rewardMocks.bobaTea.title,
+      glyph: rewardMocks.bobaTea.glyph,
+      pointsRequired: rewardMocks.bobaTea.pointsRequired,
+      notes: rewardMocks.bobaTea.notes,
+      dateAddedEpochMillis: rewardMocks.bobaTea.dateAdded.getTime(),
+    })
+    const store = makeInMemoryKeyValueStore({
+      'kro:earn.rewards.catalog': `[${good},{"id":"bad","pointsRequired":-1}]`,
+    })
+    expect(readRewardsCatalog(store)).toEqual([rewardMocks.bobaTea])
+  })
 })
 
 describe('readClaimedRewardIds / writeClaimedRewardIds', () => {

--- a/packages/app/src/features/earn/__tests__/EarnRewardsStorage.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnRewardsStorage.test.ts
@@ -1,0 +1,60 @@
+import { makeInMemoryKeyValueStore, rewardMocks } from '@kro/core/mocks'
+import { describe, expect, it } from 'vitest'
+import {
+  readClaimedRewardIds,
+  readRewardsCatalog,
+  writeClaimedRewardIds,
+  writeRewardsCatalog,
+} from '../EarnRewardsStorage'
+
+describe('readRewardsCatalog / writeRewardsCatalog', () => {
+  it('round-trips a catalog exactly', () => {
+    const store = makeInMemoryKeyValueStore()
+    writeRewardsCatalog(store, [rewardMocks.bobaTea, rewardMocks.movieNight])
+    expect(readRewardsCatalog(store)).toEqual([rewardMocks.bobaTea, rewardMocks.movieNight])
+  })
+
+  it('reads an unset key as an empty catalog, never a throw', () => {
+    expect(readRewardsCatalog(makeInMemoryKeyValueStore())).toEqual([])
+  })
+
+  it('treats a corrupt value as empty rather than fatal', () => {
+    const store = makeInMemoryKeyValueStore({ 'kro:earn.rewards.catalog': 'not json' })
+    expect(readRewardsCatalog(store)).toEqual([])
+  })
+
+  it('writes under the `kro:` namespace, so sign-out sweeps it', () => {
+    const store = makeInMemoryKeyValueStore()
+    writeRewardsCatalog(store, [rewardMocks.bobaTea])
+    expect(store.keys().every((key) => key.startsWith('kro:'))).toBe(true)
+  })
+
+  it('replaces the whole array on a second write (canon: whole-catalog semantics)', () => {
+    const store = makeInMemoryKeyValueStore()
+    writeRewardsCatalog(store, [rewardMocks.bobaTea, rewardMocks.movieNight])
+    writeRewardsCatalog(store, [rewardMocks.plain])
+    expect(readRewardsCatalog(store)).toEqual([rewardMocks.plain])
+  })
+})
+
+describe('readClaimedRewardIds / writeClaimedRewardIds', () => {
+  it('round-trips a claimed set exactly', () => {
+    const store = makeInMemoryKeyValueStore()
+    writeClaimedRewardIds(store, [rewardMocks.bobaTea.id, rewardMocks.movieNight.id])
+    expect(readClaimedRewardIds(store)).toEqual([
+      rewardMocks.bobaTea.id,
+      rewardMocks.movieNight.id,
+    ])
+  })
+
+  it('reads an unset key as an empty set', () => {
+    expect(readClaimedRewardIds(makeInMemoryKeyValueStore())).toEqual([])
+  })
+
+  it('drops a non-string entry rather than throwing on a malformed row', () => {
+    const store = makeInMemoryKeyValueStore({
+      'kro:earn.rewards.claimed': JSON.stringify(['ok-id', 42, null]),
+    })
+    expect(readClaimedRewardIds(store)).toEqual(['ok-id'])
+  })
+})

--- a/packages/app/src/features/earn/__tests__/EarnRules.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnRules.test.ts
@@ -1,0 +1,193 @@
+import { PerformResolution, makePerform } from '@kro/core'
+import { rewardMocks } from '@kro/core/mocks'
+import { describe, expect, it } from 'vitest'
+import {
+  availableSuggestions,
+  claimProgress,
+  currentPoints,
+  isCatalogEmpty,
+  partitionRewards,
+  pointsToGo,
+  spentPoints,
+  totalEarnedPoints,
+} from '../EarnRules'
+
+const perform = (rewardPoints: number) =>
+  makePerform({
+    date: new Date(2026, 2, 17, 9, 0, 0),
+    duration: 1500,
+    resolution: PerformResolution.finished,
+    rewardPoints,
+  })
+
+describe('totalEarnedPoints', () => {
+  it('is zero with no recorded performances', () => {
+    expect(totalEarnedPoints([])).toBe(0)
+  })
+
+  it('sums every performance — never a per-endeavor estimate (canon divergence)', () => {
+    expect(totalEarnedPoints([perform(30), perform(20)])).toBe(50)
+  })
+
+  it('counts a zero-point performance as zero, not as absent', () => {
+    expect(totalEarnedPoints([perform(0), perform(40)])).toBe(40)
+  })
+})
+
+describe('spentPoints', () => {
+  it('is zero with no claims', () => {
+    expect(spentPoints([rewardMocks.bobaTea], [])).toBe(0)
+  })
+
+  it('sums only claimed rewards still in the catalog', () => {
+    expect(
+      spentPoints(
+        [rewardMocks.bobaTea, rewardMocks.movieNight],
+        [rewardMocks.bobaTea.id],
+      ),
+    ).toBe(rewardMocks.bobaTea.pointsRequired)
+  })
+
+  it('drops a claimed id once its reward is deleted from the catalog (refund-on-delete)', () => {
+    expect(
+      spentPoints([rewardMocks.movieNight], [rewardMocks.bobaTea.id]),
+    ).toBe(0)
+  })
+})
+
+describe('currentPoints', () => {
+  it('is zero with nothing earned and nothing spent', () => {
+    expect(currentPoints([], [], [])).toBe(0)
+  })
+
+  it('is earned minus spent', () => {
+    expect(
+      currentPoints([perform(200)], [rewardMocks.bobaTea], [rewardMocks.bobaTea.id]),
+    ).toBe(200 - rewardMocks.bobaTea.pointsRequired)
+  })
+
+  it('never goes negative when spent exceeds earned', () => {
+    expect(
+      currentPoints([perform(10)], [rewardMocks.weekendTrip], [rewardMocks.weekendTrip.id]),
+    ).toBe(0)
+  })
+})
+
+describe('pointsToGo', () => {
+  it('is the full cost when nothing has been earned', () => {
+    expect(pointsToGo(rewardMocks.bobaTea, 0)).toBe(rewardMocks.bobaTea.pointsRequired)
+  })
+
+  it('is zero once affordable', () => {
+    expect(pointsToGo(rewardMocks.bobaTea, rewardMocks.bobaTea.pointsRequired)).toBe(0)
+  })
+
+  it('never goes negative once overfunded', () => {
+    expect(pointsToGo(rewardMocks.bobaTea, rewardMocks.bobaTea.pointsRequired + 500)).toBe(0)
+  })
+})
+
+describe('claimProgress', () => {
+  it('is 0 at zero points against a positive cost', () => {
+    expect(claimProgress(rewardMocks.bobaTea, 0)).toBe(0)
+  })
+
+  it('is 1 once the cost is met exactly', () => {
+    expect(claimProgress(rewardMocks.bobaTea, rewardMocks.bobaTea.pointsRequired)).toBe(1)
+  })
+
+  it('caps at 1 rather than reporting over 100%', () => {
+    expect(claimProgress(rewardMocks.bobaTea, rewardMocks.bobaTea.pointsRequired * 10)).toBe(1)
+  })
+
+  it('is always 1 for a free reward — division-by-zero guard (canon: `pointsRequired > 0 else return 1`)', () => {
+    expect(claimProgress(rewardMocks.free, 0)).toBe(1)
+  })
+})
+
+describe('partitionRewards', () => {
+  it('is empty on both sides with no catalog', () => {
+    const partition = partitionRewards([], [], 0)
+    expect(partition.claimable).toEqual([])
+    expect(partition.locked).toEqual([])
+  })
+
+  it('splits by affordability against the given balance', () => {
+    const partition = partitionRewards(
+      [rewardMocks.bobaTea, rewardMocks.weekendTrip],
+      [],
+      rewardMocks.bobaTea.pointsRequired,
+    )
+    expect(partition.claimable.map((r) => r.id)).toEqual([rewardMocks.bobaTea.id])
+    expect(partition.locked.map((r) => r.id)).toEqual([rewardMocks.weekendTrip.id])
+  })
+
+  it('excludes an already-claimed reward from both lanes', () => {
+    const partition = partitionRewards(
+      [rewardMocks.bobaTea],
+      [rewardMocks.bobaTea.id],
+      10_000,
+    )
+    expect(partition.claimable).toEqual([])
+    expect(partition.locked).toEqual([])
+  })
+
+  it('sorts claimable most-expensive first (canon order)', () => {
+    const partition = partitionRewards(
+      [rewardMocks.bobaTea, rewardMocks.movieNight],
+      [],
+      10_000,
+    )
+    expect(partition.claimable.map((r) => r.id)).toEqual([
+      rewardMocks.movieNight.id,
+      rewardMocks.bobaTea.id,
+    ])
+  })
+
+  it('sorts locked cheapest first (canon order)', () => {
+    const partition = partitionRewards(
+      [rewardMocks.weekendTrip, rewardMocks.movieNight],
+      [],
+      0,
+    )
+    expect(partition.locked.map((r) => r.id)).toEqual([
+      rewardMocks.movieNight.id,
+      rewardMocks.weekendTrip.id,
+    ])
+  })
+})
+
+describe('availableSuggestions', () => {
+  it('returns the whole starter catalog when the user catalog is empty', () => {
+    expect(availableSuggestions([]).length).toBeGreaterThan(0)
+  })
+
+  it('filters out a suggestion already in the catalog, by title', () => {
+    const suggestions = availableSuggestions([rewardMocks.bobaTea])
+    expect(suggestions.some((s) => s.title === rewardMocks.bobaTea.title)).toBe(false)
+  })
+
+  it('matches titles case-insensitively', () => {
+    const shouted = { ...rewardMocks.bobaTea, title: rewardMocks.bobaTea.title.toUpperCase() }
+    const suggestions = availableSuggestions([shouted])
+    expect(suggestions.some((s) => s.title.toLowerCase() === rewardMocks.bobaTea.title.toLowerCase())).toBe(false)
+  })
+})
+
+describe('isCatalogEmpty', () => {
+  it('is false before the first load has run', () => {
+    expect(isCatalogEmpty('idle', [])).toBe(false)
+  })
+
+  it('is false while a load is in flight', () => {
+    expect(isCatalogEmpty('loading', [])).toBe(false)
+  })
+
+  it('is true once loaded with nothing in it', () => {
+    expect(isCatalogEmpty('loaded', [])).toBe(true)
+  })
+
+  it('is false once loaded with rewards present', () => {
+    expect(isCatalogEmpty('loaded', [rewardMocks.bobaTea])).toBe(false)
+  })
+})

--- a/packages/app/src/features/earn/__tests__/EarnRules.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnRules.test.ts
@@ -190,4 +190,12 @@ describe('isCatalogEmpty', () => {
   it('is false once loaded with rewards present', () => {
     expect(isCatalogEmpty('loaded', [rewardMocks.bobaTea])).toBe(false)
   })
+
+  it(
+    'is false on a failed load — never claims "empty" for a read that never ' +
+      'succeeded (a preferences-load failure before the first catalog fetch)',
+    () => {
+      expect(isCatalogEmpty('failed', [])).toBe(false)
+    },
+  )
 })

--- a/packages/app/src/features/earn/__tests__/EarnSelectors.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnSelectors.test.ts
@@ -19,6 +19,7 @@ import { initialFindState } from '../../find/FindState'
 import { initialGreetingState } from '../../greeting/GreetingFeature'
 import type { RootState } from '../../../library/store'
 import { initialPlanState } from '../../plan/PlanState'
+import { initialTriageState } from '../../triage/TriageFeature'
 import { type EarnState, initialEarnState } from '../EarnFeature'
 import { earnStateMocks } from '../EarnMocks'
 import {
@@ -42,9 +43,10 @@ import {
 const rootWith = (earn: EarnState): RootState => ({
   greeting: initialGreetingState,
   // Present only because `RootState` names every registered slice; this suite
-  // asserts nothing about Do, Capture, Plan, Find or Detail.
+  // asserts nothing about Do, Capture, Triage, Plan, Find or Detail.
   do: initialDoState,
   capture: initialCaptureState,
+  triage: initialTriageState,
   plan: initialPlanState,
   find: initialFindState,
   endeavorDetail: initialEndeavorDetailState,

--- a/packages/app/src/features/earn/__tests__/EarnSelectors.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnSelectors.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Selectors run against a hand-built root state, never a live store (`RC-55`).
+ * The other registered slices are filled from their own initial states only
+ * because `RootState` names every one of them.
+ *
+ * The `selectCurrentPoints` property suite proves the acceptance criterion
+ * directly: "current-points balance derived purely from performances' reward
+ * points minus claimed (no shadow counters)". It never trusts a running total
+ * — it replays the exact same operation sequence against a plain reference
+ * implementation and checks the two never disagree, after *every* step.
+ */
+import { PerformResolution, makePerform } from '@kro/core'
+import { rewardMocks } from '@kro/core/mocks'
+import { describe, expect, it } from 'vitest'
+import { initialCaptureState } from '../../capture/CaptureFeature'
+import { initialDoState } from '../../do/DoFeature'
+import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
+import { initialFindState } from '../../find/FindState'
+import { initialGreetingState } from '../../greeting/GreetingFeature'
+import type { RootState } from '../../../library/store'
+import { initialPlanState } from '../../plan/PlanState'
+import { type EarnState, initialEarnState } from '../EarnFeature'
+import { earnStateMocks } from '../EarnMocks'
+import {
+  selectAddRewardDraft,
+  selectAvailableSuggestions,
+  selectClaimableRewards,
+  selectClaimingReward,
+  selectClaimingRewardId,
+  selectCurrentPoints,
+  selectDefaultRewardThreshold,
+  selectEarnException,
+  selectIsAddingReward,
+  selectIsEarnCatalogEmpty,
+  selectIsEarnLoading,
+  selectLockedRewards,
+  selectPointsFormula,
+  selectSpentPoints,
+  selectTotalEarnedPoints,
+} from '../EarnSelectors'
+
+const rootWith = (earn: EarnState): RootState => ({
+  greeting: initialGreetingState,
+  // Present only because `RootState` names every registered slice; this suite
+  // asserts nothing about Do, Capture, Plan, Find or Detail.
+  do: initialDoState,
+  capture: initialCaptureState,
+  plan: initialPlanState,
+  find: initialFindState,
+  endeavorDetail: initialEndeavorDetailState,
+  earn,
+})
+
+const loaded = earnStateMocks.loadedTypical
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+describe('selectIsEarnLoading', () => {
+  it('is true while a read is in flight', () => {
+    expect(selectIsEarnLoading(rootWith(earnStateMocks.loading))).toBe(true)
+  })
+
+  it('is false once loaded', () => {
+    expect(selectIsEarnLoading(rootWith(loaded))).toBe(false)
+  })
+
+  it('is false before the first load', () => {
+    expect(selectIsEarnLoading(rootWith(earnStateMocks.idle))).toBe(false)
+  })
+})
+
+describe('selectEarnException', () => {
+  it('is null on a loaded state', () => {
+    expect(selectEarnException(rootWith(loaded))).toBeNull()
+  })
+
+  it('surfaces the exception on a failed state', () => {
+    expect(
+      selectEarnException(rootWith(earnStateMocks.failedRefreshKeepingCatalog))?.kind,
+    ).toBe('catalogLoadFailed')
+  })
+
+  it('is null while loading', () => {
+    expect(selectEarnException(rootWith(earnStateMocks.loading))).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Balance
+// ---------------------------------------------------------------------------
+
+describe('selectTotalEarnedPoints / selectSpentPoints / selectCurrentPoints', () => {
+  it('sums the fixture performances (130) with nothing claimed', () => {
+    expect(selectTotalEarnedPoints(rootWith(loaded))).toBe(130)
+    expect(selectSpentPoints(rootWith(loaded))).toBe(0)
+    expect(selectCurrentPoints(rootWith(loaded))).toBe(130)
+  })
+
+  it('deducts the claimed reward from the balance', () => {
+    const claiming = rootWith(earnStateMocks.loadedWithClaim)
+    expect(selectSpentPoints(claiming)).toBe(rewardMocks.bobaTea.pointsRequired)
+    expect(selectCurrentPoints(claiming)).toBe(130 - rewardMocks.bobaTea.pointsRequired)
+  })
+
+  it('is zero on an empty catalog and no performances', () => {
+    expect(selectCurrentPoints(rootWith(earnStateMocks.loadedEmpty))).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Partition
+// ---------------------------------------------------------------------------
+
+describe('selectClaimableRewards / selectLockedRewards', () => {
+  it('places the affordable reward in claimable', () => {
+    expect(selectClaimableRewards(rootWith(loaded)).map((r) => r.id)).toContain(
+      rewardMocks.bobaTea.id,
+    )
+  })
+
+  it('places the unaffordable rewards in locked', () => {
+    const locked = selectLockedRewards(rootWith(loaded)).map((r) => r.id)
+    expect(locked).toContain(rewardMocks.plain.id)
+    expect(locked).toContain(rewardMocks.weekendTrip.id)
+  })
+
+  it('excludes a claimed reward from both lanes', () => {
+    const claiming = rootWith(earnStateMocks.loadedWithClaim)
+    const ids = [
+      ...selectClaimableRewards(claiming).map((r) => r.id),
+      ...selectLockedRewards(claiming).map((r) => r.id),
+    ]
+    expect(ids).not.toContain(rewardMocks.bobaTea.id)
+  })
+})
+
+describe('selectAvailableSuggestions / selectIsEarnCatalogEmpty', () => {
+  it('excludes suggestions already in the catalog', () => {
+    const suggestions = selectAvailableSuggestions(rootWith(loaded))
+    expect(suggestions.some((s) => s.title === rewardMocks.bobaTea.title)).toBe(false)
+  })
+
+  it('reports the catalog non-empty when loaded with rewards', () => {
+    expect(selectIsEarnCatalogEmpty(rootWith(loaded))).toBe(false)
+  })
+
+  it('reports the catalog empty once loaded with nothing in it', () => {
+    expect(selectIsEarnCatalogEmpty(rootWith(earnStateMocks.loadedEmpty))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Preferences
+// ---------------------------------------------------------------------------
+
+describe('selectDefaultRewardThreshold / selectPointsFormula', () => {
+  it('reads the default threshold (100 before any load)', () => {
+    expect(selectDefaultRewardThreshold(rootWith(initialEarnState))).toBe(100)
+  })
+
+  it('reads the loaded threshold once preferences apply', () => {
+    const withPrefs: EarnState = {
+      ...loaded,
+      preferences: { defaultRewardThreshold: 250, pointsFormula: 'legacy' },
+    }
+    expect(selectDefaultRewardThreshold(rootWith(withPrefs))).toBe(250)
+    expect(selectPointsFormula(rootWith(withPrefs))).toBe('legacy')
+  })
+
+  it('defaults the formula to the sliding scale before any load', () => {
+    expect(selectPointsFormula(rootWith(initialEarnState))).toBe('slidingScale')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Add Reward sheet + claim flow
+// ---------------------------------------------------------------------------
+
+describe('selectIsAddingReward / selectAddRewardDraft', () => {
+  it('is false before the sheet opens', () => {
+    expect(selectIsAddingReward(rootWith(loaded))).toBe(false)
+  })
+
+  it('is true once the sheet opens', () => {
+    expect(selectIsAddingReward(rootWith(earnStateMocks.addingReward))).toBe(true)
+  })
+
+  it('reflects the draft prefilled from the default threshold', () => {
+    expect(selectAddRewardDraft(rootWith(earnStateMocks.addingReward)).pointsRequired).toBe(100)
+  })
+})
+
+describe('selectClaimingRewardId / selectClaimingReward', () => {
+  it('is null with no confirm sheet open', () => {
+    expect(selectClaimingRewardId(rootWith(loaded))).toBeNull()
+    expect(selectClaimingReward(rootWith(loaded))).toBeNull()
+  })
+
+  it('resolves the id once the confirm sheet opens', () => {
+    expect(selectClaimingRewardId(rootWith(earnStateMocks.claimingReward))).toBe(
+      rewardMocks.bobaTea.id,
+    )
+  })
+
+  it('resolves the full reward from the catalog', () => {
+    expect(selectClaimingReward(rootWith(earnStateMocks.claimingReward))?.id).toBe(
+      rewardMocks.bobaTea.id,
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The balance property: no shadow counters (acceptance criterion 2)
+// ---------------------------------------------------------------------------
+
+/**
+ * A tiny deterministic PRNG (mulberry32) — no new dependency, and a fixed
+ * seed makes a failing run reproducible without recording the sequence.
+ */
+const mulberry32 = (seed: number) => {
+  let a = seed
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const catalog = [rewardMocks.bobaTea, rewardMocks.movieNight, rewardMocks.weekendTrip, rewardMocks.plain]
+
+type Operation =
+  | { readonly kind: 'earn'; readonly points: number }
+  | { readonly kind: 'claim'; readonly rewardIndex: number }
+
+const randomOperation = (rng: () => number): Operation =>
+  rng() < 0.5
+    ? { kind: 'earn', points: Math.floor(rng() * 200) }
+    : { kind: 'claim', rewardIndex: Math.floor(rng() * catalog.length) }
+
+describe('selectCurrentPoints — property: matches earned-minus-claimed for any sequence', () => {
+  it('holds after every step of 30 random sequences of 20 operations each', () => {
+    const rng = mulberry32(20260317)
+
+    for (let sequence = 0; sequence < 30; sequence += 1) {
+      let performances: ReturnType<typeof makePerform>[] = []
+      let claimedRewardIds: string[] = []
+      let expectedTotal = 0
+
+      for (let step = 0; step < 20; step += 1) {
+        const operation = randomOperation(rng)
+        if (operation.kind === 'earn') {
+          performances = [
+            ...performances,
+            makePerform({
+              date: new Date(2026, 2, 17),
+              duration: 900,
+              resolution: PerformResolution.finished,
+              rewardPoints: operation.points,
+            }),
+          ]
+          expectedTotal += operation.points
+        } else {
+          const reward = catalog[operation.rewardIndex]
+          if (reward !== undefined && !claimedRewardIds.includes(reward.id)) {
+            claimedRewardIds = [...claimedRewardIds, reward.id]
+          }
+        }
+
+        const expectedSpent = catalog
+          .filter((reward) => claimedRewardIds.includes(reward.id))
+          .reduce((sum, reward) => sum + reward.pointsRequired, 0)
+        const expectedBalance = Math.max(0, expectedTotal - expectedSpent)
+
+        const state: EarnState = {
+          ...initialEarnState,
+          load: { kind: 'loaded' },
+          rewards: catalog,
+          claimedRewardIds,
+          performances,
+        }
+
+        expect(selectCurrentPoints(rootWith(state))).toBe(expectedBalance)
+      }
+    }
+  })
+})

--- a/packages/app/src/features/earn/__tests__/EarnShifters.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnShifters.test.ts
@@ -1,0 +1,296 @@
+import { rewardMocks } from '@kro/core/mocks'
+import { describe, expect, it } from 'vitest'
+import { EarnExceptions } from '../EarnException'
+import { initialEarnState } from '../EarnFeature'
+import {
+  withCatalogInstalled,
+  withCatalogLoadStarted,
+  withClaimApplied,
+  withClaimCancelled,
+  withClaimRequested,
+  withDraftGlyphChanged,
+  withDraftNotesChanged,
+  withDraftPointsChanged,
+  withDraftTitleChanged,
+  withException,
+  withPreferencesApplied,
+  withRewardAdded,
+  withRewardDraftClosed,
+  withRewardDraftOpened,
+  withRewardRemoved,
+} from '../EarnShifters'
+
+const snapshot = {
+  rewards: [rewardMocks.bobaTea],
+  claimedRewardIds: [],
+  performances: [],
+}
+
+describe('withCatalogLoadStarted', () => {
+  it('moves load to loading', () => {
+    expect(withCatalogLoadStarted(initialEarnState).load).toEqual({ kind: 'loading' })
+  })
+
+  it('leaves the retained catalog untouched (typical)', () => {
+    const loaded = withCatalogInstalled(initialEarnState, snapshot)
+    expect(withCatalogLoadStarted(loaded).rewards).toBe(loaded.rewards)
+  })
+
+  it('is a no-op on an already-idle state beyond the load field (boundary)', () => {
+    const next = withCatalogLoadStarted(initialEarnState)
+    expect(next.rewards).toEqual([])
+  })
+})
+
+describe('withCatalogInstalled', () => {
+  it('installs rewards, claimed ids and performances together', () => {
+    const next = withCatalogInstalled(initialEarnState, snapshot)
+    expect(next.load).toEqual({ kind: 'loaded' })
+    expect(next.rewards).toBe(snapshot.rewards)
+  })
+
+  it('installs an empty catalog as loaded, not idle (boundary)', () => {
+    const next = withCatalogInstalled(initialEarnState, {
+      rewards: [],
+      claimedRewardIds: [],
+      performances: [],
+    })
+    expect(next.load.kind).toBe('loaded')
+    expect(next.rewards).toEqual([])
+  })
+
+  it('replaces a previously failed load (typical retry)', () => {
+    const failed = withException(initialEarnState, EarnExceptions.catalogLoadFailed('x'))
+    const next = withCatalogInstalled(failed, snapshot)
+    expect(next.load).toEqual({ kind: 'loaded' })
+  })
+})
+
+describe('withPreferencesApplied', () => {
+  it('replaces the preferences object', () => {
+    const next = withPreferencesApplied(initialEarnState, {
+      defaultRewardThreshold: 250,
+      pointsFormula: 'legacy',
+    })
+    expect(next.preferences.defaultRewardThreshold).toBe(250)
+  })
+
+  it('leaves the catalog untouched', () => {
+    const loaded = withCatalogInstalled(initialEarnState, snapshot)
+    const next = withPreferencesApplied(loaded, {
+      defaultRewardThreshold: 1,
+      pointsFormula: 'slidingScale',
+    })
+    expect(next.rewards).toBe(loaded.rewards)
+  })
+
+  it('does not touch load (boundary: independent from the catalog read)', () => {
+    const next = withPreferencesApplied(initialEarnState, {
+      defaultRewardThreshold: 100,
+      pointsFormula: 'slidingScale',
+    })
+    expect(next.load).toEqual({ kind: 'idle' })
+  })
+})
+
+describe('withException', () => {
+  it('moves load to failed with the given exception', () => {
+    const exception = EarnExceptions.catalogLoadFailed('offline')
+    expect(withException(initialEarnState, exception).load).toEqual({
+      kind: 'failed',
+      exception,
+    })
+  })
+
+  it('leaves the catalog untouched on a loaded state (atomicity)', () => {
+    const loaded = withCatalogInstalled(initialEarnState, snapshot)
+    const next = withException(loaded, EarnExceptions.claimRewardFailed('x'))
+    expect(next.rewards).toBe(loaded.rewards)
+    expect(next.claimedRewardIds).toBe(loaded.claimedRewardIds)
+  })
+
+  it('leaves claimingRewardId untouched, so a failed claim can be retried', () => {
+    const claiming = withClaimRequested(
+      withCatalogInstalled(initialEarnState, snapshot),
+      rewardMocks.bobaTea.id,
+    )
+    const next = withException(claiming, EarnExceptions.claimRewardFailed('x'))
+    expect(next.claimingRewardId).toBe(rewardMocks.bobaTea.id)
+  })
+})
+
+describe('withRewardDraftOpened', () => {
+  it('opens the sheet', () => {
+    expect(withRewardDraftOpened(initialEarnState).isAddingReward).toBe(true)
+  })
+
+  it('prefills the cost from the loaded default-threshold preference', () => {
+    const withPrefs = withPreferencesApplied(initialEarnState, {
+      defaultRewardThreshold: 250,
+      pointsFormula: 'slidingScale',
+    })
+    expect(withRewardDraftOpened(withPrefs).addRewardDraft.pointsRequired).toBe(250)
+  })
+
+  it('resets a stale draft rather than reusing it (boundary)', () => {
+    const dirty = withDraftTitleChanged(initialEarnState, 'stale title')
+    expect(withRewardDraftOpened(dirty).addRewardDraft.title).toBe('')
+  })
+})
+
+describe('withRewardDraftClosed', () => {
+  it('closes the sheet', () => {
+    const open = withRewardDraftOpened(initialEarnState)
+    expect(withRewardDraftClosed(open).isAddingReward).toBe(false)
+  })
+
+  it('resets the draft to blank', () => {
+    const dirty = withDraftTitleChanged(withRewardDraftOpened(initialEarnState), 'x')
+    expect(withRewardDraftClosed(dirty).addRewardDraft.title).toBe('')
+  })
+
+  it('is a no-op shape on an already-closed state (boundary)', () => {
+    expect(withRewardDraftClosed(initialEarnState).isAddingReward).toBe(false)
+  })
+})
+
+describe('withDraftTitleChanged', () => {
+  it('sets the title', () => {
+    expect(withDraftTitleChanged(initialEarnState, 'Movie Night').addRewardDraft.title).toBe(
+      'Movie Night',
+    )
+  })
+
+  it('accepts an empty string (validated later, at confirm)', () => {
+    expect(withDraftTitleChanged(initialEarnState, '').addRewardDraft.title).toBe('')
+  })
+
+  it('leaves other draft fields untouched', () => {
+    const withPoints = withDraftPointsChanged(initialEarnState, 300)
+    expect(withDraftTitleChanged(withPoints, 'x').addRewardDraft.pointsRequired).toBe(300)
+  })
+})
+
+describe('withDraftGlyphChanged', () => {
+  it('sets a short glyph as-is', () => {
+    expect(withDraftGlyphChanged(initialEarnState, '🎮').addRewardDraft.glyph).toBe('🎮')
+  })
+
+  it('truncates to two code points (canon: `String(glyph.prefix(2))`)', () => {
+    expect(withDraftGlyphChanged(initialEarnState, 'abc').addRewardDraft.glyph).toBe('ab')
+  })
+
+  it('accepts an empty glyph — the producer substitutes the default at confirm (boundary)', () => {
+    expect(withDraftGlyphChanged(initialEarnState, '').addRewardDraft.glyph).toBe('')
+  })
+})
+
+describe('withDraftPointsChanged', () => {
+  it('sets a positive value', () => {
+    expect(withDraftPointsChanged(initialEarnState, 500).addRewardDraft.pointsRequired).toBe(500)
+  })
+
+  it('clamps a negative value to zero (canon: `max(0, points)`)', () => {
+    expect(withDraftPointsChanged(initialEarnState, -50).addRewardDraft.pointsRequired).toBe(0)
+  })
+
+  it('accepts exactly zero (boundary)', () => {
+    expect(withDraftPointsChanged(initialEarnState, 0).addRewardDraft.pointsRequired).toBe(0)
+  })
+})
+
+describe('withDraftNotesChanged', () => {
+  it('sets non-empty notes', () => {
+    expect(withDraftNotesChanged(initialEarnState, 'save up').addRewardDraft.notes).toBe(
+      'save up',
+    )
+  })
+
+  it('maps an empty string to null (canon: `notes.isEmpty ? nil : notes`)', () => {
+    expect(withDraftNotesChanged(initialEarnState, '').addRewardDraft.notes).toBeNull()
+  })
+
+  it('clears previously set notes back to null', () => {
+    const withNotes = withDraftNotesChanged(initialEarnState, 'x')
+    expect(withDraftNotesChanged(withNotes, '').addRewardDraft.notes).toBeNull()
+  })
+})
+
+describe('withRewardAdded', () => {
+  it('prepends the reward — canon: `insert(_, at: 0)`', () => {
+    const withOne = withCatalogInstalled(initialEarnState, snapshot)
+    const next = withRewardAdded(withOne, rewardMocks.movieNight)
+    expect(next.rewards[0]?.id).toBe(rewardMocks.movieNight.id)
+    expect(next.rewards).toHaveLength(2)
+  })
+
+  it('closes the Add-Reward sheet and resets the draft', () => {
+    const open = withRewardDraftOpened(initialEarnState)
+    const next = withRewardAdded(open, rewardMocks.bobaTea)
+    expect(next.isAddingReward).toBe(false)
+    expect(next.addRewardDraft.title).toBe('')
+  })
+
+  it('is harmless when the sheet was never open — the suggestion path (boundary)', () => {
+    const next = withRewardAdded(initialEarnState, rewardMocks.bobaTea)
+    expect(next.isAddingReward).toBe(false)
+    expect(next.rewards).toEqual([rewardMocks.bobaTea])
+  })
+})
+
+describe('withRewardRemoved', () => {
+  it('removes the matching reward', () => {
+    const withOne = withCatalogInstalled(initialEarnState, snapshot)
+    expect(withRewardRemoved(withOne, rewardMocks.bobaTea.id).rewards).toEqual([])
+  })
+
+  it('is a no-op for an id not in the catalog', () => {
+    const withOne = withCatalogInstalled(initialEarnState, snapshot)
+    expect(withRewardRemoved(withOne, 'ghost').rewards).toEqual(snapshot.rewards)
+  })
+
+  it('empties the last reward without error (boundary)', () => {
+    const withOne = withCatalogInstalled(initialEarnState, {
+      ...snapshot,
+      rewards: [rewardMocks.bobaTea],
+    })
+    expect(withRewardRemoved(withOne, rewardMocks.bobaTea.id).rewards).toHaveLength(0)
+  })
+})
+
+describe('withClaimRequested / withClaimCancelled', () => {
+  it('opens the confirm sheet on the given id', () => {
+    expect(withClaimRequested(initialEarnState, rewardMocks.bobaTea.id).claimingRewardId).toBe(
+      rewardMocks.bobaTea.id,
+    )
+  })
+
+  it('cancel clears the confirm sheet', () => {
+    const requested = withClaimRequested(initialEarnState, rewardMocks.bobaTea.id)
+    expect(withClaimCancelled(requested).claimingRewardId).toBeNull()
+  })
+
+  it('re-requesting a different id replaces the pointer (boundary)', () => {
+    const first = withClaimRequested(initialEarnState, rewardMocks.bobaTea.id)
+    const second = withClaimRequested(first, rewardMocks.movieNight.id)
+    expect(second.claimingRewardId).toBe(rewardMocks.movieNight.id)
+  })
+})
+
+describe('withClaimApplied', () => {
+  it('adds the id to the claimed set', () => {
+    const next = withClaimApplied(initialEarnState, rewardMocks.bobaTea.id)
+    expect(next.claimedRewardIds).toEqual([rewardMocks.bobaTea.id])
+  })
+
+  it('clears the confirm sheet', () => {
+    const requested = withClaimRequested(initialEarnState, rewardMocks.bobaTea.id)
+    expect(withClaimApplied(requested, rewardMocks.bobaTea.id).claimingRewardId).toBeNull()
+  })
+
+  it('is idempotent on an already-claimed id — canon: guard not already present', () => {
+    const once = withClaimApplied(initialEarnState, rewardMocks.bobaTea.id)
+    const twice = withClaimApplied(once, rewardMocks.bobaTea.id)
+    expect(twice.claimedRewardIds).toEqual([rewardMocks.bobaTea.id])
+  })
+})

--- a/packages/app/src/features/earn/index.ts
+++ b/packages/app/src/features/earn/index.ts
@@ -1,0 +1,15 @@
+/**
+ * The Earn feature's public surface — a pure re-export barrel.
+ *
+ * `#28` (Earn UI) imports from here rather than reaching into individual
+ * modules, so the boundary between the logic tier and the render tier is one
+ * line to read.
+ */
+export * from './EarnException'
+export * from './EarnFeature'
+export * from './EarnMocks'
+export * from './EarnProducer'
+export * from './EarnRewardsStorage'
+export * from './EarnRules'
+export * from './EarnSelectors'
+export * from './EarnShifters'

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailSelectors.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailSelectors.test.ts
@@ -7,6 +7,7 @@ import { EndeavorField, EndeavorHost, EndeavorRelation } from '@kro/core'
 import { describe, expect, it } from 'vitest'
 import { initialCaptureState } from '../../capture/CaptureFeature'
 import { initialDoState } from '../../do/DoFeature'
+import { initialEarnState } from '../../earn/EarnFeature'
 import { initialFindState } from '../../find/FindState'
 import { initialGreetingState } from '../../greeting/GreetingFeature'
 import type { RootState } from '../../../library/store'
@@ -57,6 +58,7 @@ const rootWith = (endeavorDetail: EndeavorDetailState): RootState => ({
   plan: initialPlanState,
   find: initialFindState,
   endeavorDetail,
+  earn: initialEarnState,
 })
 
 describe('presentation', () => {

--- a/packages/app/src/features/find/__tests__/FindSelectors.test.ts
+++ b/packages/app/src/features/find/__tests__/FindSelectors.test.ts
@@ -12,6 +12,7 @@ import { EndeavorKind, EndeavorStatus } from '@kro/core'
 import { describe, expect, it } from 'vitest'
 import { initialCaptureState } from '../../capture/CaptureFeature'
 import { initialDoState } from '../../do/DoFeature'
+import { initialEarnState } from '../../earn/EarnFeature'
 import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
 import { initialGreetingState } from '../../greeting/GreetingFeature'
 import type { RootState } from '../../../library/store'
@@ -60,6 +61,7 @@ const rootWith = (find: FindState): RootState => ({
   plan: initialPlanState,
   find,
   endeavorDetail: initialEndeavorDetailState,
+  earn: initialEarnState,
 })
 
 const loaded = rootWith(findStateMocks.loaded)

--- a/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
+++ b/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
@@ -2,6 +2,7 @@ import { greetingMocks } from '@kro/core/mocks'
 import { describe, expect, it } from 'vitest'
 import { initialCaptureState } from '../../capture/CaptureFeature'
 import { initialDoState } from '../../do/DoFeature'
+import { initialEarnState } from '../../earn/EarnFeature'
 import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
 import { initialFindState } from '../../find/FindState'
 import type { RootState } from '../../../library/store'
@@ -29,6 +30,7 @@ const rootWith = (greeting: GreetingState): RootState => ({
   capture: initialCaptureState,
   find: initialFindState,
   endeavorDetail: initialEndeavorDetailState,
+  earn: initialEarnState,
 })
 
 describe('selectGreeting', () => {

--- a/packages/app/src/features/plan/__tests__/PlanSelectors.test.ts
+++ b/packages/app/src/features/plan/__tests__/PlanSelectors.test.ts
@@ -13,6 +13,7 @@ import {
 import { describe, expect, it } from 'vitest'
 import { initialCaptureState } from '../../capture/CaptureFeature'
 import { initialDoState } from '../../do/DoFeature'
+import { initialEarnState } from '../../earn/EarnFeature'
 import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
 import { initialFindState } from '../../find/FindState'
 import { initialGreetingState } from '../../greeting/GreetingFeature'
@@ -65,6 +66,7 @@ const rootWith = (plan: PlanState): RootState => ({
   plan,
   find: initialFindState,
   endeavorDetail: initialEndeavorDetailState,
+  earn: initialEarnState,
 })
 
 describe('selectPlanViewMode and the FAB rules', () => {

--- a/packages/app/src/features/triage/__tests__/TriageSelectors.test.ts
+++ b/packages/app/src/features/triage/__tests__/TriageSelectors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { RootState } from '../../../library/store'
 import { initialCaptureState } from '../../capture/CaptureFeature'
 import { initialDoState } from '../../do/DoFeature'
+import { initialEarnState } from '../../earn/EarnFeature'
 import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
 import { initialFindState } from '../../find/FindState'
 import { greetingStateMocks } from '../../greeting/GreetingMocks'
@@ -65,6 +66,7 @@ const rootWith = (slice: TriageState): RootState => ({
   plan: initialPlanState,
   find: initialFindState,
   endeavorDetail: initialEndeavorDetailState,
+  earn: initialEarnState,
 })
 
 describe('lifecycle selectors', () => {

--- a/packages/app/src/library/store.ts
+++ b/packages/app/src/library/store.ts
@@ -18,6 +18,7 @@ import type { LocalStore } from '@kro/core'
 import { configureStore, isPlain } from '@reduxjs/toolkit'
 import { captureSlice } from '../features/capture/CaptureFeature'
 import { doSlice } from '../features/do/DoFeature'
+import { earnSlice } from '../features/earn/EarnFeature'
 import { endeavorDetailSlice } from '../features/endeavorDetail/EndeavorDetailFeature'
 import { findSlice } from '../features/find/FindFeature'
 import { greetingSlice } from '../features/greeting/GreetingFeature'
@@ -74,6 +75,7 @@ export const makeStore = (extra: ThunkExtra = liveThunkExtra) =>
       plan: planSlice.reducer,
       find: findSlice.reducer,
       endeavorDetail: endeavorDetailSlice.reducer,
+      earn: earnSlice.reducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({


### PR DESCRIPTION
> **Ichigo — Substitute** · Earn logic: rewards catalog partition, claim flow, suggestions, points balance
> local, on your creds · handbook `v0.5`

Closes #27

# What this changes for you

Kro Web's Earn tab now has its logic layer: a reward catalog you can add to, delete from and claim against, split into **Claimable** / **Locked** / **Suggestions**, with a points balance that is always derived — never cached — from your recorded focus-session performances minus what you've already spent. Nothing renders yet (#28 owns the UI); this is the store, the math and the persistence underneath it.

| | Before | After |
|---|---|---|
| Earn tab | Nothing — no slice registered | `earnSlice` registered in the store, ready for #28 |
| Reward catalog | N/A | Add (typed or from a suggestion), delete, list — persisted locally |
| Points balance | N/A | `sum(performance rewardPoints) − sum(claimed rewards' cost)`, floored at 0, recomputed on every read |
| Claiming a reward | N/A | Confirm → persist → apply, **atomically**: a failed write leaves the balance and the catalog exactly as they were |

```mermaid
flowchart TD
    A[User taps Claim] --> B[userDidTapClaim opens confirm sheet]
    B --> C[claimRewardThunk persists the id FIRST]
    C -->|write succeeds| D[reducer applies: claimed set updated, sheet closes]
    C -->|write fails| E[reducer applies: exception only, catalog and balance untouched]
    E --> F[confirm sheet stays open, user can retry]
```

## How this session found and used canon

- `zheref/KroApple@2c1ee45` (pinned in the epic; re-fetched at session start — `origin/main` had not moved).
- Ported from `Kro/Application/Earn/EarnFeature.swift` + `EarnProducer.swift` + `EarnSelectors.swift` + `EarnShifters.swift`, `KroUI/Earn/EarnView.swift`, `KroCore/Model/Reward.swift`, and `docs/Features/Performances.md` (points-formula preference section).

## The reward-storage discovery (stated up front, per the issue's ask)

**`KroDatabase` has no `RewardRecord`.** Grepping `Kro/Dependencies` and `KroCore` for `Reward`/`RewardsStore` turns up exactly one dependency: `EarnFeature.swift`'s `RewardsStore`, whose `liveValue` is backed by **`UserDefaults`** — two keys, `io.zheref.kro.rewards.catalog.v1` (the whole `[Reward]` array, JSON-encoded) and `io.zheref.kro.rewards.claimed.v1` (a bare `[String]` of claimed ids). Nothing else in the app touches it; there is no Supabase table.

**The port mirrors that choice rather than inventing a store.** `EarnRewardsStorage.ts` reads/writes through **#10's existing `KeyValueStore` port** (`extra.localStore.preferences`) under two `kro:`-namespaced keys, with a small JSON codec in place of `SettingsCodec`'s scalar one — exactly the shape the issue asked for. **No new persistence port was added**: no `RewardStore` interface, nothing new in `packages/core/src/persistence/` or `packages/app/src/services/localStore/`. The whole discovery and the resulting file lives in `packages/app/src/features/earn/EarnRewardsStorage.ts`, in-lane.

One flagged divergence: canon's two `UserDefaults` keys sit outside the `kro:` namespace, so nothing wipes them on sign-out. This port's keys sit *inside* `kro:` on purpose, so the existing generic sign-out sweep (`services/localStore/signOutWipe.ts`, untouched) clears them automatically — closing a gap canon's own preferences-wipe rule says every other piece of device state must not have.

## What changed

`packages/app/src/features/earn/**` (logic only, no UI — #28's lane):

- **`EarnFeature.ts`** — the slice: `EarnState` (one `load` lifecycle field per `RC-24`; `rewards`, `claimedRewardIds`, `performances` as raw domain arrays — no stored total), the Add-Reward draft, the claim-confirm pointer, and the two `earn.*` preferences.
- **`EarnRules.ts`** — the pure math: `totalEarnedPoints` (sums `performance.rewardPoints` — see divergence note below), `spentPoints`, `currentPoints` (floored at 0), `pointsToGo`, `claimProgress`, `partitionRewards` (claimable desc / locked asc, canon's order), `availableSuggestions` (case-insensitive title filter).
- **`EarnShifters.ts`** — pure `with…` transitions, including the shared `withException` that never touches the catalog (the atomicity contract).
- **`EarnProducer.ts`** — six thunks: `loadEarnPreferencesThunk`, `loadEarnCatalogThunk` (rewards + claimed ids + `#10`'s `performances.all()`, raw pass-through), `addRewardThunk`, `addSuggestionThunk`, `deleteRewardThunk`, and the atomic `claimRewardThunk`. Every mutation reads fresh from storage and persists **before** anything is returned; the reducer only ever applies a change on `ok`.
- **`EarnRewardsStorage.ts`** — the persistence discovery, above.
- **`EarnSelectors.ts`** — `createSelector`-built projections: balance, partition, suggestions, catalog-empty, preferences, draft, claim state.
- **`EarnException.ts`**, **`EarnMocks.ts`**, **`index.ts`**.
- **`packages/app/src/library/store.ts`** — `earn: earnSlice.reducer`, registered directly after the `endeavorDetail` entry (`find`/`endeavorDetail` were already adjacent).
- **One-line `RootState` test-literal fixups** (per the #52 precedent) in `CaptureSelectors.test.ts`, `DoSelectors.test.ts`, `EndeavorDetailSelectors.test.ts`, `FindSelectors.test.ts`, `GreetingSelectors.test.ts`, `PlanSelectors.test.ts` — each now seeds `earn: initialEarnState` in its hand-built `rootWith(...)`, since `RootState` names every registered slice.

## Divergences from canon (code is the tie-breaker per the epic)

1. **Balance source.** Canon's `totalEarnedPointsSelector` sums `endeavor.sessionPoints ?? 10` over completed endeavors — a coarse per-endeavor estimate. This port sums `performance.rewardPoints` instead: the ported domain (`#8`) already stamps the *exact* award on each `Perform` at completion time (`RewardCalculator.awardRewardPoints`). Re-deriving a second, coarser number would be exactly the "shadow counter" acceptance criterion 2 rules out. Named as the issue's own stated criterion, not an unstated choice.
2. **Claim is atomic, not optimistic.** Canon mutates `state.rewards`/`claimedIDs` synchronously and fires the `UserDefaults` write fire-and-forget afterwards — a failed write leaves memory and disk disagreeing forever. This port makes **every** catalog mutation persist-then-apply (not only claim, for consistency), per acceptance criterion 1's explicit "atomically."
3. **Reward storage keys sit inside the `kro:` namespace** (see the discovery section) — canon's don't, so canon's rewards survive sign-out and this port's don't.
4. **`earn.pointsFormula` is read-only here.** The issue asks for it "surfaced (formula math itself lives in domain/session — consume, don't duplicate)" — it is read alongside `earn.defaultRewardThreshold` in one `loadEarnPreferencesThunk` and exposed via `selectPointsFormula`. Canon's separate `EarnPreferencesFeature`/screen (editing the choice) has no corresponding child in this epic's 34-issue plan, so no write path was built here — #32 (Settings UI) is where editing would live if scoped.
5. **Weekly challenge / milestones / milestone haptics** (`earn.showWeeklyChallenge`, `earn.celebrateMilestones`, `earn.milestoneHaptics`) stay **declared, not consumed** — matching their `consumption: declared` marking in `#11`'s `SettingOptions.ts` and canon parity. No consumer was invented for them.
6. **Emoji-glyph truncation** uses `[...glyph].slice(0, 2)` (code-point aware) rather than Swift's grapheme-cluster-aware `String(prefix(2))` — a multi-codepoint ZWJ emoji could theoretically split differently. Not covered by this issue's acceptance criteria; flagged for whoever next touches the draft form.

## Test expectations met

- **Partition + "N to go" math vs canon** — `EarnRules.test.ts` (claimable/locked split and sort order, `pointsToGo`, `claimProgress`, all ported 1:1 from `EarnSelectors.swift`).
- **Claim atomicity** — `EarnProducer.test.ts` includes an end-to-end test (through a real `AppStore`) proving a failed claim leaves `selectCurrentPoints` and `selectLockedRewards` byte-for-byte unchanged, and leaves the confirm sheet open for a retry.
- **The balance property test** — `EarnSelectors.test.ts`, 30 random sequences × 20 operations each (a seeded `mulberry32` PRNG, no new dependency), asserting `selectCurrentPoints` matches a plain earned-minus-claimed reference computation after **every** step.
- **≥3 tests per arm/shifter/selector/producer** — every reducer arm, Shifter, Selector and Producer thunk in the feature.
- **≥7 reward mocks** — reused from `@kro/core/mocks`' `rewardMocks` (#7's seven variants), not duplicated.
- Every test is clock-controlled (`now`/ids always passed in, never read ambiently) and network-free (`stubbedThunkExtra` / `makeInMemoryLocalStore` throughout).

## How to verify

### Scenario 1 — Balance derives purely from performances and claims (acceptance criterion 2)
**Setup:** none — pure logic.
**Steps:**
1. `cd packages/app && npx vitest run src/features/earn/__tests__/EarnSelectors.test.ts`
**Expected:** all tests pass, including the `selectCurrentPoints — property: matches earned-minus-claimed for any sequence` suite (600 assertions across 30 sequences).

### Scenario 2 — Claim is atomic (acceptance criterion 1)
**Setup:** none — pure logic.
**Steps:**
1. `cd packages/app && npx vitest run src/features/earn/__tests__/EarnProducer.test.ts -t "claimRewardThunk"`
**Expected:** all pass, including `end-to-end: a failed claim leaves the balance and the catalog partition untouched`.

### Scenario 3 — Partition + "N to go" match canon
**Steps:**
1. `cd packages/app && npx vitest run src/features/earn/__tests__/EarnRules.test.ts`
**Expected:** all pass — `partitionRewards` sorts claimable desc / locked asc; `pointsToGo` is `max(0, cost − balance)`.

### Scenario 4 — Add-reward prefill from `earn.defaultRewardThreshold`
**Steps:**
1. `cd packages/app && npx vitest run src/features/earn/__tests__/EarnFeature.test.ts -t "userDidTapAddReward"`
**Expected:** all pass — prefill is 250 when the preference is set, 100 (the declared default) when unset.

### Scenario 5 — Reward storage discovery (persistence)
**Steps:**
1. `cd packages/app && npx vitest run src/features/earn/__tests__/EarnRewardsStorage.test.ts`
**Expected:** all pass — round-trip through the `kro:`-namespaced `KeyValueStore` keys, corrupt data degrades to empty rather than throwing.

### Regression — the whole repo
1. `make typecheck && make lint && make test && make build`
**Expected:** all green (already run and confirmed in this session: 2225/2225 tests across `@kro/core`/`@kro/app`/`@kro/web`, build succeeds).

## Notes

- Weekly challenge / milestones / milestone haptics are declared-not-consumed, matching canon — no consumers were invented (out of scope per the issue).
- No new dependency; lockfile untouched.
- Strict file lane held: `packages/app/src/features/earn/**`, the one `store.ts` line, and the six one-line `RootState` fixups. No persistence-port files were needed — the discovery's answer was "reuse #10's existing port," not "add a new one."

<!-- bankai agent=ichigo session=27earn0831 handbook=v0.5 trigger=local -->
