### PR TITLE
feat(thirst): add Thirst vote surface for gated destinations

### DIFF
--- a/apps/web/src/app/(shell)/blueprints/BlueprintsPageClient.spec.tsx
+++ b/apps/web/src/app/(shell)/blueprints/BlueprintsPageClient.spec.tsx
@@ -1,14 +1,14 @@
 import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import BlueprintsRoute from './page'
+import { BlueprintsPageClient } from './BlueprintsPageClient'
 
-describe('/blueprints', () => {
-  it("mounts the Blueprints Thirst vote surface inside the shell's store", () => {
+describe('BlueprintsPageClient', () => {
+  it('mounts the Thirst destination page for the blueprints feature key', () => {
     const store = makeStore(stubbedThunkExtra)
     render(
       <StoreProvider store={store}>
-        <BlueprintsRoute />
+        <BlueprintsPageClient />
       </StoreProvider>,
     )
 

--- a/apps/web/src/app/(shell)/blueprints/BlueprintsPageClient.tsx
+++ b/apps/web/src/app/(shell)/blueprints/BlueprintsPageClient.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ThirstDestinationPage } from '@kro/app/thirst'
+
+/**
+ * Client wrapper (`RC-39`): imports the Page, forwards nothing, ≤10 lines.
+ *
+ * `#35` mounts the Thirst vote surface here instead of the shared
+ * `DestinationPageClient` — see `ThirstDestinationPage.tsx`'s header for why.
+ */
+export function BlueprintsPageClient() {
+  return <ThirstDestinationPage kind="blueprints" />
+}

--- a/apps/web/src/app/(shell)/blueprints/page.tsx
+++ b/apps/web/src/app/(shell)/blueprints/page.tsx
@@ -1,13 +1,13 @@
-import { DestinationPageClient } from '../DestinationPageClient'
+import { BlueprintsPageClient } from './BlueprintsPageClient'
 
 /**
  * `/blueprints` — the Blueprints destination.
  *
  * A passive Server Component (`RC-38`): it names its destination and renders
- * the client wrapper. No hook, no store read, no markup. The surface itself
- * lives in `packages/app`, so the feature child that builds Blueprints replaces
- * a Page there and never touches this file.
+ * the client wrapper. No hook, no store read, no markup. `#35` mounts the
+ * Thirst vote surface (Blueprints is a canon *available soon* dead-end,
+ * `docs/Features/Thirst.md`) rather than the shared placeholder.
  */
 export default function BlueprintsRoute() {
-  return <DestinationPageClient kind="blueprints" />
+  return <BlueprintsPageClient />
 }

--- a/apps/web/src/app/(shell)/board/BoardPageClient.spec.tsx
+++ b/apps/web/src/app/(shell)/board/BoardPageClient.spec.tsx
@@ -1,14 +1,14 @@
 import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import BoardRoute from './page'
+import { BoardPageClient } from './BoardPageClient'
 
-describe('/board', () => {
-  it("mounts the Board Thirst vote surface inside the shell's store", () => {
+describe('BoardPageClient', () => {
+  it('mounts the Thirst destination page for the board feature key', () => {
     const store = makeStore(stubbedThunkExtra)
     render(
       <StoreProvider store={store}>
-        <BoardRoute />
+        <BoardPageClient />
       </StoreProvider>,
     )
 

--- a/apps/web/src/app/(shell)/board/BoardPageClient.tsx
+++ b/apps/web/src/app/(shell)/board/BoardPageClient.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ThirstDestinationPage } from '@kro/app/thirst'
+
+/**
+ * Client wrapper (`RC-39`): imports the Page, forwards nothing, ≤10 lines.
+ *
+ * `#35` mounts the Thirst vote surface here instead of the shared
+ * `DestinationPageClient` — see `ThirstDestinationPage.tsx`'s header for why.
+ */
+export function BoardPageClient() {
+  return <ThirstDestinationPage kind="board" />
+}

--- a/apps/web/src/app/(shell)/board/page.tsx
+++ b/apps/web/src/app/(shell)/board/page.tsx
@@ -1,13 +1,13 @@
-import { DestinationPageClient } from '../DestinationPageClient'
+import { BoardPageClient } from './BoardPageClient'
 
 /**
  * `/board` — the Board destination.
  *
  * A passive Server Component (`RC-38`): it names its destination and renders
- * the client wrapper. No hook, no store read, no markup. The surface itself
- * lives in `packages/app`, so the feature child that builds Board replaces
- * a Page there and never touches this file.
+ * the client wrapper. No hook, no store read, no markup. `#35` mounts the
+ * Thirst vote surface (Board is a canon *available soon* dead-end,
+ * `docs/Features/Thirst.md`) rather than the shared placeholder.
  */
 export default function BoardRoute() {
-  return <DestinationPageClient kind="board" />
+  return <BoardPageClient />
 }

--- a/apps/web/src/app/(shell)/habits/HabitsPageClient.spec.tsx
+++ b/apps/web/src/app/(shell)/habits/HabitsPageClient.spec.tsx
@@ -1,14 +1,14 @@
 import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import HabitsRoute from './page'
+import { HabitsPageClient } from './HabitsPageClient'
 
-describe('/habits', () => {
-  it("mounts the Habits Thirst vote surface inside the shell's store", () => {
+describe('HabitsPageClient', () => {
+  it('mounts the Thirst destination page for the habits feature key', () => {
     const store = makeStore(stubbedThunkExtra)
     render(
       <StoreProvider store={store}>
-        <HabitsRoute />
+        <HabitsPageClient />
       </StoreProvider>,
     )
 

--- a/apps/web/src/app/(shell)/habits/HabitsPageClient.tsx
+++ b/apps/web/src/app/(shell)/habits/HabitsPageClient.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ThirstDestinationPage } from '@kro/app/thirst'
+
+/**
+ * Client wrapper (`RC-39`): imports the Page, forwards nothing, ≤10 lines.
+ *
+ * `#35` mounts the Thirst vote surface here instead of the shared
+ * `DestinationPageClient` — see `ThirstDestinationPage.tsx`'s header for why.
+ */
+export function HabitsPageClient() {
+  return <ThirstDestinationPage kind="habits" />
+}

--- a/apps/web/src/app/(shell)/habits/page.tsx
+++ b/apps/web/src/app/(shell)/habits/page.tsx
@@ -1,13 +1,13 @@
-import { DestinationPageClient } from '../DestinationPageClient'
+import { HabitsPageClient } from './HabitsPageClient'
 
 /**
  * `/habits` — the Habits destination.
  *
  * A passive Server Component (`RC-38`): it names its destination and renders
- * the client wrapper. No hook, no store read, no markup. The surface itself
- * lives in `packages/app`, so the feature child that builds Habits replaces
- * a Page there and never touches this file.
+ * the client wrapper. No hook, no store read, no markup. `#35` mounts the
+ * Thirst vote surface (Habits is a canon *available soon* dead-end,
+ * `docs/Features/Thirst.md`) rather than the shared placeholder.
  */
 export default function HabitsRoute() {
-  return <DestinationPageClient kind="habits" />
+  return <HabitsPageClient />
 }

--- a/apps/web/src/app/(shell)/matrix/MatrixPageClient.spec.tsx
+++ b/apps/web/src/app/(shell)/matrix/MatrixPageClient.spec.tsx
@@ -1,20 +1,20 @@
 import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import BlueprintsRoute from './page'
+import { MatrixPageClient } from './MatrixPageClient'
 
-describe('/blueprints', () => {
-  it("mounts the Blueprints Thirst vote surface inside the shell's store", () => {
+describe('MatrixPageClient', () => {
+  it('mounts the Thirst destination page for the matrix feature key', () => {
     const store = makeStore(stubbedThunkExtra)
     render(
       <StoreProvider store={store}>
-        <BlueprintsRoute />
+        <MatrixPageClient />
       </StoreProvider>,
     )
 
     expect(screen.getByRole('heading', { level: 2 }).textContent).toBe(
-      'Blueprints',
+      'Priority Matrix',
     )
-    expect(store.getState().main.selected.kind).toBe('blueprints')
+    expect(store.getState().main.selected.kind).toBe('matrix')
   })
 })

--- a/apps/web/src/app/(shell)/matrix/MatrixPageClient.tsx
+++ b/apps/web/src/app/(shell)/matrix/MatrixPageClient.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ThirstDestinationPage } from '@kro/app/thirst'
+
+/**
+ * Client wrapper (`RC-39`): imports the Page, forwards nothing, ≤10 lines.
+ *
+ * `#35` mounts the Thirst vote surface here instead of the shared
+ * `DestinationPageClient` — see `ThirstDestinationPage.tsx`'s header for why.
+ */
+export function MatrixPageClient() {
+  return <ThirstDestinationPage kind="matrix" />
+}

--- a/apps/web/src/app/(shell)/matrix/page.spec.tsx
+++ b/apps/web/src/app/(shell)/matrix/page.spec.tsx
@@ -4,9 +4,10 @@ import { describe, expect, it } from 'vitest'
 import MatrixRoute from './page'
 
 describe('/matrix', () => {
-  it("mounts the Priority Matrix destination inside the shell's store", () => {
+  it("mounts the Priority Matrix Thirst vote surface inside the shell's store", () => {
+    const store = makeStore(stubbedThunkExtra)
     render(
-      <StoreProvider store={makeStore(stubbedThunkExtra)}>
+      <StoreProvider store={store}>
         <MatrixRoute />
       </StoreProvider>,
     )
@@ -14,5 +15,8 @@ describe('/matrix', () => {
     expect(screen.getByRole('heading', { level: 2 }).textContent).toBe(
       'Priority Matrix',
     )
+    // The sidebar highlight still follows the URL (`RC-17`, `RC-63`) even
+    // though this route no longer mounts the shared `DestinationPage`.
+    expect(store.getState().main.selected.kind).toBe('matrix')
   })
 })

--- a/apps/web/src/app/(shell)/matrix/page.tsx
+++ b/apps/web/src/app/(shell)/matrix/page.tsx
@@ -1,13 +1,13 @@
-import { DestinationPageClient } from '../DestinationPageClient'
+import { MatrixPageClient } from './MatrixPageClient'
 
 /**
  * `/matrix` — the Priority Matrix destination.
  *
  * A passive Server Component (`RC-38`): it names its destination and renders
- * the client wrapper. No hook, no store read, no markup. The surface itself
- * lives in `packages/app`, so the feature child that builds Priority Matrix replaces
- * a Page there and never touches this file.
+ * the client wrapper. No hook, no store read, no markup. `#35` mounts the
+ * Thirst vote surface (Priority Matrix is a canon *available soon* dead-end,
+ * `docs/Features/Thirst.md`) rather than the shared placeholder.
  */
 export default function MatrixRoute() {
-  return <DestinationPageClient kind="matrix" />
+  return <MatrixPageClient />
 }

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -35,6 +35,12 @@ export default defineConfig({
       '@kro/app/design': fileURLToPath(
         new URL('../../packages/app/src/design/index.ts', import.meta.url),
       ),
+      '@kro/app/thirst': fileURLToPath(
+        new URL(
+          '../../packages/app/src/features/thirst/index.ts',
+          import.meta.url,
+        ),
+      ),
       '@kro/app': fileURLToPath(
         new URL('../../packages/app/src/index.ts', import.meta.url),
       ),

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -9,6 +9,7 @@
     ".": "./src/index.ts",
     "./design": "./src/design/index.ts",
     "./google": "./src/services/googleCalendar/index.ts",
+    "./thirst": "./src/features/thirst/index.ts",
     "./design/system/styles.css": "./src/design/system/styles.css",
     "./package.json": "./package.json"
   },

--- a/packages/app/src/features/auth/__tests__/AuthSelectors.test.ts
+++ b/packages/app/src/features/auth/__tests__/AuthSelectors.test.ts
@@ -39,6 +39,7 @@ import {
 import { initialMainState } from '../../main/MainFeature'
 import { initialPlatformState } from '../../platform/PlatformFeature'
 import { initialSessionState } from '../../session/SessionState'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 import { AuthFlow, type AuthState } from '../AuthState'
 import { signOutIntents } from '../SignOutIntents'
 
@@ -57,6 +58,7 @@ const rootWith = (auth: AuthState): RootState => ({
   session: initialSessionState,
   auth,
   main: initialMainState,
+  thirst: initialThirstState,
 })
 
 describe('the session', () => {

--- a/packages/app/src/features/capture/__tests__/CaptureSelectors.test.ts
+++ b/packages/app/src/features/capture/__tests__/CaptureSelectors.test.ts
@@ -49,6 +49,7 @@ import {
   withTriageRequested,
 } from '../CaptureShifters'
 import { initialMainState } from '../../main/MainFeature'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 
 /** Selectors run against a hand-built root state, never a live store. */
 const rootWith = (slice: CaptureState): RootState => ({
@@ -67,6 +68,7 @@ const rootWith = (slice: CaptureState): RootState => ({
   session: initialSessionState,
   auth: initialAuthState,
   main: initialMainState,
+  thirst: initialThirstState,
 })
 
 const loaded = rootWith(captureStateMocks.loadedPool)

--- a/packages/app/src/features/do/__tests__/DoSelectors.test.ts
+++ b/packages/app/src/features/do/__tests__/DoSelectors.test.ts
@@ -32,6 +32,7 @@ import { initialFindState } from '../../find/FindState'
 import { initialPlanState } from '../../plan/PlanState'
 import { initialTriageState } from '../../triage/TriageFeature'
 import { initialMainState } from '../../main/MainFeature'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 
 /** Selectors run against a hand-built root state, never a live store. */
 const rootWith = (slice: DoState): RootState => ({
@@ -50,6 +51,7 @@ const rootWith = (slice: DoState): RootState => ({
   session: initialSessionState,
   auth: initialAuthState,
   main: initialMainState,
+  thirst: initialThirstState,
 })
 
 const loaded = rootWith(doStateMocks.loadedTypicalDay)

--- a/packages/app/src/features/earn/__tests__/EarnSelectors.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnSelectors.test.ts
@@ -43,6 +43,7 @@ import {
   selectTotalEarnedPoints,
 } from '../EarnSelectors'
 import { initialMainState } from '../../main/MainFeature'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 
 const rootWith = (earn: EarnState): RootState => ({
   greeting: initialGreetingState,
@@ -59,6 +60,7 @@ const rootWith = (earn: EarnState): RootState => ({
   session: initialSessionState,
   auth: initialAuthState,
   main: initialMainState,
+  thirst: initialThirstState,
 })
 
 const loaded = earnStateMocks.loadedTypical

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailSelectors.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailSelectors.test.ts
@@ -54,6 +54,7 @@ import {
 } from '../EndeavorDetailSelectors'
 import type { EndeavorDetailState } from '../EndeavorDetailState'
 import { initialMainState } from '../../main/MainFeature'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 
 const rootWith = (endeavorDetail: EndeavorDetailState): RootState => ({
   greeting: initialGreetingState,
@@ -69,6 +70,7 @@ const rootWith = (endeavorDetail: EndeavorDetailState): RootState => ({
   session: initialSessionState,
   auth: initialAuthState,
   main: initialMainState,
+  thirst: initialThirstState,
 })
 
 describe('presentation', () => {

--- a/packages/app/src/features/find/__tests__/FindSelectors.test.ts
+++ b/packages/app/src/features/find/__tests__/FindSelectors.test.ts
@@ -56,6 +56,7 @@ import {
   selectTasksVista,
 } from '../FindSelectors'
 import { initialMainState } from '../../main/MainFeature'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 
 const rootWith = (find: FindState): RootState => ({
   greeting: initialGreetingState,
@@ -72,6 +73,7 @@ const rootWith = (find: FindState): RootState => ({
   session: initialSessionState,
   auth: initialAuthState,
   main: initialMainState,
+  thirst: initialThirstState,
 })
 
 const loaded = rootWith(findStateMocks.loaded)

--- a/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
+++ b/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
@@ -21,6 +21,7 @@ import {
   selectIsGreetingLoading,
 } from '../GreetingSelectors'
 import { initialMainState } from '../../main/MainFeature'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 
 /**
  * Selectors are exercised against a hand-built root state, never a live store.
@@ -42,6 +43,7 @@ const rootWith = (greeting: GreetingState): RootState => ({
   session: initialSessionState,
   auth: initialAuthState,
   main: initialMainState,
+  thirst: initialThirstState,
 })
 
 describe('selectGreeting', () => {

--- a/packages/app/src/features/main/__tests__/MainSelectors.test.ts
+++ b/packages/app/src/features/main/__tests__/MainSelectors.test.ts
@@ -18,6 +18,7 @@ import { initialFindState } from '../../find/FindState'
 import { initialGreetingState } from '../../greeting/GreetingFeature'
 import { initialPlanState } from '../../plan/PlanState'
 import { initialTriageState } from '../../triage/TriageFeature'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 import type { MainState } from '../MainFeature'
 import { MainMocks, handheldSurface, projectMocks } from '../MainMocks'
 import {
@@ -49,6 +50,7 @@ const rootWith = (main: MainState): RootState => ({
   platform: initialPlatformState,
   session: initialSessionState,
   main,
+  thirst: initialThirstState,
 })
 
 describe('the shell shape', () => {

--- a/packages/app/src/features/plan/__tests__/PlanSelectors.test.ts
+++ b/packages/app/src/features/plan/__tests__/PlanSelectors.test.ts
@@ -58,6 +58,7 @@ import {
 import type { TimelineEditSession } from '../PlanEditSession'
 import type { PlanState } from '../PlanState'
 import { initialMainState } from '../../main/MainFeature'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 
 const today = startOfPlanDay(PLAN_REFERENCE_DAY)
 const tomorrow = addingPlanDays(today, 1)
@@ -77,6 +78,7 @@ const rootWith = (plan: PlanState): RootState => ({
   session: initialSessionState,
   auth: initialAuthState,
   main: initialMainState,
+  thirst: initialThirstState,
 })
 
 describe('selectPlanViewMode and the FAB rules', () => {

--- a/packages/app/src/features/platform/__tests__/PlatformSelectors.test.ts
+++ b/packages/app/src/features/platform/__tests__/PlatformSelectors.test.ts
@@ -15,6 +15,7 @@ import { initialGreetingState } from '../../greeting/GreetingFeature'
 import { initialPlanState } from '../../plan/PlanState'
 import { initialSessionState } from '../../session/SessionState'
 import { initialTriageState } from '../../triage/TriageFeature'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 import type { PlatformState } from '../PlatformFeature'
 import { PlatformMocks } from '../PlatformMocks'
 import {
@@ -47,6 +48,7 @@ const rootWith = (platform: PlatformState): RootState => ({
   main: initialMainState,
   session: initialSessionState,
   platform,
+  thirst: initialThirstState,
 })
 
 describe('selectIsPlatformLoading', () => {

--- a/packages/app/src/features/session/__tests__/SessionSelectors.test.ts
+++ b/packages/app/src/features/session/__tests__/SessionSelectors.test.ts
@@ -66,6 +66,7 @@ import {
   withException,
 } from '../SessionShifters'
 import { SessionPhase, SessionPillAffordance, SessionTint } from '../SessionVocabulary'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 
 /** Selectors run against a hand-built root state, never a live store. */
 const rootWith = (session: SessionState): RootState => ({
@@ -83,6 +84,7 @@ const rootWith = (session: SessionState): RootState => ({
   session,
   auth: initialAuthState,
   main: initialMainState,
+  thirst: initialThirstState,
 })
 
 const running = rootWith(sessionStateMocks.running)

--- a/packages/app/src/features/thirst/ComingSoonFragment.stories.tsx
+++ b/packages/app/src/features/thirst/ComingSoonFragment.stories.tsx
@@ -1,0 +1,164 @@
+import type { ReactNode } from 'react'
+import { Stage } from '../../design/endeavor/storyStage'
+import { ComingSoonFragment } from './ComingSoonFragment'
+
+/**
+ * The Thirst "Available soon — vote to get it sooner" surface — canon's
+ * `ComingSoonView.swift` previews, ported. Every state (`ThirstVoteStatus`)
+ * mirrors `ComingSoonFragment.test.tsx` 1:1.
+ */
+export default {
+  title: 'Thirst/Coming soon',
+  component: ComingSoonFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+function Frame({ children }: { readonly children: ReactNode }) {
+  return (
+    <div style={{ height: 480, width: 420 }}>
+      <Stage>{children}</Stage>
+    </div>
+  )
+}
+
+export const Votable = {
+  render: () => (
+    <Frame>
+      <ComingSoonFragment
+        featureTitle="Priority Matrix"
+        featureBlurb="Sort what matters by urgency and importance."
+        status={{ kind: 'votable' }}
+        hasCounts
+        totalCount={42}
+        perPlatform={[
+          { platform: 'ios', count: 30 },
+          { platform: 'android', count: 12 },
+        ]}
+        isVoting={false}
+      />
+    </Frame>
+  ),
+}
+
+export const Voted = {
+  render: () => (
+    <Frame>
+      <ComingSoonFragment
+        featureTitle="Habits"
+        featureBlurb="Build routines and keep your streaks alive."
+        status={{ kind: 'voted' }}
+        hasCounts
+        totalCount={43}
+        perPlatform={[
+          { platform: 'ios', count: 31 },
+          { platform: 'android', count: 12 },
+        ]}
+        isVoting={false}
+      />
+    </Frame>
+  ),
+}
+
+export const Loading = {
+  render: () => (
+    <Frame>
+      <ComingSoonFragment
+        featureTitle="Board"
+        featureBlurb="Organize your work on a flexible board."
+        status={{ kind: 'loading' }}
+        hasCounts={false}
+        totalCount={0}
+        perPlatform={[]}
+        isVoting={false}
+      />
+    </Frame>
+  ),
+}
+
+export const UnavailableSignedOut = {
+  render: () => (
+    <Frame>
+      <ComingSoonFragment
+        featureTitle="Blueprints"
+        featureBlurb="Reusable templates to start endeavors faster."
+        status={{ kind: 'unavailable', message: 'Sign in to vote for upcoming features.' }}
+        hasCounts
+        totalCount={17}
+        perPlatform={[{ platform: 'ios', count: 17 }]}
+        isVoting={false}
+      />
+    </Frame>
+  ),
+}
+
+export const UnavailableOfflineNoCounts = {
+  render: () => (
+    <Frame>
+      <ComingSoonFragment
+        featureTitle="Blueprints"
+        featureBlurb="Reusable templates to start endeavors faster."
+        status={{ kind: 'unavailable', message: 'No internet connection. Please try again.' }}
+        hasCounts={false}
+        totalCount={0}
+        perPlatform={[]}
+        isVoting={false}
+      />
+    </Frame>
+  ),
+}
+
+export const NotVotable = {
+  render: () => (
+    <Frame>
+      <ComingSoonFragment
+        featureTitle="Unknown"
+        status={{ kind: 'notVotable' }}
+        hasCounts={false}
+        totalCount={0}
+        perPlatform={[]}
+        isVoting={false}
+      />
+    </Frame>
+  ),
+}
+
+export const VotingInFlight = {
+  render: () => (
+    <Frame>
+      <ComingSoonFragment
+        featureTitle="Priority Matrix"
+        featureBlurb="Sort what matters by urgency and importance."
+        status={{ kind: 'votable' }}
+        hasCounts
+        totalCount={42}
+        perPlatform={[{ platform: 'ios', count: 42 }]}
+        isVoting
+      />
+    </Frame>
+  ),
+}
+
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr' }}>
+      {(['light', 'dark'] as const).map((theme) => (
+        <div key={theme} style={{ height: 480 }}>
+          <Stage theme={theme}>
+            <ComingSoonFragment
+              featureTitle="Priority Matrix"
+              featureBlurb="Sort what matters by urgency and importance."
+              status={{ kind: 'votable' }}
+              hasCounts
+              totalCount={42}
+              perPlatform={[
+                { platform: 'ios', count: 30 },
+                { platform: 'android', count: 12 },
+              ]}
+              isVoting={false}
+            />
+          </Stage>
+        </div>
+      ))}
+    </div>
+  ),
+}

--- a/packages/app/src/features/thirst/ComingSoonFragment.tsx
+++ b/packages/app/src/features/thirst/ComingSoonFragment.tsx
@@ -60,7 +60,12 @@ export function ComingSoonFragment({
 
   return (
     <section
-      aria-labelledby="coming-soon-heading"
+      // `aria-label`, not `aria-labelledby` + a fixed id (found in review):
+      // a fixed id collides the moment two Fragments render on one page
+      // (e.g. Storybook's `BothSchemes` story), producing duplicate DOM ids
+      // — invalid HTML that leaves assistive tech pointing at the wrong
+      // instance's heading. `aria-label` needs no id to stay unique.
+      aria-label={featureTitle}
       data-testid="coming-soon-surface"
       className={cn(
         'flex h-full flex-col items-center justify-center',
@@ -73,9 +78,7 @@ export function ComingSoonFragment({
           aria-hidden="true"
           style={{ color: colorVar('accent') }}
         />
-        <h2 id="coming-soon-heading" className="font-semibold text-2xl text-kro-fore">
-          {featureTitle}
-        </h2>
+        <h2 className="font-semibold text-2xl text-kro-fore">{featureTitle}</h2>
         <p className="font-semibold text-kro-fore-secondary text-xs uppercase tracking-wide">
           Available soon
         </p>

--- a/packages/app/src/features/thirst/ComingSoonFragment.tsx
+++ b/packages/app/src/features/thirst/ComingSoonFragment.tsx
@@ -1,0 +1,232 @@
+/**
+ * `ComingSoonFragment` — canon `KroUI/ComingSoon/ComingSoonView.swift` (epic
+ * #83, sub-issue #87). Pure renderer (`RC-15`): plain values + callbacks, no
+ * `useAppSelector`/`useAppDispatch`, no store import. Shown at flag-gated
+ * dead-ends that map to an *available soon* registry feature; the caller
+ * (`ComingSoonPage.tsx`) resolves the featureKey against the registry and
+ * passes `status.kind === 'notVotable'` for an unmapped dead-end, at which
+ * point this Fragment renders the plain "coming soon" card with no vote
+ * affordance — no count, no CTA.
+ */
+import { Apple, Globe, Heart, Monitor, Smartphone } from 'lucide-react'
+import { InlineBanner } from '../../design/endeavor/InlineBanner'
+import { KroChip } from '../../design/endeavor/KroChip'
+import { colorVar } from '../../design/system/tokens/roles'
+import { cn } from '../../design/system/utils/cn'
+import { Button } from '../../design/system/primitives/button'
+import { ICON_SIZE, iconForSymbol, type LucideIcon } from '../../design/system/icons/icons'
+import {
+  type PlatformVoteTally,
+  type ThirstVoteStatus,
+  VotePlatform,
+  votePlatformLabel,
+} from './ThirstModels'
+
+const PLATFORM_ICON: Readonly<Record<VotePlatform, LucideIcon>> = {
+  [VotePlatform.ios]: Apple,
+  [VotePlatform.android]: Smartphone,
+  [VotePlatform.web]: Globe,
+  [VotePlatform.windows]: Monitor,
+}
+
+export interface ComingSoonFragmentProps {
+  readonly featureTitle: string
+  readonly featureBlurb?: string | null
+  readonly status: ThirstVoteStatus
+  /** Whether real counts have loaded — hides the count block rather than
+   * showing a misleading "0 people want this" (canon's `hasCounts`). */
+  readonly hasCounts: boolean
+  readonly totalCount: number
+  readonly perPlatform: readonly PlatformVoteTally[]
+  readonly isVoting: boolean
+  /** A transient error from a failed vote attempt. Distinct from
+   * `status.kind === 'unavailable'`, which blocks voting outright. */
+  readonly voteErrorMessage?: string | null
+  readonly onVote?: () => void
+}
+
+export function ComingSoonFragment({
+  featureTitle,
+  featureBlurb,
+  status,
+  hasCounts,
+  totalCount,
+  perPlatform,
+  isVoting,
+  voteErrorMessage,
+  onVote,
+}: ComingSoonFragmentProps) {
+  const SparklesIcon = iconForSymbol('sparkles')
+
+  return (
+    <section
+      aria-labelledby="coming-soon-heading"
+      data-testid="coming-soon-surface"
+      className={cn(
+        'flex h-full flex-col items-center justify-center',
+        'gap-kro-large p-kro-x-large text-center',
+      )}
+    >
+      <div className="flex flex-col items-center gap-kro-small">
+        <SparklesIcon
+          size={ICON_SIZE.large}
+          aria-hidden="true"
+          style={{ color: colorVar('accent') }}
+        />
+        <h2 id="coming-soon-heading" className="font-semibold text-2xl text-kro-fore">
+          {featureTitle}
+        </h2>
+        <p className="font-semibold text-kro-fore-secondary text-xs uppercase tracking-wide">
+          Available soon
+        </p>
+        {featureBlurb === null || featureBlurb === undefined || featureBlurb.length === 0 ? null : (
+          <p className="max-w-prose text-kro-fore-secondary text-sm">{featureBlurb}</p>
+        )}
+      </div>
+
+      {status.kind === 'notVotable' ? null : (
+        <>
+          <CountsPanel
+            status={status}
+            hasCounts={hasCounts}
+            totalCount={totalCount}
+            perPlatform={perPlatform}
+          />
+          <CtaPanel
+            status={status}
+            isVoting={isVoting}
+            voteErrorMessage={voteErrorMessage}
+            onVote={onVote}
+          />
+        </>
+      )}
+    </section>
+  )
+}
+
+function CountsPanel({
+  status,
+  hasCounts,
+  totalCount,
+  perPlatform,
+}: {
+  readonly status: ThirstVoteStatus
+  readonly hasCounts: boolean
+  readonly totalCount: number
+  readonly perPlatform: readonly PlatformVoteTally[]
+}) {
+  if (status.kind === 'loading') {
+    return (
+      <div
+        role="status"
+        aria-label="Loading votes"
+        className="flex h-16 items-center justify-center"
+      >
+        <span
+          aria-hidden="true"
+          className="size-6 animate-spin rounded-full border-2 border-current border-t-transparent"
+          style={{ color: colorVar('accent') }}
+        />
+      </div>
+    )
+  }
+
+  if (!hasCounts) return null
+
+  return (
+    <div className="flex flex-col items-center gap-kro-tiny">
+      <span className="font-extrabold text-5xl text-kro-fore tabular-nums">
+        {totalCount}
+      </span>
+      <span className="text-kro-fore-secondary text-sm">
+        {totalCount === 1 ? 'person wants this' : 'people want this'}
+      </span>
+      {perPlatform.length === 0 ? null : (
+        <div className="mt-1 flex flex-wrap items-center justify-center gap-1.5">
+          {perPlatform.map((tally) => (
+            <PlatformTallyChip key={tally.platform} tally={tally} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function PlatformTallyChip({ tally }: { readonly tally: PlatformVoteTally }) {
+  const PlatformIcon = PLATFORM_ICON[tally.platform]
+  return (
+    <span
+      aria-label={`${votePlatformLabel(tally.platform)}: ${tally.count}`}
+      className="inline-flex items-center gap-1 rounded-kro-pill bg-kro-back-inner px-2.5 py-1.5 text-kro-fore-secondary text-xs"
+    >
+      <PlatformIcon size={12} aria-hidden="true" />
+      <span className="font-semibold tabular-nums">{tally.count}</span>
+    </span>
+  )
+}
+
+function CtaPanel({
+  status,
+  isVoting,
+  voteErrorMessage,
+  onVote,
+}: {
+  readonly status: ThirstVoteStatus
+  readonly isVoting: boolean
+  readonly voteErrorMessage?: string | null
+  readonly onVote?: () => void
+}) {
+  if (status.kind === 'voted') {
+    return (
+      <KroChip
+        title="You voted"
+        icon="checkmark.circle.fill"
+        tint={{ kind: 'color', role: 'badgeGreen' }}
+        emphasis="soft"
+      />
+    )
+  }
+
+  if (status.kind === 'unavailable') {
+    return (
+      <div className="flex w-full max-w-xs flex-col items-center gap-kro-small">
+        <InlineBanner kind="info" message={status.message} />
+        <Button variant="primary" size="lg" disabled className="w-full max-w-xs">
+          <Heart size={ICON_SIZE.medium} aria-hidden="true" />
+          Vote to get it sooner
+        </Button>
+      </div>
+    )
+  }
+
+  if (status.kind === 'votable' || status.kind === 'loading') {
+    return (
+      <div className="flex w-full max-w-xs flex-col items-center gap-kro-small">
+        <Button
+          variant="primary"
+          size="lg"
+          className="w-full max-w-xs"
+          disabled={isVoting || status.kind === 'loading'}
+          onClick={onVote}
+        >
+          {isVoting ? (
+            <span
+              aria-hidden="true"
+              className="size-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+            />
+          ) : (
+            <Heart size={ICON_SIZE.medium} aria-hidden="true" />
+          )}
+          Vote to get it sooner
+        </Button>
+        {voteErrorMessage === null || voteErrorMessage === undefined ? null : (
+          <p className="text-xs" style={{ color: colorVar('bannerDanger') }}>
+            {voteErrorMessage}
+          </p>
+        )}
+      </div>
+    )
+  }
+
+  return null
+}

--- a/packages/app/src/features/thirst/ComingSoonPage.tsx
+++ b/packages/app/src/features/thirst/ComingSoonPage.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+/**
+ * `ComingSoonPage` — stateful container (`RC-37`; implements `UZF-4`) for the
+ * Thirst vote surface. Canon's `ComingSoonScreen.swift`: reads the Selectors,
+ * dispatches the mount effects and the vote intent, renders the pure
+ * `ComingSoonFragment`.
+ */
+import { useEffect } from 'react'
+import { useAppDispatch, useAppSelector } from '../../library/hooks'
+import { ComingSoonFragment } from './ComingSoonFragment'
+import { castVoteThunk, checkVoteStateThunk, fetchCountsThunk } from './ThirstProducer'
+import { isThirstVotable, thirstFeatureBlurb, thirstFeatureTitle } from './ThirstRegistry'
+import {
+  selectThirstHasLoadedCounts,
+  selectThirstIsVoting,
+  selectThirstPerPlatformTallies,
+  selectThirstTotalCount,
+  selectThirstVoteErrorMessage,
+  selectThirstVoteStatus,
+} from './ThirstSelectors'
+
+export interface ComingSoonPageProps {
+  readonly featureKey: string
+  /** Shown for an unmapped dead-end (the *Unknown* fallback), which has no
+   * registry entry — canon: "fall back to the caller's title for unmapped
+   * dead-ends". Defaults to the raw key so a Page never renders blank. */
+  readonly fallbackTitle?: string
+}
+
+export function ComingSoonPage({ featureKey, fallbackTitle }: ComingSoonPageProps) {
+  const dispatch = useAppDispatch()
+  const status = useAppSelector((state) => selectThirstVoteStatus(state, featureKey))
+  const hasCounts = useAppSelector((state) =>
+    selectThirstHasLoadedCounts(state, featureKey),
+  )
+  const totalCount = useAppSelector((state) => selectThirstTotalCount(state, featureKey))
+  const perPlatform = useAppSelector((state) =>
+    selectThirstPerPlatformTallies(state, featureKey),
+  )
+  const isVoting = useAppSelector((state) => selectThirstIsVoting(state, featureKey))
+  const voteErrorMessage = useAppSelector((state) =>
+    selectThirstVoteErrorMessage(state, featureKey),
+  )
+
+  useEffect(() => {
+    // Unmapped dead-ends never fetch and never offer a vote (canon:
+    // "nothing is fetched and no vote is offered").
+    if (!isThirstVotable(featureKey)) return
+    const checking = dispatch(checkVoteStateThunk({ featureKey }))
+    const fetching = dispatch(fetchCountsThunk({ featureKey }))
+    return () => {
+      checking.abort()
+      fetching.abort()
+    }
+  }, [dispatch, featureKey])
+
+  const onVote = () => {
+    // Defense in depth, mirroring canon's `userDidTapVote` guard: reject a
+    // vote unless the surface is genuinely votable right now, even if a
+    // caller dispatches this outside the (disabled) CTA.
+    if (status.kind !== 'votable') return
+    dispatch(castVoteThunk({ featureKey, id: crypto.randomUUID() }))
+  }
+
+  return (
+    <ComingSoonFragment
+      featureTitle={thirstFeatureTitle(featureKey) ?? fallbackTitle ?? featureKey}
+      featureBlurb={thirstFeatureBlurb(featureKey)}
+      status={status}
+      hasCounts={hasCounts}
+      totalCount={totalCount}
+      perPlatform={perPlatform}
+      isVoting={isVoting}
+      voteErrorMessage={voteErrorMessage}
+      onVote={onVote}
+    />
+  )
+}

--- a/packages/app/src/features/thirst/HelpFeedbackFragment.stories.tsx
+++ b/packages/app/src/features/thirst/HelpFeedbackFragment.stories.tsx
@@ -1,0 +1,44 @@
+import { Stage } from '../../design/endeavor/storyStage'
+import { HelpFeedbackFragment } from './HelpFeedbackFragment'
+
+/** Canon `HelpFeedbackView.swift`'s previews, ported: light, dark, and the
+ * full six-row set together (canon has no separate "long content" preview —
+ * the row count itself is the whole surface). */
+export default {
+  title: 'Thirst/Help & feedback',
+  component: HelpFeedbackFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+export const Light = {
+  render: () => (
+    <div style={{ width: 360 }}>
+      <Stage theme="light">
+        <HelpFeedbackFragment />
+      </Stage>
+    </div>
+  ),
+}
+
+export const Dark = {
+  render: () => (
+    <div style={{ width: 360 }}>
+      <Stage theme="dark">
+        <HelpFeedbackFragment />
+      </Stage>
+    </div>
+  ),
+}
+
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr' }}>
+      <Stage theme="light">
+        <HelpFeedbackFragment />
+      </Stage>
+      <Stage theme="dark">
+        <HelpFeedbackFragment />
+      </Stage>
+    </div>
+  ),
+}

--- a/packages/app/src/features/thirst/HelpFeedbackFragment.tsx
+++ b/packages/app/src/features/thirst/HelpFeedbackFragment.tsx
@@ -1,0 +1,118 @@
+/**
+ * `HelpFeedbackFragment` — canon `KroUI/Settings/HelpFeedbackView.swift`.
+ * Domain-less otherwise (`RC-14`); kept in the Thirst feature's lane rather
+ * than `design/` only because that tier is outside `#35`'s declared file
+ * lane — see the header note in `ThirstDestinationPage.tsx` for the same
+ * shape of divergence.
+ *
+ * Six rows across three sections — Resources (Documentation, Community
+ * Forum), Support (Contact Support, Rate on App Store), Feedback (Report a
+ * Problem, Suggest a Feature) — every one genuinely **inert**: canon's
+ * `docs/Features/Thirst.md` lists this menu explicitly as *not* a Thirst
+ * surface ("Support affordances, not features to vote on") and its own view
+ * wires every row to an empty `{}` action. This port does the same — no
+ * `onClick`, no `href`, no invented destination — rather than "fixing" a row
+ * canon deliberately leaves unwired.
+ */
+import type { LucideIcon } from 'lucide-react'
+import { BookOpen, Flag, Lightbulb, Mail, MessagesSquare, Star } from 'lucide-react'
+import { colorVar } from '../../design/system/tokens/roles'
+import { cn } from '../../design/system/utils/cn'
+
+interface HelpFeedbackRow {
+  readonly icon: LucideIcon
+  readonly label: string
+}
+
+interface HelpFeedbackSection {
+  readonly title: string
+  readonly rows: readonly HelpFeedbackRow[]
+}
+
+/** Canon's three `Section`s, verbatim — six rows, in canon's own order. */
+const HELP_FEEDBACK_SECTIONS: readonly HelpFeedbackSection[] = [
+  {
+    title: 'Resources',
+    rows: [
+      { icon: BookOpen, label: 'Documentation' },
+      { icon: MessagesSquare, label: 'Community Forum' },
+    ],
+  },
+  {
+    title: 'Support',
+    rows: [
+      { icon: Mail, label: 'Contact Support' },
+      { icon: Star, label: 'Rate on App Store' },
+    ],
+  },
+  {
+    title: 'Feedback',
+    rows: [
+      { icon: Flag, label: 'Report a Problem' },
+      { icon: Lightbulb, label: 'Suggest a Feature' },
+    ],
+  },
+]
+
+export interface HelpFeedbackFragmentProps {
+  readonly className?: string
+}
+
+export function HelpFeedbackFragment({ className }: HelpFeedbackFragmentProps) {
+  return (
+    <nav
+      aria-label="Help & Feedback"
+      data-testid="help-feedback-surface"
+      className={cn('flex w-full flex-col gap-kro-large', className)}
+    >
+      {HELP_FEEDBACK_SECTIONS.map((section) => (
+        <div key={section.title} className="flex flex-col gap-kro-small">
+          <h3
+            className="px-kro-small font-semibold text-xs uppercase tracking-wide"
+            style={{ color: colorVar('foreSecondary') }}
+          >
+            {section.title}
+          </h3>
+          <div
+            className="flex flex-col overflow-hidden rounded-kro-card"
+            style={{ boxShadow: `inset 0 0 0 1px ${colorVar('hairline')}` }}
+          >
+            {section.rows.map((row, index) => (
+              <HelpFeedbackRowView
+                key={row.label}
+                row={row}
+                isLast={index === section.rows.length - 1}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </nav>
+  )
+}
+
+function HelpFeedbackRowView({
+  row,
+  isLast,
+}: {
+  readonly row: HelpFeedbackRow
+  readonly isLast: boolean
+}) {
+  const Icon = row.icon
+  return (
+    <button
+      type="button"
+      // Genuinely inert — canon's own `{}` action. No destination is invented.
+      className={cn(
+        'flex min-h-11 items-center gap-kro-small px-kro-medium py-kro-small',
+        'bg-kro-back text-left text-kro-fore text-sm',
+      )}
+      style={
+        isLast ? undefined : { boxShadow: `inset 0 -1px 0 ${colorVar('hairline')}` }
+      }
+    >
+      <Icon size={16} aria-hidden="true" style={{ color: colorVar('foreSecondary') }} />
+      <span>{row.label}</span>
+    </button>
+  )
+}

--- a/packages/app/src/features/thirst/ThirstDestinationPage.tsx
+++ b/packages/app/src/features/thirst/ThirstDestinationPage.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+/**
+ * Mounts a Thirst-gated sidebar destination — Priority Matrix, Board,
+ * Blueprints, Habits (`#35`'s four routes). `notifications` is a sheet on a
+ * different surface (reached from the Profile menu on iPhone; canon's
+ * `docs/Features/Thirst.md`), not a sidebar route, so it is out of this
+ * component's (and this issue's) scope.
+ *
+ * `packages/app/src/features/main/DestinationPage.tsx` documents itself as
+ * "the swap point" every destination's feature child edits to replace the
+ * shared placeholder — but it is a single file every in-flight feature
+ * child's route would contend to edit, and `#35`'s declared file lane is its
+ * four `apps/web` route directories only, not `features/main/**`. So this
+ * component stands in for that swap for exactly these four kinds, still
+ * firing the identical `onDestinationRouteMounted` lifecycle event
+ * `DestinationPage.tsx` fires — the sidebar/tab-bar highlight and the
+ * URL-is-authority contract (`RC-17`, `RC-63`) are unaffected by which file
+ * mounts the destination. Named as a divergence in the PR.
+ */
+import { useEffect } from 'react'
+import { useAppDispatch } from '../../library/hooks'
+import { onDestinationRouteMounted } from '../main/MainFeature'
+import { ComingSoonPage } from './ComingSoonPage'
+
+export type ThirstDestinationKind = 'matrix' | 'board' | 'blueprints' | 'habits'
+
+export interface ThirstDestinationPageProps {
+  readonly kind: ThirstDestinationKind
+}
+
+export function ThirstDestinationPage({ kind }: ThirstDestinationPageProps) {
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    dispatch(onDestinationRouteMounted({ destination: { kind } }))
+  }, [dispatch, kind])
+
+  return <ComingSoonPage featureKey={kind} />
+}

--- a/packages/app/src/features/thirst/ThirstException.ts
+++ b/packages/app/src/features/thirst/ThirstException.ts
@@ -1,0 +1,85 @@
+/**
+ * The Thirst vote surface's typed failure union (`RC-8`, `UZF-8`) — canon
+ * `ThirstException` (`Kro/Dependencies/ThirstClient.swift`), minus
+ * `.alreadyVoted`: this port's `castVote`/`hasVoted` never surface that case
+ * as a failure — a repeat vote converges quietly (canon's own comment: *"A
+ * second vote … resolves quietly as already-voted rather than throwing"*),
+ * so there is nothing here for it to carry.
+ *
+ * `ThirstService`'s operations throw these directly where they know the
+ * answer (no signed-in session), exactly as `AuthService`/`AuthException`
+ * does; `toThirstException` below is the single translation site for
+ * everything else (`RC-30`).
+ */
+import { type Exception, assertNever, exception, toUnknownException } from '@kro/core'
+
+export type ThirstException =
+  /** No signed-in session — voting (and checking whether one already voted)
+   * needs one; the public counts read does not. */
+  | Exception<'notSignedIn'>
+  /** The network is unavailable. */
+  | Exception<'offline'>
+  /** Anything else — carries the server's message for logs. */
+  | Exception<'unknown'>
+
+export const ThirstExceptions = {
+  notSignedIn: (): ThirstException =>
+    exception('notSignedIn', 'Sign in to vote for upcoming features.', false),
+
+  offline: (): ThirstException =>
+    exception('offline', 'No internet connection. Please try again.', true),
+
+  unknown: (message: string): ThirstException =>
+    exception(
+      'unknown',
+      message.length === 0 ? 'Something went wrong while voting.' : message,
+      true,
+    ),
+} as const
+
+/** Every `kind` in the union, for the exhaustiveness tests and the type guard. */
+export const thirstExceptionKinds: readonly ThirstException['kind'][] = [
+  'notSignedIn',
+  'offline',
+  'unknown',
+]
+
+/** Whether an arbitrary caught value already is one of ours. */
+export function isThirstException(value: unknown): value is ThirstException {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as { kind?: unknown; message?: unknown; recoverable?: unknown }
+  return (
+    typeof candidate.kind === 'string' &&
+    typeof candidate.message === 'string' &&
+    typeof candidate.recoverable === 'boolean' &&
+    (thirstExceptionKinds as readonly string[]).includes(candidate.kind)
+  )
+}
+
+/**
+ * `ThirstClient.map` — the Service already knows `notSignedIn`; a browser
+ * transport failure (opaque `TypeError`, the same signal `AuthMapper.ts`
+ * reads) degrades to `offline`; everything else is `unknown`.
+ */
+export function toThirstException(error: unknown): ThirstException {
+  if (isThirstException(error)) return error
+  if (error instanceof TypeError) return ThirstExceptions.offline()
+  return ThirstExceptions.unknown(toUnknownException(error).message)
+}
+
+/**
+ * User-facing copy, derived from `kind` only — never from `.message`
+ * (`RC-8`) — canon's `ThirstException.errorDescription`.
+ */
+export function thirstExceptionCopy(value: ThirstException): string {
+  switch (value.kind) {
+    case 'notSignedIn':
+      return 'Sign in to vote for upcoming features.'
+    case 'offline':
+      return 'No internet connection. Please try again.'
+    case 'unknown':
+      return 'Something went wrong while voting.'
+    default:
+      return assertNever(value)
+  }
+}

--- a/packages/app/src/features/thirst/ThirstFeature.ts
+++ b/packages/app/src/features/thirst/ThirstFeature.ts
@@ -1,0 +1,159 @@
+/**
+ * The Thirst vote surface's slice (`RC-1`, `RC-2`, `RC-24`, `RC-36`) — port of
+ * KroApple's `ComingSoonFeature.swift` (epic #83, sub-issue #87) to the web,
+ * tagged with the `web` `VotePlatform`.
+ *
+ * ## One entry per feature key, not one shared surface
+ *
+ * Canon's `ComingSoonFeature.State` is per-composed-child (TCA mounts one
+ * store per destination). This app has one global store, so `ThirstState`
+ * keys its vote bookkeeping by `featureKey` in `byFeatureKey` — a route
+ * mounts one destination at a time, but the shape does not assume that (a
+ * future surface reusing the same store while more than one Thirst surface
+ * is mounted, e.g. a route plus a sheet, is unaffected).
+ *
+ * ## Two independent load flags, not canon's one fused `applyLoadStarted`
+ *
+ * Canon flips `isLoadingCounts` and `isCheckingVoteState` together from one
+ * `.onAppeared` reducer arm because both effects are kicked off by the same
+ * event. Here the Page (`ComingSoonPage.tsx`) dispatches
+ * `checkVoteStateThunk` and `fetchCountsThunk` directly — the shape every
+ * other multi-effect mount in this repo uses (`MainShellPage.tsx`'s
+ * `onShellMounted` + `loadShellThunk`) — so each thunk's own `.pending` arm
+ * flips only its own flag. `ThirstSelectors.ts`'s `selectThirstVoteStatus`
+ * still reads them exactly per canon's `voteStatusSelector` priority, so the
+ * observable behavior is unchanged; only where the flag is set differs.
+ */
+import { err } from '@kro/core'
+import { createSlice } from '@reduxjs/toolkit'
+import { ThirstExceptions, type ThirstException } from './ThirstException'
+import type { FeatureVoteCounts } from './ThirstModels'
+import { castVoteThunk, checkVoteStateThunk, fetchCountsThunk } from './ThirstProducer'
+import {
+  withCountsFetchStarted,
+  withCountsResult,
+  withVoteResult,
+  withVoteStarted,
+  withVoteStateCheckStarted,
+  withVoteStateResult,
+} from './ThirstShifters'
+
+/** One feature key's whole vote-surface bookkeeping. */
+export interface ThirstVoteEntryState {
+  /** Live counts (total + per-platform); `null` until first load. */
+  readonly counts: FeatureVoteCounts | null
+  readonly alreadyVoted: boolean
+  /** A vote request is in flight. */
+  readonly isVoting: boolean
+  /** A counts fetch is in flight. */
+  readonly isLoadingCounts: boolean
+  /**
+   * The auth-gated vote-state check is in flight. The surface stays
+   * `.loading` until this resolves, so a signed-out user never sees a
+   * transiently-`.votable` CTA when the public counts fetch wins the race
+   * (canon's own note, kept verbatim in `ThirstSelectors.ts`).
+   */
+  readonly isCheckingVoteState: boolean
+  /** Failure from the vote-state (auth) check — the only thing that blocks
+   * voting. A public counts fetch failing does NOT block voting. */
+  readonly voteStateException: ThirstException | null
+  /** Failure from a vote attempt — surface stays votable so a retry works. */
+  readonly voteException: ThirstException | null
+}
+
+export const initialThirstVoteEntry: ThirstVoteEntryState = {
+  counts: null,
+  alreadyVoted: false,
+  isVoting: false,
+  isLoadingCounts: false,
+  isCheckingVoteState: false,
+  voteStateException: null,
+  voteException: null,
+}
+
+export interface ThirstState {
+  readonly byFeatureKey: Readonly<Record<string, ThirstVoteEntryState>>
+}
+
+export const initialThirstState: ThirstState = { byFeatureKey: {} }
+
+export const thirstSlice = createSlice({
+  name: 'thirst',
+  initialState: initialThirstState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      // --- the auth-gated "have I already voted" check -----------------
+      .addCase(checkVoteStateThunk.pending, (state, action) => {
+        Object.assign(
+          state,
+          withVoteStateCheckStarted(state, action.meta.arg.featureKey),
+        )
+      })
+      .addCase(checkVoteStateThunk.fulfilled, (state, action) => {
+        Object.assign(
+          state,
+          withVoteStateResult(state, action.meta.arg.featureKey, action.payload),
+        )
+      })
+      // Defensive only — the payload creator's try/catch means this should
+      // not fire in practice (`RC-26`).
+      .addCase(checkVoteStateThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withVoteStateResult(
+            state,
+            action.meta.arg.featureKey,
+            err(ThirstExceptions.unknown(action.error.message ?? 'Unknown error')),
+          ),
+        )
+      })
+
+      // --- the public counts fetch ---------------------------------------
+      .addCase(fetchCountsThunk.pending, (state, action) => {
+        Object.assign(state, withCountsFetchStarted(state, action.meta.arg.featureKey))
+      })
+      .addCase(fetchCountsThunk.fulfilled, (state, action) => {
+        Object.assign(
+          state,
+          withCountsResult(state, action.meta.arg.featureKey, action.payload),
+        )
+      })
+      .addCase(fetchCountsThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        // Non-blocking, matching canon: leaves `counts` (and
+        // `voteStateException`) untouched — only the in-flight flag clears.
+        Object.assign(
+          state,
+          withCountsResult(
+            state,
+            action.meta.arg.featureKey,
+            err(ThirstExceptions.unknown(action.error.message ?? 'Unknown error')),
+          ),
+        )
+      })
+
+      // --- the vote itself -------------------------------------------------
+      .addCase(castVoteThunk.pending, (state, action) => {
+        Object.assign(state, withVoteStarted(state, action.meta.arg.featureKey))
+      })
+      .addCase(castVoteThunk.fulfilled, (state, action) => {
+        Object.assign(
+          state,
+          withVoteResult(state, action.meta.arg.featureKey, action.payload),
+        )
+      })
+      .addCase(castVoteThunk.rejected, (state, action) => {
+        if (action.meta.aborted) return
+        Object.assign(
+          state,
+          withVoteResult(
+            state,
+            action.meta.arg.featureKey,
+            err(ThirstExceptions.unknown(action.error.message ?? 'Unknown error')),
+          ),
+        )
+      })
+  },
+})

--- a/packages/app/src/features/thirst/ThirstFeature.ts
+++ b/packages/app/src/features/thirst/ThirstFeature.ts
@@ -59,16 +59,60 @@ export interface ThirstVoteEntryState {
   readonly voteStateException: ThirstException | null
   /** Failure from a vote attempt — surface stays votable so a retry works. */
   readonly voteException: ThirstException | null
+  /**
+   * Bumped every time a vote is locally confirmed (`withVoteResult`'s
+   * success branch). Lets a `checkVoteStateThunk`/`fetchCountsThunk`
+   * dispatched *before* that confirmation recognize its own response, on
+   * arrival, as stale relative to the vote — see
+   * `pendingCountsVoteEpoch`/`pendingVoteStateVoteEpoch` below and
+   * `ThirstShifters.ts`'s header (found in review: a slower counts fetch
+   * landing after a faster vote was silently erasing the optimistic bump).
+   */
+  readonly voteEpoch: number
+  /** The `requestId` of the currently-outstanding counts fetch, so an OLDER
+   * dispatch's late response (e.g. a fetch from before a remount) is
+   * recognized as superseded by a newer one rather than applied. `null`
+   * when no fetch is outstanding. */
+  readonly pendingCountsRequestId: string | null
+  /** `voteEpoch` as of the moment `pendingCountsRequestId`'s fetch was
+   * dispatched. If `voteEpoch` has since moved on by the time that fetch
+   * resolves, its payload predates a vote and must not overwrite the
+   * optimistic bump. */
+  readonly pendingCountsVoteEpoch: number
+  /** The same guard, for `checkVoteStateThunk` — a stale "not yet voted"
+   * answer must never revert `alreadyVoted` back to `false` after a vote
+   * has since been confirmed. */
+  readonly pendingVoteStateRequestId: string | null
+  readonly pendingVoteStateVoteEpoch: number
 }
 
+/**
+ * `isCheckingVoteState` defaults to `true`, not `false`.
+ *
+ * `ComingSoonPage.tsx` dispatches `checkVoteStateThunk` from a `useEffect`,
+ * which fires strictly *after* the first paint — so any read of this entry
+ * before that effect runs (or for a feature key the store has never touched
+ * at all) is genuinely "we don't yet know whether this account voted", never
+ * "resolved, and the answer is no". Defaulting to `false` here let
+ * `selectThirstVoteStatus` fall through to `votable` for that one frame,
+ * flashing an enabled vote CTA at a signed-out visitor before the auth check
+ * ever started (found in review). `.pending` still sets this explicitly on
+ * dispatch, so the value is unchanged once the effect fires — only the
+ * pre-effect gap is fixed.
+ */
 export const initialThirstVoteEntry: ThirstVoteEntryState = {
   counts: null,
   alreadyVoted: false,
   isVoting: false,
   isLoadingCounts: false,
-  isCheckingVoteState: false,
+  isCheckingVoteState: true,
   voteStateException: null,
   voteException: null,
+  voteEpoch: 0,
+  pendingCountsRequestId: null,
+  pendingCountsVoteEpoch: 0,
+  pendingVoteStateRequestId: null,
+  pendingVoteStateVoteEpoch: 0,
 }
 
 export interface ThirstState {
@@ -87,13 +131,22 @@ export const thirstSlice = createSlice({
       .addCase(checkVoteStateThunk.pending, (state, action) => {
         Object.assign(
           state,
-          withVoteStateCheckStarted(state, action.meta.arg.featureKey),
+          withVoteStateCheckStarted(
+            state,
+            action.meta.arg.featureKey,
+            action.meta.requestId,
+          ),
         )
       })
       .addCase(checkVoteStateThunk.fulfilled, (state, action) => {
         Object.assign(
           state,
-          withVoteStateResult(state, action.meta.arg.featureKey, action.payload),
+          withVoteStateResult(
+            state,
+            action.meta.arg.featureKey,
+            action.meta.requestId,
+            action.payload,
+          ),
         )
       })
       // Defensive only — the payload creator's try/catch means this should
@@ -105,6 +158,7 @@ export const thirstSlice = createSlice({
           withVoteStateResult(
             state,
             action.meta.arg.featureKey,
+            action.meta.requestId,
             err(ThirstExceptions.unknown(action.error.message ?? 'Unknown error')),
           ),
         )
@@ -112,12 +166,20 @@ export const thirstSlice = createSlice({
 
       // --- the public counts fetch ---------------------------------------
       .addCase(fetchCountsThunk.pending, (state, action) => {
-        Object.assign(state, withCountsFetchStarted(state, action.meta.arg.featureKey))
+        Object.assign(
+          state,
+          withCountsFetchStarted(state, action.meta.arg.featureKey, action.meta.requestId),
+        )
       })
       .addCase(fetchCountsThunk.fulfilled, (state, action) => {
         Object.assign(
           state,
-          withCountsResult(state, action.meta.arg.featureKey, action.payload),
+          withCountsResult(
+            state,
+            action.meta.arg.featureKey,
+            action.meta.requestId,
+            action.payload,
+          ),
         )
       })
       .addCase(fetchCountsThunk.rejected, (state, action) => {
@@ -129,6 +191,7 @@ export const thirstSlice = createSlice({
           withCountsResult(
             state,
             action.meta.arg.featureKey,
+            action.meta.requestId,
             err(ThirstExceptions.unknown(action.error.message ?? 'Unknown error')),
           ),
         )

--- a/packages/app/src/features/thirst/ThirstMocks.ts
+++ b/packages/app/src/features/thirst/ThirstMocks.ts
@@ -1,0 +1,83 @@
+/**
+ * The Thirst feature's canned fixtures (`RC-31`, `UZF-18`) — canned
+ * `ThirstVoteEntryState`/`ThirstState` variants that back both the slice's
+ * own tests and the render-tier tests (`ComingSoonPage.test.tsx`,
+ * `ThirstDestinationPage.test.tsx`), so a scenario is never hand-built twice.
+ */
+import { ThirstExceptions } from './ThirstException'
+import { initialThirstState, initialThirstVoteEntry, type ThirstState, type ThirstVoteEntryState } from './ThirstFeature'
+import { bumpVotePlatform, type FeatureVoteCounts, VotePlatform } from './ThirstModels'
+
+/** The registry key every mock below is built against — a real votable key
+ * (`ThirstRegistry.ts`), so a story/test exercises the actual "Priority
+ * Matrix" title rather than an invented one. */
+export const THIRST_MOCK_FEATURE_KEY = 'matrix'
+
+export const thirstCountsFixture: FeatureVoteCounts = {
+  featureKey: THIRST_MOCK_FEATURE_KEY,
+  total: 42,
+  perPlatform: { [VotePlatform.ios]: 30, [VotePlatform.android]: 12 },
+}
+
+/** The states the Thirst vote surface claims to support — canon's five
+ * (`docs/Features/Thirst.md`'s "States" section). */
+export const thirstEntryMocks = {
+  /** Nothing asked for yet — first paint before the Page mounts. */
+  idle: initialThirstVoteEntry,
+
+  /** Both the auth check and the counts fetch are in flight. */
+  loading: {
+    ...initialThirstVoteEntry,
+    isCheckingVoteState: true,
+    isLoadingCounts: true,
+  } satisfies ThirstVoteEntryState,
+
+  /** Signed in, not yet voted, counts loaded. */
+  votable: {
+    ...initialThirstVoteEntry,
+    counts: thirstCountsFixture,
+  } satisfies ThirstVoteEntryState,
+
+  /** Already voted — the `web` tally the vote bumped is visible. */
+  voted: {
+    ...initialThirstVoteEntry,
+    counts: bumpVotePlatform(thirstCountsFixture, THIRST_MOCK_FEATURE_KEY, VotePlatform.web),
+    alreadyVoted: true,
+  } satisfies ThirstVoteEntryState,
+
+  /** Signed out — the vote-state check failed with the typed reason. */
+  unavailableSignedOut: {
+    ...initialThirstVoteEntry,
+    voteStateException: ThirstExceptions.notSignedIn(),
+  } satisfies ThirstVoteEntryState,
+
+  /** Offline before the auth check ever resolved — no counts loaded either. */
+  unavailableOffline: {
+    ...initialThirstVoteEntry,
+    voteStateException: ThirstExceptions.offline(),
+  } satisfies ThirstVoteEntryState,
+
+  /** A vote request in flight. */
+  voting: {
+    ...initialThirstVoteEntry,
+    counts: thirstCountsFixture,
+    isVoting: true,
+  } satisfies ThirstVoteEntryState,
+
+  /** A vote attempt failed — the surface stays votable for a retry. */
+  voteFailed: {
+    ...initialThirstVoteEntry,
+    counts: thirstCountsFixture,
+    voteException: ThirstExceptions.unknown('insert failed'),
+  } satisfies ThirstVoteEntryState,
+}
+
+export const thirstStateMocks = {
+  empty: initialThirstState,
+  matrixVotable: {
+    byFeatureKey: { [THIRST_MOCK_FEATURE_KEY]: thirstEntryMocks.votable },
+  } satisfies ThirstState,
+  matrixVoted: {
+    byFeatureKey: { [THIRST_MOCK_FEATURE_KEY]: thirstEntryMocks.voted },
+  } satisfies ThirstState,
+}

--- a/packages/app/src/features/thirst/ThirstMocks.ts
+++ b/packages/app/src/features/thirst/ThirstMocks.ts
@@ -32,10 +32,17 @@ export const thirstEntryMocks = {
     isLoadingCounts: true,
   } satisfies ThirstVoteEntryState,
 
-  /** Signed in, not yet voted, counts loaded. */
+  /**
+   * Signed in, not yet voted, counts loaded — both checks have RESOLVED, so
+   * `isCheckingVoteState` is explicitly `false` here rather than inherited
+   * from `initialThirstVoteEntry`'s default (`true`, meaning "not yet
+   * known" — see that field's own doc comment). Every other "resolved"
+   * mock below does the same for the same reason.
+   */
   votable: {
     ...initialThirstVoteEntry,
     counts: thirstCountsFixture,
+    isCheckingVoteState: false,
   } satisfies ThirstVoteEntryState,
 
   /** Already voted — the `web` tally the vote bumped is visible. */
@@ -43,25 +50,29 @@ export const thirstEntryMocks = {
     ...initialThirstVoteEntry,
     counts: bumpVotePlatform(thirstCountsFixture, THIRST_MOCK_FEATURE_KEY, VotePlatform.web),
     alreadyVoted: true,
+    isCheckingVoteState: false,
   } satisfies ThirstVoteEntryState,
 
   /** Signed out — the vote-state check failed with the typed reason. */
   unavailableSignedOut: {
     ...initialThirstVoteEntry,
     voteStateException: ThirstExceptions.notSignedIn(),
+    isCheckingVoteState: false,
   } satisfies ThirstVoteEntryState,
 
   /** Offline before the auth check ever resolved — no counts loaded either. */
   unavailableOffline: {
     ...initialThirstVoteEntry,
     voteStateException: ThirstExceptions.offline(),
+    isCheckingVoteState: false,
   } satisfies ThirstVoteEntryState,
 
-  /** A vote request in flight. */
+  /** A vote request in flight — both checks already resolved cleanly. */
   voting: {
     ...initialThirstVoteEntry,
     counts: thirstCountsFixture,
     isVoting: true,
+    isCheckingVoteState: false,
   } satisfies ThirstVoteEntryState,
 
   /** A vote attempt failed — the surface stays votable for a retry. */
@@ -69,6 +80,7 @@ export const thirstEntryMocks = {
     ...initialThirstVoteEntry,
     counts: thirstCountsFixture,
     voteException: ThirstExceptions.unknown('insert failed'),
+    isCheckingVoteState: false,
   } satisfies ThirstVoteEntryState,
 }
 

--- a/packages/app/src/features/thirst/ThirstModels.ts
+++ b/packages/app/src/features/thirst/ThirstModels.ts
@@ -1,0 +1,127 @@
+/**
+ * Thirst's domain shapes — canon `KroCore/Model/VotePlatform.swift` +
+ * `FeatureVoteCounts.swift` (epic #83), ported for `#35`.
+ *
+ * ## Why these live in the feature and not in `@kro/core`
+ *
+ * `07-models-mocks-mappers.md` puts a domain Model in `packages/core/models/`
+ * by default. That package is outside this issue's declared file lane
+ * (`packages/app/src/features/thirst/**`,
+ * `packages/app/src/services/thirst/**` only), so `VotePlatform` and
+ * `FeatureVoteCounts` are co-located here instead — the same exception
+ * `07`'s Mapper rule already carves out for a mapping that is "genuinely
+ * feature-local". Named as a divergence in the PR; promoting these two types
+ * into `@kro/core` (alongside `User`/`AuthProvider`, which Auth's own domain
+ * types already prove the pattern for) is a natural follow-up once a session
+ * holds that lane.
+ */
+import { assertNever } from '@kro/core'
+
+/**
+ * The platform a vote was cast from — canon's `ios | android | web |
+ * windows`, already the accepted `votes.platform` CHECK-constraint set
+ * (`zheref/KroApple@2117efc`'s
+ * `supabase/migrations/20260607000000_thirst_backend.sql`). This app always
+ * casts `web` (`ThirstService.ts`).
+ */
+export const VotePlatform = {
+  ios: 'ios',
+  android: 'android',
+  web: 'web',
+  windows: 'windows',
+} as const
+
+export type VotePlatform = (typeof VotePlatform)[keyof typeof VotePlatform]
+
+/** Canon's declaration order — also the order platform chips render in. */
+export const ALL_VOTE_PLATFORMS: readonly VotePlatform[] = [
+  VotePlatform.ios,
+  VotePlatform.android,
+  VotePlatform.web,
+  VotePlatform.windows,
+]
+
+/** The label a platform chip's accessible name reads. */
+export function votePlatformLabel(platform: VotePlatform): string {
+  switch (platform) {
+    case VotePlatform.ios:
+      return 'iOS'
+    case VotePlatform.android:
+      return 'Android'
+    case VotePlatform.web:
+      return 'Web'
+    case VotePlatform.windows:
+      return 'Windows'
+    default:
+      return assertNever(platform)
+  }
+}
+
+/** Aggregated Thirst vote counts for one feature — canon's `FeatureVoteCounts`. */
+export interface FeatureVoteCounts {
+  readonly featureKey: string
+  readonly total: number
+  readonly perPlatform: Readonly<Partial<Record<VotePlatform, number>>>
+}
+
+/** No votes yet — canon's `FeatureVoteCounts.empty(featureKey:)`. */
+export function emptyFeatureVoteCounts(featureKey: string): FeatureVoteCounts {
+  return { featureKey, total: 0, perPlatform: {} }
+}
+
+/** Canon's `FeatureVoteCounts.count(for:)`. */
+export function countFor(counts: FeatureVoteCounts, platform: VotePlatform): number {
+  return counts.perPlatform[platform] ?? 0
+}
+
+/**
+ * The local optimistic bump a confirmed `web` vote applies — canon's
+ * `applyVoteResult`'s `perPlatform[.ios, default: 0] += 1`, ported to the
+ * platform this app casts from. Pure: takes the prior counts (or `null`, for
+ * a vote confirmed before any count ever loaded) and returns a new value.
+ */
+export function bumpVotePlatform(
+  counts: FeatureVoteCounts | null,
+  featureKey: string,
+  platform: VotePlatform,
+): FeatureVoteCounts {
+  const base = counts ?? emptyFeatureVoteCounts(featureKey)
+  return {
+    ...base,
+    total: base.total + 1,
+    perPlatform: { ...base.perPlatform, [platform]: countFor(base, platform) + 1 },
+  }
+}
+
+/** One platform's slice of the count, for the breakdown row. */
+export interface PlatformVoteTally {
+  readonly platform: VotePlatform
+  readonly count: number
+}
+
+/**
+ * Per-platform tallies for the breakdown row, in canon's stable platform
+ * order, including only platforms with at least one vote — canon's
+ * `perPlatformTalliesSelector`.
+ */
+export function perPlatformTalliesFor(
+  counts: FeatureVoteCounts,
+): readonly PlatformVoteTally[] {
+  return ALL_VOTE_PLATFORMS.map((platform) => ({
+    platform,
+    count: countFor(counts, platform),
+  })).filter((tally) => tally.count > 0)
+}
+
+/**
+ * The composed status a vote surface renders — canon's `ThirstVoteStatus`
+ * (`KroUI/ComingSoon/ComingSoonView.swift`), as a discriminated union rather
+ * than an enum-with-associated-value so the `unavailable` message is typed
+ * rather than read back out of a `switch`.
+ */
+export type ThirstVoteStatus =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'votable' }
+  | { readonly kind: 'voted' }
+  | { readonly kind: 'unavailable'; readonly message: string }
+  | { readonly kind: 'notVotable' }

--- a/packages/app/src/features/thirst/ThirstProducer.ts
+++ b/packages/app/src/features/thirst/ThirstProducer.ts
@@ -1,0 +1,63 @@
+/**
+ * The Thirst vote surface's Producers (`RC-3`, `RC-6`, `RC-25`) — canon's
+ * `ComingSoonProducer.swift`, against the injected `thirstService`
+ * (`ThunkExtra`, `library/store.ts`).
+ *
+ * None of these mints an id: `castVoteThunk`'s `id` is a caller-supplied
+ * argument (the Page mints it, `crypto.randomUUID()`), the same convention
+ * `EarnProducer.ts`'s `addRewardThunk` documents for itself.
+ */
+import { type Result, err, ok } from '@kro/core'
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import type { ThunkExtra } from '../../library/store'
+import { type ThirstException, toThirstException } from './ThirstException'
+import type { FeatureVoteCounts } from './ThirstModels'
+
+/** Whether the current user has already voted for `featureKey`. Requires a
+ * signed-in session; a signed-out caller's typed failure is what blocks
+ * voting (`ThirstSelectors.ts`'s `.unavailable`). */
+export const checkVoteStateThunk = createAsyncThunk<
+  Result<boolean, ThirstException>,
+  { featureKey: string },
+  { extra: ThunkExtra }
+>('thirst/onVoteStateCheckCompleted', async ({ featureKey }, { extra, signal }) => {
+  try {
+    const voted = await extra.thirstService.hasVoted(featureKey, { signal })
+    return ok(voted)
+  } catch (error) {
+    return err(toThirstException(error))
+  }
+})
+
+/** Total + per-platform vote counts for `featureKey`. Public — no session
+ * required. */
+export const fetchCountsThunk = createAsyncThunk<
+  Result<FeatureVoteCounts, ThirstException>,
+  { featureKey: string },
+  { extra: ThunkExtra }
+>('thirst/onCountsFetchCompleted', async ({ featureKey }, { extra, signal }) => {
+  try {
+    const counts = await extra.thirstService.fetchCounts(featureKey, { signal })
+    return ok(counts)
+  } catch (error) {
+    return err(toThirstException(error))
+  }
+})
+
+/** Casts the signed-in user's single vote for `featureKey`, tagged `web`
+ * (`ThirstService.ts`). A vote the server already has (the unique-constraint
+ * conflict) converges quietly — the Service resolves `void`, so this always
+ * reports `ok(true)` on a non-throwing return, matching canon's
+ * `.success(true)`. */
+export const castVoteThunk = createAsyncThunk<
+  Result<boolean, ThirstException>,
+  { featureKey: string; id: string },
+  { extra: ThunkExtra }
+>('thirst/onVoteCastCompleted', async ({ featureKey, id }, { extra, signal }) => {
+  try {
+    await extra.thirstService.castVote(featureKey, id, { signal })
+    return ok(true)
+  } catch (error) {
+    return err(toThirstException(error))
+  }
+})

--- a/packages/app/src/features/thirst/ThirstRegistry.ts
+++ b/packages/app/src/features/thirst/ThirstRegistry.ts
@@ -1,0 +1,67 @@
+/**
+ * The client-side mirror of the shared feature registry's *available soon*
+ * set — canon `KroCore/Domain/ThirstRegistry.swift` (epic #83, sub-issue
+ * #86's dead-end audit). A dead-end whose key is absent here is **not
+ * votable** — the surface shows a plain "coming soon" card with no vote
+ * affordance, never a vote for a feature the registry doesn't list (the
+ * generic *Unknown* fallback).
+ *
+ * `#35`'s four routes (`matrix`, `board`, `blueprints`, `habits`) are the
+ * ones this issue wires; `notifications` is kept in the registry for parity
+ * with canon (it is a sheet reached from the Profile menu on iPhone, not a
+ * sidebar destination — out of this issue's route lane, `#34`/a later
+ * child's surface to mount).
+ */
+
+export interface ThirstRegistryFeature {
+  readonly key: string
+  readonly title: string
+  readonly blurb: string
+}
+
+/** `ThirstRegistry.availableSoon`, keyed by stable feature key. */
+export const THIRST_AVAILABLE_SOON: Readonly<Record<string, ThirstRegistryFeature>> = {
+  matrix: {
+    key: 'matrix',
+    title: 'Priority Matrix',
+    blurb: 'Sort what matters by urgency and importance.',
+  },
+  board: {
+    key: 'board',
+    title: 'Board',
+    blurb: 'Organize your work on a flexible board.',
+  },
+  blueprints: {
+    key: 'blueprints',
+    title: 'Blueprints',
+    blurb: 'Reusable templates to start endeavors faster.',
+  },
+  habits: {
+    key: 'habits',
+    title: 'Habits',
+    blurb: 'Build routines and keep your streaks alive.',
+  },
+  notifications: {
+    key: 'notifications',
+    title: 'Notifications',
+    blurb: 'Fine-tune reminders and daily nudges.',
+  },
+}
+
+/** Canon's `ThirstRegistry.isVotable(_:)`. */
+export function isThirstVotable(featureKey: string): boolean {
+  return featureKey in THIRST_AVAILABLE_SOON
+}
+
+/**
+ * Canon's `ThirstRegistry.title(for:)` — the registry's own title, preferred
+ * over any caller-supplied one so the surface can't drift from it.
+ */
+export function thirstFeatureTitle(featureKey: string): string | null {
+  return THIRST_AVAILABLE_SOON[featureKey]?.title ?? null
+}
+
+/** Canon's `ThirstRegistry.blurb(for:)`. */
+export function thirstFeatureBlurb(featureKey: string): string | null {
+  return THIRST_AVAILABLE_SOON[featureKey]?.blurb ?? null
+}

--- a/packages/app/src/features/thirst/ThirstRegistry.ts
+++ b/packages/app/src/features/thirst/ThirstRegistry.ts
@@ -48,9 +48,17 @@ export const THIRST_AVAILABLE_SOON: Readonly<Record<string, ThirstRegistryFeatur
   },
 }
 
-/** Canon's `ThirstRegistry.isVotable(_:)`. */
+/**
+ * Canon's `ThirstRegistry.isVotable(_:)`.
+ *
+ * `Object.hasOwn`, not the `in` operator (found in review): `in` also
+ * matches inherited `Object.prototype` members, so a dead-end whose key
+ * happens to collide with one — `"toString"`, `"constructor"`,
+ * `"hasOwnProperty"` — would read as votable even though the registry never
+ * listed it.
+ */
 export function isThirstVotable(featureKey: string): boolean {
-  return featureKey in THIRST_AVAILABLE_SOON
+  return Object.hasOwn(THIRST_AVAILABLE_SOON, featureKey)
 }
 
 /**

--- a/packages/app/src/features/thirst/ThirstSelectors.ts
+++ b/packages/app/src/features/thirst/ThirstSelectors.ts
@@ -8,7 +8,7 @@
 import { createSelector } from '@reduxjs/toolkit'
 import type { RootState } from '../../library/store'
 import { initialThirstVoteEntry, type ThirstState, type ThirstVoteEntryState } from './ThirstFeature'
-import { isThirstVotable, thirstFeatureBlurb, thirstFeatureTitle } from './ThirstRegistry'
+import { isThirstVotable } from './ThirstRegistry'
 import { thirstExceptionCopy } from './ThirstException'
 import {
   type PlatformVoteTally,
@@ -24,16 +24,6 @@ export const selectThirstEntry = createSelector(
   [selectThirstSlice, featureKeyArg],
   (thirst, featureKey): ThirstVoteEntryState =>
     thirst.byFeatureKey[featureKey] ?? initialThirstVoteEntry,
-)
-
-/** The registry title, falling back to the feature key itself — a caller
- * (`ComingSoonPage.tsx`) supplies its own copy for an unmapped dead-end. */
-export const selectThirstFeatureTitle = createSelector([featureKeyArg], (featureKey) =>
-  thirstFeatureTitle(featureKey),
-)
-
-export const selectThirstFeatureBlurb = createSelector([featureKeyArg], (featureKey) =>
-  thirstFeatureBlurb(featureKey),
 )
 
 /**

--- a/packages/app/src/features/thirst/ThirstSelectors.ts
+++ b/packages/app/src/features/thirst/ThirstSelectors.ts
@@ -1,0 +1,102 @@
+/**
+ * The Thirst vote surface's Selectors (`RC-5`, `RC-20`) — canon's
+ * `ComingSoonSelectors.swift`, built with `createSelector` over `RootState`
+ * and parameterized by `featureKey` (the reselect "selector with props"
+ * shape — one exported selector per derived read, not a factory minted per
+ * call).
+ */
+import { createSelector } from '@reduxjs/toolkit'
+import type { RootState } from '../../library/store'
+import { initialThirstVoteEntry, type ThirstState, type ThirstVoteEntryState } from './ThirstFeature'
+import { isThirstVotable, thirstFeatureBlurb, thirstFeatureTitle } from './ThirstRegistry'
+import { thirstExceptionCopy } from './ThirstException'
+import {
+  type PlatformVoteTally,
+  type ThirstVoteStatus,
+  perPlatformTalliesFor,
+} from './ThirstModels'
+
+const selectThirstSlice = (state: RootState): ThirstState => state.thirst
+
+const featureKeyArg = (_state: RootState, featureKey: string): string => featureKey
+
+export const selectThirstEntry = createSelector(
+  [selectThirstSlice, featureKeyArg],
+  (thirst, featureKey): ThirstVoteEntryState =>
+    thirst.byFeatureKey[featureKey] ?? initialThirstVoteEntry,
+)
+
+/** The registry title, falling back to the feature key itself — a caller
+ * (`ComingSoonPage.tsx`) supplies its own copy for an unmapped dead-end. */
+export const selectThirstFeatureTitle = createSelector([featureKeyArg], (featureKey) =>
+  thirstFeatureTitle(featureKey),
+)
+
+export const selectThirstFeatureBlurb = createSelector([featureKeyArg], (featureKey) =>
+  thirstFeatureBlurb(featureKey),
+)
+
+/**
+ * The composed status the Fragment renders — canon's `voteStatusSelector`.
+ * Order matters: a not-votable dead-end never votes; an already-voted
+ * surface shows the voted state even while counts are still arriving; only a
+ * vote-state (auth) failure blocks voting (a counts-only failure keeps the
+ * surface votable with the count block hidden); a fresh load in flight shows
+ * loading.
+ */
+export const selectThirstVoteStatus = createSelector(
+  [featureKeyArg, selectThirstEntry],
+  (featureKey, entry): ThirstVoteStatus => {
+    if (!isThirstVotable(featureKey)) return { kind: 'notVotable' }
+    if (entry.alreadyVoted) return { kind: 'voted' }
+    if (entry.voteStateException !== null) {
+      return { kind: 'unavailable', message: thirstExceptionCopy(entry.voteStateException) }
+    }
+    // Stay in loading until the auth check resolves, even if public counts
+    // already arrived — never show a votable CTA to a not-yet-verified user.
+    if (entry.isCheckingVoteState) return { kind: 'loading' }
+    if (entry.isLoadingCounts && entry.counts === null) return { kind: 'loading' }
+    return { kind: 'votable' }
+  },
+)
+
+/** Whether real counts have loaded — lets the Fragment distinguish "unknown /
+ * not yet loaded" from a genuine zero-vote result. */
+export const selectThirstHasLoadedCounts = createSelector(
+  [selectThirstEntry],
+  (entry) => entry.counts !== null,
+)
+
+/** Grand total across platforms (0 until counts load; pair with
+ * `selectThirstHasLoadedCounts` so a not-yet-loaded count is never shown as
+ * a genuine zero). */
+export const selectThirstTotalCount = createSelector(
+  [selectThirstEntry],
+  (entry) => entry.counts?.total ?? 0,
+)
+
+/** Per-platform tallies for the breakdown row, platforms with zero votes
+ * omitted. */
+export const selectThirstPerPlatformTallies = createSelector(
+  [selectThirstEntry],
+  (entry): readonly PlatformVoteTally[] =>
+    entry.counts === null ? [] : perPlatformTalliesFor(entry.counts),
+)
+
+export const selectThirstIsVoting = createSelector(
+  [selectThirstEntry],
+  (entry) => entry.isVoting,
+)
+
+/** A transient vote-attempt error, shown inline only while the surface is
+ * still votable (not while loading or blocked by an auth failure) — canon's
+ * `voteErrorMessageSelector`. */
+export const selectThirstVoteErrorMessage = createSelector(
+  [selectThirstEntry],
+  (entry): string | null => {
+    if (entry.alreadyVoted || entry.voteStateException !== null || entry.counts === null) {
+      return null
+    }
+    return entry.voteException === null ? null : thirstExceptionCopy(entry.voteException)
+  },
+)

--- a/packages/app/src/features/thirst/ThirstSelectors.ts
+++ b/packages/app/src/features/thirst/ThirstSelectors.ts
@@ -54,6 +54,10 @@ export const selectThirstVoteStatus = createSelector(
     }
     // Stay in loading until the auth check resolves, even if public counts
     // already arrived — never show a votable CTA to a not-yet-verified user.
+    // This also covers the check NOT having started yet: `isCheckingVoteState`
+    // defaults `true` (`ThirstFeature.ts`'s `initialThirstVoteEntry`) for
+    // exactly this reason — the pre-`useEffect` first paint reads as loading,
+    // never as a transiently-votable false positive (found in review).
     if (entry.isCheckingVoteState) return { kind: 'loading' }
     if (entry.isLoadingCounts && entry.counts === null) return { kind: 'loading' }
     return { kind: 'votable' }
@@ -88,15 +92,21 @@ export const selectThirstIsVoting = createSelector(
   (entry) => entry.isVoting,
 )
 
-/** A transient vote-attempt error, shown inline only while the surface is
- * still votable (not while loading or blocked by an auth failure) — canon's
- * `voteErrorMessageSelector`. */
+/**
+ * A transient vote-attempt error, shown inline only while the surface is
+ * still votable (not while blocked by an auth failure, and not once a vote
+ * already landed) — canon's `voteErrorMessageSelector`, minus its `counts !=
+ * nil` guard. That guard is dropped deliberately: casting a vote never
+ * depends on counts having loaded (`ComingSoonPage.tsx`'s `onVote` does not
+ * check `hasCounts`), so requiring it here only hid a genuine failed-vote
+ * retry message whenever the public counts fetch had itself failed — the
+ * user would see the CTA stop spinning with no explanation at all (found in
+ * review).
+ */
 export const selectThirstVoteErrorMessage = createSelector(
   [selectThirstEntry],
   (entry): string | null => {
-    if (entry.alreadyVoted || entry.voteStateException !== null || entry.counts === null) {
-      return null
-    }
+    if (entry.alreadyVoted || entry.voteStateException !== null) return null
     return entry.voteException === null ? null : thirstExceptionCopy(entry.voteException)
   },
 )

--- a/packages/app/src/features/thirst/ThirstShifters.ts
+++ b/packages/app/src/features/thirst/ThirstShifters.ts
@@ -1,0 +1,148 @@
+/**
+ * The Thirst vote surface's Shifters (`RC-4`, `RC-19`) — canon's
+ * `ComingSoonShifters.swift`, widened from one shared `ThirstVoteEntryState`
+ * to the `byFeatureKey`-keyed `ThirstState` this store uses.
+ *
+ * Every one returns a brand-new plain object; none reads a clock, a service
+ * or a random source (`UZF-10`) — `id` for a cast vote is a caller-supplied
+ * argument (`ThirstProducer.ts`).
+ */
+import type { Result } from '@kro/core'
+import type { ThirstException } from './ThirstException'
+import { initialThirstVoteEntry, type ThirstState, type ThirstVoteEntryState } from './ThirstFeature'
+import { type FeatureVoteCounts, VotePlatform, bumpVotePlatform } from './ThirstModels'
+
+const entryOf = (state: ThirstState, featureKey: string): ThirstVoteEntryState =>
+  state.byFeatureKey[featureKey] ?? initialThirstVoteEntry
+
+const withEntry = (
+  state: ThirstState,
+  featureKey: string,
+  entry: ThirstVoteEntryState,
+): ThirstState => ({
+  ...state,
+  byFeatureKey: { ...state.byFeatureKey, [featureKey]: entry },
+})
+
+// ---------------------------------------------------------------------------
+// The auth-gated "have I already voted" check
+// ---------------------------------------------------------------------------
+
+/** A load begins: flag the check in flight, clear any stale exception so a
+ * retry surfaces `.loading` rather than the previous attempt's
+ * `.unavailable` (canon's `applyLoadStarted`). */
+export const withVoteStateCheckStarted = (
+  state: ThirstState,
+  featureKey: string,
+): ThirstState =>
+  withEntry(state, featureKey, {
+    ...entryOf(state, featureKey),
+    isCheckingVoteState: true,
+    voteStateException: null,
+  })
+
+/** Canon's `applyVoteStateResult`: a success records whether the person
+ * already voted; a failure (signed out / offline) blocks voting. Either way
+ * the check is no longer in flight. */
+export const withVoteStateResult = (
+  state: ThirstState,
+  featureKey: string,
+  result: Result<boolean, ThirstException>,
+): ThirstState => {
+  const current = entryOf(state, featureKey)
+  return withEntry(state, featureKey, {
+    ...current,
+    isCheckingVoteState: false,
+    alreadyVoted: result.ok ? result.value : current.alreadyVoted,
+    voteStateException: result.ok ? null : result.error,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// The public counts fetch
+// ---------------------------------------------------------------------------
+
+export const withCountsFetchStarted = (
+  state: ThirstState,
+  featureKey: string,
+): ThirstState =>
+  withEntry(state, featureKey, { ...entryOf(state, featureKey), isLoadingCounts: true })
+
+/** Canon's `applyCountsResult`: a success stores the counts; a failure is
+ * non-blocking — the count is secondary, so `counts` (and
+ * `voteStateException`) are left exactly as they were. */
+export const withCountsResult = (
+  state: ThirstState,
+  featureKey: string,
+  result: Result<FeatureVoteCounts, ThirstException>,
+): ThirstState => {
+  const current = entryOf(state, featureKey)
+  return withEntry(state, featureKey, {
+    ...current,
+    isLoadingCounts: false,
+    counts: result.ok ? result.value : current.counts,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// The vote itself
+// ---------------------------------------------------------------------------
+
+/** A vote request begins: flag it in-flight and clear any prior retry error. */
+export const withVoteStarted = (state: ThirstState, featureKey: string): ThirstState =>
+  withEntry(state, featureKey, {
+    ...entryOf(state, featureKey),
+    isVoting: true,
+    voteException: null,
+  })
+
+/**
+ * Canon's `applyVoteResult`. On a confirmed vote (`ok(true)`): lock to voted,
+ * clear the retry error, and optimistically bump the total + the `web`
+ * platform's tally (canon bumps `.ios`; this app always casts `web`) so the
+ * count reflects the new vote without a refetch. `ok(false)` (no vote
+ * recorded) leaves the surface votable. On failure: keep votable and surface
+ * the retry error.
+ *
+ * **Idempotent on an already-voted entry — the one place this diverges from
+ * canon's literal shape, on purpose.** `ThirstService.castVote`'s own
+ * `23505` branch converges a second in-flight vote for the same feature into
+ * a non-throwing `ok(true)` (matching canon's "resolves quietly as
+ * already-voted"), so two overlapping `castVoteThunk` dispatches for one
+ * feature key BOTH fulfil `ok(true)`. Bumping unconditionally on every
+ * `ok(true)` — canon's literal `perPlatform[.ios, default: 0] += 1` — would
+ * double-count that second, no-op confirmation. Guarding on
+ * `!current.alreadyVoted` is the vote-once invariant the server enforces,
+ * expressed here too, so the count stays correct even when a race reaches
+ * the reducer before the UI's own `isVoting`-disabled button could prevent
+ * the second dispatch (`ThirstProducer.test.ts`'s race case).
+ */
+export const withVoteResult = (
+  state: ThirstState,
+  featureKey: string,
+  result: Result<boolean, ThirstException>,
+): ThirstState => {
+  const current = entryOf(state, featureKey)
+  if (!result.ok) {
+    return withEntry(state, featureKey, {
+      ...current,
+      isVoting: false,
+      voteException: result.error,
+    })
+  }
+  if (!result.value || current.alreadyVoted) {
+    return withEntry(state, featureKey, {
+      ...current,
+      isVoting: false,
+      alreadyVoted: current.alreadyVoted || result.value,
+      voteException: null,
+    })
+  }
+  return withEntry(state, featureKey, {
+    ...current,
+    isVoting: false,
+    alreadyVoted: true,
+    voteException: null,
+    counts: bumpVotePlatform(current.counts, featureKey, VotePlatform.web),
+  })
+}

--- a/packages/app/src/features/thirst/ThirstShifters.ts
+++ b/packages/app/src/features/thirst/ThirstShifters.ts
@@ -6,6 +6,37 @@
  * Every one returns a brand-new plain object; none reads a clock, a service
  * or a random source (`UZF-10`) — `id` for a cast vote is a caller-supplied
  * argument (`ThirstProducer.ts`).
+ *
+ * ## Guarding both async reads against a race with the vote (found in review)
+ *
+ * `checkVoteStateThunk` and `fetchCountsThunk` are each dispatched once per
+ * mount, independently of `castVoteThunk` — so either can still be in flight
+ * when a vote resolves, and its own (now-stale) response can arrive *after*.
+ * Applied blindly, a stale response overwrites the optimistic state a
+ * faster-resolving vote already wrote: a stale `hasVoted: false` would flip
+ * `alreadyVoted` back to `false`, and a stale counts payload (fetched before
+ * the vote landed server-side) would erase the optimistic bump while the
+ * "You voted" chip stays put — a real, silent-looking regression a reviewer
+ * caught, not a hypothetical.
+ *
+ * Both are guarded the same two ways:
+ *   - **`requestId`** — each entry remembers the `requestId` of its own
+ *     currently-outstanding request. A response whose `requestId` doesn't
+ *     match is from an *older, superseded* dispatch (e.g. a second mount
+ *     firing a fresh request while an earlier one is still in flight) and is
+ *     dropped entirely — not even the in-flight flag moves, because the
+ *     request that flag is tracking hasn't resolved yet.
+ *   - **`voteEpoch`** — bumped every time a vote is locally confirmed
+ *     (`withVoteResult`'s success branch). Each in-flight request also
+ *     remembers `voteEpoch` as it stood at dispatch time. If a matching
+ *     response's stored epoch no longer equals the *current* epoch, a vote
+ *     landed while that request was in flight — so its payload predates the
+ *     vote and must not be allowed to overwrite what the vote already wrote,
+ *     even though it's otherwise the "current" (non-superseded) request.
+ *
+ * A fetch/check dispatched *after* the vote confirms is unaffected either
+ * way: its own epoch matches the (now-current) `voteEpoch`, so its answer —
+ * genuinely fresher than the vote — is trusted and applied normally.
  */
 import type { Result } from '@kro/core'
 import type { ThirstException } from './ThirstException'
@@ -30,31 +61,54 @@ const withEntry = (
 
 /** A load begins: flag the check in flight, clear any stale exception so a
  * retry surfaces `.loading` rather than the previous attempt's
- * `.unavailable` (canon's `applyLoadStarted`). */
+ * `.unavailable` (canon's `applyLoadStarted`), and remember this dispatch's
+ * identity for the race guard above. */
 export const withVoteStateCheckStarted = (
   state: ThirstState,
   featureKey: string,
-): ThirstState =>
-  withEntry(state, featureKey, {
-    ...entryOf(state, featureKey),
+  requestId: string,
+): ThirstState => {
+  const current = entryOf(state, featureKey)
+  return withEntry(state, featureKey, {
+    ...current,
     isCheckingVoteState: true,
     voteStateException: null,
+    pendingVoteStateRequestId: requestId,
+    pendingVoteStateVoteEpoch: current.voteEpoch,
   })
+}
 
-/** Canon's `applyVoteStateResult`: a success records whether the person
+/**
+ * Canon's `applyVoteStateResult`: a success records whether the person
  * already voted; a failure (signed out / offline) blocks voting. Either way
- * the check is no longer in flight. */
+ * the check is no longer in flight — unless this response is superseded
+ * (see the file header): a response for a `requestId` other than the one
+ * currently tracked is silently dropped, and a response that predates a
+ * vote confirmed while it was in flight never reverts `alreadyVoted`.
+ */
 export const withVoteStateResult = (
   state: ThirstState,
   featureKey: string,
+  requestId: string,
   result: Result<boolean, ThirstException>,
 ): ThirstState => {
   const current = entryOf(state, featureKey)
+  if (requestId !== current.pendingVoteStateRequestId) return state
+  if (current.pendingVoteStateVoteEpoch !== current.voteEpoch) {
+    // A vote landed while this check was in flight — its answer predates
+    // that vote. Only clear the in-flight flag; never touch `alreadyVoted`.
+    return withEntry(state, featureKey, {
+      ...current,
+      isCheckingVoteState: false,
+      pendingVoteStateRequestId: null,
+    })
+  }
   return withEntry(state, featureKey, {
     ...current,
     isCheckingVoteState: false,
     alreadyVoted: result.ok ? result.value : current.alreadyVoted,
     voteStateException: result.ok ? null : result.error,
+    pendingVoteStateRequestId: null,
   })
 }
 
@@ -65,22 +119,46 @@ export const withVoteStateResult = (
 export const withCountsFetchStarted = (
   state: ThirstState,
   featureKey: string,
-): ThirstState =>
-  withEntry(state, featureKey, { ...entryOf(state, featureKey), isLoadingCounts: true })
-
-/** Canon's `applyCountsResult`: a success stores the counts; a failure is
- * non-blocking — the count is secondary, so `counts` (and
- * `voteStateException`) are left exactly as they were. */
-export const withCountsResult = (
-  state: ThirstState,
-  featureKey: string,
-  result: Result<FeatureVoteCounts, ThirstException>,
+  requestId: string,
 ): ThirstState => {
   const current = entryOf(state, featureKey)
   return withEntry(state, featureKey, {
     ...current,
+    isLoadingCounts: true,
+    pendingCountsRequestId: requestId,
+    pendingCountsVoteEpoch: current.voteEpoch,
+  })
+}
+
+/**
+ * Canon's `applyCountsResult`: a success stores the counts; a failure is
+ * non-blocking — the count is secondary, so `counts` (and
+ * `voteStateException`) are left exactly as they were. A superseded or
+ * vote-predating response is handled the same way `withVoteStateResult`
+ * handles its own (see the file header).
+ */
+export const withCountsResult = (
+  state: ThirstState,
+  featureKey: string,
+  requestId: string,
+  result: Result<FeatureVoteCounts, ThirstException>,
+): ThirstState => {
+  const current = entryOf(state, featureKey)
+  if (requestId !== current.pendingCountsRequestId) return state
+  if (current.pendingCountsVoteEpoch !== current.voteEpoch) {
+    // A vote landed while this fetch was in flight — its payload predates
+    // that vote. Clear the in-flight flag only; the optimistic bump wins.
+    return withEntry(state, featureKey, {
+      ...current,
+      isLoadingCounts: false,
+      pendingCountsRequestId: null,
+    })
+  }
+  return withEntry(state, featureKey, {
+    ...current,
     isLoadingCounts: false,
     counts: result.ok ? result.value : current.counts,
+    pendingCountsRequestId: null,
   })
 }
 
@@ -98,11 +176,11 @@ export const withVoteStarted = (state: ThirstState, featureKey: string): ThirstS
 
 /**
  * Canon's `applyVoteResult`. On a confirmed vote (`ok(true)`): lock to voted,
- * clear the retry error, and optimistically bump the total + the `web`
- * platform's tally (canon bumps `.ios`; this app always casts `web`) so the
- * count reflects the new vote without a refetch. `ok(false)` (no vote
- * recorded) leaves the surface votable. On failure: keep votable and surface
- * the retry error.
+ * clear the retry error, bump `voteEpoch` (the race guard above), and
+ * optimistically bump the total + the `web` platform's tally (canon bumps
+ * `.ios`; this app always casts `web`) so the count reflects the new vote
+ * without a refetch. `ok(false)` (no vote recorded) leaves the surface
+ * votable. On failure: keep votable and surface the retry error.
  *
  * **Idempotent on an already-voted entry — the one place this diverges from
  * canon's literal shape, on purpose.** `ThirstService.castVote`'s own
@@ -143,6 +221,7 @@ export const withVoteResult = (
     isVoting: false,
     alreadyVoted: true,
     voteException: null,
+    voteEpoch: current.voteEpoch + 1,
     counts: bumpVotePlatform(current.counts, featureKey, VotePlatform.web),
   })
 }

--- a/packages/app/src/features/thirst/__tests__/ComingSoonFragment.test.tsx
+++ b/packages/app/src/features/thirst/__tests__/ComingSoonFragment.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * `ComingSoonFragment`'s render tests, mirroring its stories 1:1 (`RC-11`).
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ComingSoonFragment } from '../ComingSoonFragment'
+
+afterEach(cleanup)
+
+describe('ComingSoonFragment', () => {
+  it('shows the count and platform breakdown when votable', () => {
+    render(
+      <ComingSoonFragment
+        featureTitle="Priority Matrix"
+        featureBlurb="Sort what matters by urgency and importance."
+        status={{ kind: 'votable' }}
+        hasCounts
+        totalCount={42}
+        perPlatform={[
+          { platform: 'ios', count: 30 },
+          { platform: 'android', count: 12 },
+        ]}
+        isVoting={false}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe(
+      'Priority Matrix',
+    )
+    expect(screen.getByText('42')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /vote to get it sooner/i })).toBeTruthy()
+  })
+
+  it('shows the voted chip and no vote CTA once voted', () => {
+    render(
+      <ComingSoonFragment
+        featureTitle="Habits"
+        status={{ kind: 'voted' }}
+        hasCounts
+        totalCount={43}
+        perPlatform={[{ platform: 'ios', count: 31 }]}
+        isVoting={false}
+      />,
+    )
+
+    expect(screen.getByText('You voted')).toBeTruthy()
+    expect(
+      screen.queryByRole('button', { name: /vote to get it sooner/i }),
+    ).toBeNull()
+  })
+
+  it('shows a loading indicator and no count block while loading', () => {
+    render(
+      <ComingSoonFragment
+        featureTitle="Board"
+        status={{ kind: 'loading' }}
+        hasCounts={false}
+        totalCount={0}
+        perPlatform={[]}
+        isVoting={false}
+      />,
+    )
+
+    expect(screen.getByRole('status', { name: /loading votes/i })).toBeTruthy()
+    expect(screen.queryByText('42')).toBeNull()
+  })
+
+  it('explains why voting is unavailable and disables the CTA when signed out', () => {
+    render(
+      <ComingSoonFragment
+        featureTitle="Blueprints"
+        status={{ kind: 'unavailable', message: 'Sign in to vote for upcoming features.' }}
+        hasCounts
+        totalCount={17}
+        perPlatform={[{ platform: 'ios', count: 17 }]}
+        isVoting={false}
+      />,
+    )
+
+    expect(screen.getByText('Sign in to vote for upcoming features.')).toBeTruthy()
+    const cta = screen.getByRole('button', {
+      name: /vote to get it sooner/i,
+    }) as HTMLButtonElement
+    expect(cta.disabled).toBe(true)
+  })
+
+  it('hides the count and any counts block when offline and nothing has loaded', () => {
+    render(
+      <ComingSoonFragment
+        featureTitle="Blueprints"
+        status={{ kind: 'unavailable', message: 'No internet connection. Please try again.' }}
+        hasCounts={false}
+        totalCount={0}
+        perPlatform={[]}
+        isVoting={false}
+      />,
+    )
+
+    expect(screen.getByText('No internet connection. Please try again.')).toBeTruthy()
+    expect(screen.queryByText('0')).toBeNull()
+  })
+
+  it('renders the plain card with no vote affordance for an unmapped dead-end', () => {
+    render(
+      <ComingSoonFragment
+        featureTitle="Unknown"
+        status={{ kind: 'notVotable' }}
+        hasCounts={false}
+        totalCount={0}
+        perPlatform={[]}
+        isVoting={false}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('Unknown')
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('disables the CTA and shows a spinner glyph while a vote is in flight', () => {
+    render(
+      <ComingSoonFragment
+        featureTitle="Priority Matrix"
+        status={{ kind: 'votable' }}
+        hasCounts
+        totalCount={42}
+        perPlatform={[]}
+        isVoting
+      />,
+    )
+
+    const cta = screen.getByRole('button', {
+      name: /vote to get it sooner/i,
+    }) as HTMLButtonElement
+    expect(cta.disabled).toBe(true)
+  })
+
+  it('calls onVote when the CTA is tapped while votable', () => {
+    const onVote = vi.fn()
+    render(
+      <ComingSoonFragment
+        featureTitle="Priority Matrix"
+        status={{ kind: 'votable' }}
+        hasCounts
+        totalCount={42}
+        perPlatform={[]}
+        isVoting={false}
+        onVote={onVote}
+      />,
+    )
+
+    screen.getByRole('button', { name: /vote to get it sooner/i }).click()
+    expect(onVote).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a transient vote-error message alongside the still-enabled CTA', () => {
+    render(
+      <ComingSoonFragment
+        featureTitle="Priority Matrix"
+        status={{ kind: 'votable' }}
+        hasCounts
+        totalCount={42}
+        perPlatform={[]}
+        isVoting={false}
+        voteErrorMessage="Couldn't record that vote. Try again."
+      />,
+    )
+
+    expect(screen.getByText("Couldn't record that vote. Try again.")).toBeTruthy()
+    const cta = screen.getByRole('button', {
+      name: /vote to get it sooner/i,
+    }) as HTMLButtonElement
+    expect(cta.disabled).toBe(false)
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ComingSoonFragment.test.tsx
+++ b/packages/app/src/features/thirst/__tests__/ComingSoonFragment.test.tsx
@@ -172,4 +172,31 @@ describe('ComingSoonFragment', () => {
     }) as HTMLButtonElement
     expect(cta.disabled).toBe(false)
   })
+
+  it('two instances on one page never produce a duplicate DOM id (found in review — the BothSchemes story renders exactly this)', () => {
+    const { container } = render(
+      <>
+        <ComingSoonFragment
+          featureTitle="Priority Matrix"
+          status={{ kind: 'votable' }}
+          hasCounts={false}
+          totalCount={0}
+          perPlatform={[]}
+          isVoting={false}
+        />
+        <ComingSoonFragment
+          featureTitle="Priority Matrix"
+          status={{ kind: 'votable' }}
+          hasCounts={false}
+          totalCount={0}
+          perPlatform={[]}
+          isVoting={false}
+        />
+      </>,
+    )
+
+    const ids = Array.from(container.querySelectorAll('[id]')).map((el) => el.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(screen.getAllByRole('heading', { level: 2, name: 'Priority Matrix' })).toHaveLength(2)
+  })
 })

--- a/packages/app/src/features/thirst/__tests__/ComingSoonPage.test.tsx
+++ b/packages/app/src/features/thirst/__tests__/ComingSoonPage.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * `ComingSoonPage` driven through a real store against a stubbed
+ * `thirstService` — the same shape `DestinationPage.test.tsx` uses for the
+ * shell.
+ */
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { StoreProvider } from '../../../library/StoreProvider'
+import { makeStore, stubbedThunkExtra, type ThunkExtra } from '../../../library/store'
+import { makeStubbedThirstService } from '../../../services/thirst/ThirstService'
+import { thirstCountsFixture } from '../ThirstMocks'
+import { ComingSoonPage } from '../ComingSoonPage'
+
+afterEach(cleanup)
+
+const renderPage = (
+  featureKey: string,
+  overrides: Partial<Parameters<typeof makeStubbedThirstService>[0]> = {},
+) => {
+  const extra: ThunkExtra = {
+    ...stubbedThunkExtra,
+    thirstService: makeStubbedThirstService(overrides),
+  }
+  const store = makeStore(extra)
+  render(
+    <StoreProvider store={store}>
+      <ComingSoonPage featureKey={featureKey} />
+    </StoreProvider>,
+  )
+  return store
+}
+
+describe('ComingSoonPage', () => {
+  it('renders the registry title for a votable feature key', async () => {
+    renderPage('matrix')
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe(
+      'Priority Matrix',
+    )
+  })
+
+  it('shows the honest signed-out state once the auth check resolves', async () => {
+    renderPage('matrix', { signedIn: false })
+    await waitFor(() =>
+      expect(
+        screen.getByText('Sign in to vote for upcoming features.'),
+      ).toBeTruthy(),
+    )
+  })
+
+  it('reaches a seeded voted state through the real Page → Producer → reducer loop', async () => {
+    renderPage('matrix', {
+      signedIn: true,
+      initialVotedFeatureKeys: ['matrix'],
+      initialCounts: { matrix: thirstCountsFixture },
+    })
+    await waitFor(() => expect(screen.getByText('You voted')).toBeTruthy())
+  })
+
+  it('never fetches or offers a vote for an unmapped dead-end', () => {
+    const thirstService = makeStubbedThirstService()
+    const extra: ThunkExtra = { ...stubbedThunkExtra, thirstService }
+    render(
+      <StoreProvider store={makeStore(extra)}>
+        <ComingSoonPage featureKey="unknown" />
+      </StoreProvider>,
+    )
+
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('unknown')
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(thirstService.operations()).toEqual([])
+  })
+
+  it('falls back to the caller-supplied title for an unmapped dead-end', () => {
+    render(
+      <StoreProvider store={makeStore(stubbedThunkExtra)}>
+        <ComingSoonPage featureKey="unknown" fallbackTitle="Unknown" />
+      </StoreProvider>,
+    )
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('Unknown')
+  })
+
+  it('a tap on the vote CTA reaches the store as a cast vote', async () => {
+    const store = renderPage('matrix', {
+      signedIn: true,
+      initialCounts: { matrix: thirstCountsFixture },
+    })
+    await waitFor(() => {
+      const cta = screen.getByRole('button', {
+        name: /vote to get it sooner/i,
+      }) as HTMLButtonElement
+      expect(cta.disabled).toBe(false)
+    })
+    screen.getByRole('button', { name: /vote to get it sooner/i }).click()
+    await waitFor(() =>
+      expect(store.getState().thirst.byFeatureKey.matrix?.alreadyVoted).toBe(true),
+    )
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/HelpFeedbackFragment.test.tsx
+++ b/packages/app/src/features/thirst/__tests__/HelpFeedbackFragment.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * `HelpFeedbackFragment`'s render tests, mirroring its stories (`RC-11`).
+ * Canon parity: six rows, three sections, every row genuinely inert.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { HelpFeedbackFragment } from '../HelpFeedbackFragment'
+
+afterEach(cleanup)
+
+const ROW_LABELS = [
+  'Documentation',
+  'Community Forum',
+  'Contact Support',
+  'Rate on App Store',
+  'Report a Problem',
+  'Suggest a Feature',
+]
+
+describe('HelpFeedbackFragment', () => {
+  it('renders exactly canon\'s six rows', () => {
+    render(<HelpFeedbackFragment />)
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(6)
+    expect(buttons.map((button) => button.textContent)).toEqual(ROW_LABELS)
+  })
+
+  it('groups the rows under canon\'s three section headings', () => {
+    render(<HelpFeedbackFragment />)
+    expect(screen.getByText('Resources')).toBeTruthy()
+    expect(screen.getByText('Support')).toBeTruthy()
+    expect(screen.getByText('Feedback')).toBeTruthy()
+  })
+
+  it.each(ROW_LABELS)('%s is genuinely inert — no href, no navigation target', (label) => {
+    render(<HelpFeedbackFragment />)
+    const row = screen.getByRole('button', { name: label }) as HTMLButtonElement
+    expect(row.getAttribute('href')).toBeNull()
+    expect(row.hasAttribute('aria-disabled')).toBe(false)
+    expect(row.disabled).toBe(false)
+  })
+
+  it('labels the whole surface for assistive tech', () => {
+    render(<HelpFeedbackFragment />)
+    expect(screen.getByTestId('help-feedback-surface')).toBeTruthy()
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ThirstDestinationPage.test.tsx
+++ b/packages/app/src/features/thirst/__tests__/ThirstDestinationPage.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * `ThirstDestinationPage` — mirrors `DestinationPage.test.tsx`'s own shape:
+ * what matters is that mounting one of these four routes still selects the
+ * destination in the shell slice, the same as the shared `DestinationPage`
+ * this component stands in for (see its own header for why).
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { StoreProvider } from '../../../library/StoreProvider'
+import { makeStore, stubbedThunkExtra } from '../../../library/store'
+import { ThirstDestinationPage } from '../ThirstDestinationPage'
+
+afterEach(cleanup)
+
+describe.each([
+  ['matrix', 'Priority Matrix'],
+  ['board', 'Board'],
+  ['blueprints', 'Blueprints'],
+  ['habits', 'Habits'],
+] as const)('ThirstDestinationPage kind=%s', (kind, title) => {
+  it(`selects "${kind}" on mount and renders "${title}"`, () => {
+    const store = makeStore(stubbedThunkExtra)
+    render(
+      <StoreProvider store={store}>
+        <ThirstDestinationPage kind={kind} />
+      </StoreProvider>,
+    )
+
+    expect(store.getState().main.selected.kind).toBe(kind)
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe(title)
+  })
+})
+
+describe('ThirstDestinationPage', () => {
+  it('re-mounting a different kind re-selects the shell to that destination', () => {
+    const store = makeStore(stubbedThunkExtra)
+    const { rerender } = render(
+      <StoreProvider store={store}>
+        <ThirstDestinationPage kind="matrix" />
+      </StoreProvider>,
+    )
+    expect(store.getState().main.selected.kind).toBe('matrix')
+
+    rerender(
+      <StoreProvider store={store}>
+        <ThirstDestinationPage kind="habits" />
+      </StoreProvider>,
+    )
+    expect(store.getState().main.selected.kind).toBe('habits')
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ThirstException.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstException.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ThirstExceptions,
+  isThirstException,
+  thirstExceptionCopy,
+  toThirstException,
+} from '../ThirstException'
+
+describe('ThirstExceptions factory', () => {
+  it('notSignedIn is not recoverable — no retry fixes a missing session', () => {
+    expect(ThirstExceptions.notSignedIn().recoverable).toBe(false)
+  })
+
+  it('offline is recoverable — a retry once connectivity returns can succeed', () => {
+    expect(ThirstExceptions.offline().recoverable).toBe(true)
+  })
+
+  it('unknown falls back to a generic message on an empty string', () => {
+    expect(ThirstExceptions.unknown('').message).toBe(
+      'Something went wrong while voting.',
+    )
+  })
+})
+
+describe('isThirstException', () => {
+  it('recognizes a value this module built', () => {
+    expect(isThirstException(ThirstExceptions.offline())).toBe(true)
+  })
+
+  it('rejects a plain Error', () => {
+    expect(isThirstException(new Error('boom'))).toBe(false)
+  })
+
+  it('rejects an object missing the recoverable field', () => {
+    expect(isThirstException({ kind: 'offline', message: 'x' })).toBe(false)
+  })
+})
+
+describe('toThirstException', () => {
+  it('passes an already-typed exception straight through — the Service already knew the answer', () => {
+    const original = ThirstExceptions.notSignedIn()
+    expect(toThirstException(original)).toBe(original)
+  })
+
+  it('maps a browser transport TypeError to offline', () => {
+    expect(toThirstException(new TypeError('Failed to fetch')).kind).toBe('offline')
+  })
+
+  it('degrades any other caught value to unknown, keeping its message for logs', () => {
+    const result = toThirstException(new Error('constraint violated'))
+    expect(result.kind).toBe('unknown')
+    expect(result.message).toBe('constraint violated')
+  })
+})
+
+describe('thirstExceptionCopy', () => {
+  it('derives copy from kind, never from a raw server message', () => {
+    expect(thirstExceptionCopy(ThirstExceptions.unknown('pg error 23514'))).toBe(
+      'Something went wrong while voting.',
+    )
+  })
+
+  it('reads the sign-in prompt for notSignedIn', () => {
+    expect(thirstExceptionCopy(ThirstExceptions.notSignedIn())).toBe(
+      'Sign in to vote for upcoming features.',
+    )
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ThirstFeature.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstFeature.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The slice's own extraReducers wiring — `ThirstShifters.test.ts` proves each
+ * Shifter in isolation; this proves the slice dispatches to the *right* one
+ * per thunk lifecycle action, exactly as `EarnFeature.test.ts` does for Earn.
+ */
+import { describe, expect, it } from 'vitest'
+import { THIRST_MOCK_FEATURE_KEY, thirstCountsFixture } from '../ThirstMocks'
+import { initialThirstState, thirstSlice } from '../ThirstFeature'
+import { castVoteThunk, checkVoteStateThunk, fetchCountsThunk } from '../ThirstProducer'
+
+const reduce = (
+  state: ReturnType<typeof thirstSlice.reducer>,
+  action: Parameters<typeof thirstSlice.reducer>[1],
+) => thirstSlice.reducer(state, action)
+
+const key = THIRST_MOCK_FEATURE_KEY
+
+const abortError = () => {
+  const error = new Error('Aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+describe('checkVoteStateThunk lifecycle', () => {
+  it('pending flags the check in flight', () => {
+    const next = reduce(
+      initialThirstState,
+      checkVoteStateThunk.pending('req', { featureKey: key }),
+    )
+    expect(next.byFeatureKey[key]?.isCheckingVoteState).toBe(true)
+  })
+
+  it('fulfilled(ok(true)) records already-voted', () => {
+    const next = reduce(
+      initialThirstState,
+      checkVoteStateThunk.fulfilled({ ok: true, value: true }, 'req', { featureKey: key }),
+    )
+    expect(next.byFeatureKey[key]?.alreadyVoted).toBe(true)
+  })
+
+  it('fulfilled(err(notSignedIn)) blocks voting with the typed reason', () => {
+    const next = reduce(
+      initialThirstState,
+      checkVoteStateThunk.fulfilled(
+        { ok: false, error: { kind: 'notSignedIn', message: 'x', recoverable: false } },
+        'req',
+        { featureKey: key },
+      ),
+    )
+    expect(next.byFeatureKey[key]?.voteStateException?.kind).toBe('notSignedIn')
+  })
+
+  it('rejected degrades to the defensive unknown exception', () => {
+    const next = reduce(
+      initialThirstState,
+      checkVoteStateThunk.rejected(new Error('kaboom'), 'req', { featureKey: key }),
+    )
+    expect(next.byFeatureKey[key]?.voteStateException?.kind).toBe('unknown')
+  })
+
+  it('stays silent on an aborted check', () => {
+    const started = reduce(
+      initialThirstState,
+      checkVoteStateThunk.pending('req', { featureKey: key }),
+    )
+    const next = reduce(
+      started,
+      checkVoteStateThunk.rejected(abortError(), 'req', { featureKey: key }),
+    )
+    expect(next.byFeatureKey[key]).toEqual(started.byFeatureKey[key])
+  })
+})
+
+describe('fetchCountsThunk lifecycle', () => {
+  it('pending flags the fetch in flight', () => {
+    const next = reduce(
+      initialThirstState,
+      fetchCountsThunk.pending('req', { featureKey: key }),
+    )
+    expect(next.byFeatureKey[key]?.isLoadingCounts).toBe(true)
+  })
+
+  it('fulfilled(ok(...)) installs the counts', () => {
+    const next = reduce(
+      initialThirstState,
+      fetchCountsThunk.fulfilled({ ok: true, value: thirstCountsFixture }, 'req', {
+        featureKey: key,
+      }),
+    )
+    expect(next.byFeatureKey[key]?.counts).toEqual(thirstCountsFixture)
+  })
+
+  it('fulfilled(err(...)) is non-blocking — clears the flag, leaves counts alone', () => {
+    const loaded = reduce(
+      initialThirstState,
+      fetchCountsThunk.fulfilled({ ok: true, value: thirstCountsFixture }, 'req', {
+        featureKey: key,
+      }),
+    )
+    const next = reduce(
+      loaded,
+      fetchCountsThunk.fulfilled(
+        { ok: false, error: { kind: 'offline', message: 'x', recoverable: true } },
+        'req',
+        { featureKey: key },
+      ),
+    )
+    expect(next.byFeatureKey[key]?.counts).toEqual(thirstCountsFixture)
+    expect(next.byFeatureKey[key]?.isLoadingCounts).toBe(false)
+  })
+})
+
+describe('castVoteThunk lifecycle', () => {
+  const arg = { featureKey: key, id: 'vote-1' }
+
+  it('pending flags voting in flight', () => {
+    const next = reduce(initialThirstState, castVoteThunk.pending('req', arg))
+    expect(next.byFeatureKey[key]?.isVoting).toBe(true)
+  })
+
+  it('fulfilled(ok(true)) locks to voted', () => {
+    const next = reduce(
+      initialThirstState,
+      castVoteThunk.fulfilled({ ok: true, value: true }, 'req', arg),
+    )
+    expect(next.byFeatureKey[key]?.alreadyVoted).toBe(true)
+    expect(next.byFeatureKey[key]?.counts?.perPlatform.web).toBe(1)
+  })
+
+  it('fulfilled(err(...)) surfaces the retry error and stays votable', () => {
+    const next = reduce(
+      initialThirstState,
+      castVoteThunk.fulfilled(
+        { ok: false, error: { kind: 'unknown', message: 'insert failed', recoverable: true } },
+        'req',
+        arg,
+      ),
+    )
+    expect(next.byFeatureKey[key]?.alreadyVoted).toBe(false)
+    expect(next.byFeatureKey[key]?.voteException?.message).toBe('insert failed')
+  })
+
+  it('rejected degrades to the defensive unknown exception, isVoting cleared', () => {
+    const next = reduce(
+      initialThirstState,
+      castVoteThunk.rejected(new Error('kaboom'), 'req', arg),
+    )
+    expect(next.byFeatureKey[key]?.isVoting).toBe(false)
+    expect(next.byFeatureKey[key]?.voteException?.kind).toBe('unknown')
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ThirstFeature.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstFeature.test.ts
@@ -2,6 +2,12 @@
  * The slice's own extraReducers wiring — `ThirstShifters.test.ts` proves each
  * Shifter in isolation; this proves the slice dispatches to the *right* one
  * per thunk lifecycle action, exactly as `EarnFeature.test.ts` does for Earn.
+ *
+ * `checkVoteStateThunk` and `fetchCountsThunk` fulfillments are guarded by
+ * `requestId` (`ThirstShifters.ts`'s race-safety header), so every
+ * `.fulfilled`/`.rejected` here is dispatched against a state that already
+ * saw the matching `.pending` — the same order the real thunk lifecycle
+ * always produces.
  */
 import { describe, expect, it } from 'vitest'
 import { THIRST_MOCK_FEATURE_KEY, thirstCountsFixture } from '../ThirstMocks'
@@ -14,6 +20,7 @@ const reduce = (
 ) => thirstSlice.reducer(state, action)
 
 const key = THIRST_MOCK_FEATURE_KEY
+const REQ = 'req'
 
 const abortError = () => {
   const error = new Error('Aborted')
@@ -23,27 +30,32 @@ const abortError = () => {
 
 describe('checkVoteStateThunk lifecycle', () => {
   it('pending flags the check in flight', () => {
-    const next = reduce(
-      initialThirstState,
-      checkVoteStateThunk.pending('req', { featureKey: key }),
-    )
+    const next = reduce(initialThirstState, checkVoteStateThunk.pending(REQ, { featureKey: key }))
     expect(next.byFeatureKey[key]?.isCheckingVoteState).toBe(true)
   })
 
   it('fulfilled(ok(true)) records already-voted', () => {
-    const next = reduce(
+    const started = reduce(
       initialThirstState,
-      checkVoteStateThunk.fulfilled({ ok: true, value: true }, 'req', { featureKey: key }),
+      checkVoteStateThunk.pending(REQ, { featureKey: key }),
+    )
+    const next = reduce(
+      started,
+      checkVoteStateThunk.fulfilled({ ok: true, value: true }, REQ, { featureKey: key }),
     )
     expect(next.byFeatureKey[key]?.alreadyVoted).toBe(true)
   })
 
   it('fulfilled(err(notSignedIn)) blocks voting with the typed reason', () => {
-    const next = reduce(
+    const started = reduce(
       initialThirstState,
+      checkVoteStateThunk.pending(REQ, { featureKey: key }),
+    )
+    const next = reduce(
+      started,
       checkVoteStateThunk.fulfilled(
         { ok: false, error: { kind: 'notSignedIn', message: 'x', recoverable: false } },
-        'req',
+        REQ,
         { featureKey: key },
       ),
     )
@@ -51,9 +63,13 @@ describe('checkVoteStateThunk lifecycle', () => {
   })
 
   it('rejected degrades to the defensive unknown exception', () => {
-    const next = reduce(
+    const started = reduce(
       initialThirstState,
-      checkVoteStateThunk.rejected(new Error('kaboom'), 'req', { featureKey: key }),
+      checkVoteStateThunk.pending(REQ, { featureKey: key }),
+    )
+    const next = reduce(
+      started,
+      checkVoteStateThunk.rejected(new Error('kaboom'), REQ, { featureKey: key }),
     )
     expect(next.byFeatureKey[key]?.voteStateException?.kind).toBe('unknown')
   })
@@ -61,29 +77,43 @@ describe('checkVoteStateThunk lifecycle', () => {
   it('stays silent on an aborted check', () => {
     const started = reduce(
       initialThirstState,
-      checkVoteStateThunk.pending('req', { featureKey: key }),
+      checkVoteStateThunk.pending(REQ, { featureKey: key }),
     )
     const next = reduce(
       started,
-      checkVoteStateThunk.rejected(abortError(), 'req', { featureKey: key }),
+      checkVoteStateThunk.rejected(abortError(), REQ, { featureKey: key }),
     )
     expect(next.byFeatureKey[key]).toEqual(started.byFeatureKey[key])
+  })
+
+  it('drops a fulfillment whose requestId is not the one currently tracked — superseded by a newer dispatch', () => {
+    const firstPending = reduce(
+      initialThirstState,
+      checkVoteStateThunk.pending(REQ, { featureKey: key }),
+    )
+    const secondPending = reduce(
+      firstPending,
+      checkVoteStateThunk.pending('req-2', { featureKey: key }),
+    )
+    const next = reduce(
+      secondPending,
+      checkVoteStateThunk.fulfilled({ ok: true, value: true }, REQ, { featureKey: key }),
+    )
+    expect(next).toBe(secondPending)
   })
 })
 
 describe('fetchCountsThunk lifecycle', () => {
   it('pending flags the fetch in flight', () => {
-    const next = reduce(
-      initialThirstState,
-      fetchCountsThunk.pending('req', { featureKey: key }),
-    )
+    const next = reduce(initialThirstState, fetchCountsThunk.pending(REQ, { featureKey: key }))
     expect(next.byFeatureKey[key]?.isLoadingCounts).toBe(true)
   })
 
   it('fulfilled(ok(...)) installs the counts', () => {
+    const started = reduce(initialThirstState, fetchCountsThunk.pending(REQ, { featureKey: key }))
     const next = reduce(
-      initialThirstState,
-      fetchCountsThunk.fulfilled({ ok: true, value: thirstCountsFixture }, 'req', {
+      started,
+      fetchCountsThunk.fulfilled({ ok: true, value: thirstCountsFixture }, REQ, {
         featureKey: key,
       }),
     )
@@ -91,17 +121,25 @@ describe('fetchCountsThunk lifecycle', () => {
   })
 
   it('fulfilled(err(...)) is non-blocking — clears the flag, leaves counts alone', () => {
-    const loaded = reduce(
+    const firstStarted = reduce(
       initialThirstState,
-      fetchCountsThunk.fulfilled({ ok: true, value: thirstCountsFixture }, 'req', {
+      fetchCountsThunk.pending(REQ, { featureKey: key }),
+    )
+    const loaded = reduce(
+      firstStarted,
+      fetchCountsThunk.fulfilled({ ok: true, value: thirstCountsFixture }, REQ, {
         featureKey: key,
       }),
     )
-    const next = reduce(
+    const secondStarted = reduce(
       loaded,
+      fetchCountsThunk.pending('req-2', { featureKey: key }),
+    )
+    const next = reduce(
+      secondStarted,
       fetchCountsThunk.fulfilled(
         { ok: false, error: { kind: 'offline', message: 'x', recoverable: true } },
-        'req',
+        'req-2',
         { featureKey: key },
       ),
     )
@@ -114,14 +152,14 @@ describe('castVoteThunk lifecycle', () => {
   const arg = { featureKey: key, id: 'vote-1' }
 
   it('pending flags voting in flight', () => {
-    const next = reduce(initialThirstState, castVoteThunk.pending('req', arg))
+    const next = reduce(initialThirstState, castVoteThunk.pending(REQ, arg))
     expect(next.byFeatureKey[key]?.isVoting).toBe(true)
   })
 
   it('fulfilled(ok(true)) locks to voted', () => {
     const next = reduce(
       initialThirstState,
-      castVoteThunk.fulfilled({ ok: true, value: true }, 'req', arg),
+      castVoteThunk.fulfilled({ ok: true, value: true }, REQ, arg),
     )
     expect(next.byFeatureKey[key]?.alreadyVoted).toBe(true)
     expect(next.byFeatureKey[key]?.counts?.perPlatform.web).toBe(1)
@@ -132,7 +170,7 @@ describe('castVoteThunk lifecycle', () => {
       initialThirstState,
       castVoteThunk.fulfilled(
         { ok: false, error: { kind: 'unknown', message: 'insert failed', recoverable: true } },
-        'req',
+        REQ,
         arg,
       ),
     )
@@ -143,7 +181,7 @@ describe('castVoteThunk lifecycle', () => {
   it('rejected degrades to the defensive unknown exception, isVoting cleared', () => {
     const next = reduce(
       initialThirstState,
-      castVoteThunk.rejected(new Error('kaboom'), 'req', arg),
+      castVoteThunk.rejected(new Error('kaboom'), REQ, arg),
     )
     expect(next.byFeatureKey[key]?.isVoting).toBe(false)
     expect(next.byFeatureKey[key]?.voteException?.kind).toBe('unknown')

--- a/packages/app/src/features/thirst/__tests__/ThirstMocks.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstMocks.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { thirstEntryMocks, thirstStateMocks, THIRST_MOCK_FEATURE_KEY } from '../ThirstMocks'
+import { selectThirstVoteStatus } from '../ThirstSelectors'
+import type { RootState } from '../../../library/store'
+import { initialAuthState } from '../../auth/AuthState'
+import { initialCaptureState } from '../../capture/CaptureFeature'
+import { initialDoState } from '../../do/DoFeature'
+import { initialEarnState } from '../../earn/EarnFeature'
+import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
+import { initialFindState } from '../../find/FindState'
+import { initialGreetingState } from '../../greeting/GreetingFeature'
+import { initialMainState } from '../../main/MainFeature'
+import { initialPlanState } from '../../plan/PlanState'
+import { initialPlatformState } from '../../platform/PlatformFeature'
+import { initialSessionState } from '../../session/SessionState'
+import { initialTriageState } from '../../triage/TriageFeature'
+import type { ThirstState } from '../ThirstFeature'
+
+const rootWith = (thirst: ThirstState): RootState => ({
+  greeting: initialGreetingState,
+  do: initialDoState,
+  capture: initialCaptureState,
+  triage: initialTriageState,
+  plan: initialPlanState,
+  find: initialFindState,
+  endeavorDetail: initialEndeavorDetailState,
+  earn: initialEarnState,
+  platform: initialPlatformState,
+  session: initialSessionState,
+  auth: initialAuthState,
+  main: initialMainState,
+  thirst,
+})
+
+describe('thirstEntryMocks', () => {
+  it('idle carries no counts and no exceptions', () => {
+    expect(thirstEntryMocks.idle.counts).toBeNull()
+    expect(thirstEntryMocks.idle.voteStateException).toBeNull()
+  })
+
+  it('votable has loaded counts and is not yet voted', () => {
+    expect(thirstEntryMocks.votable.counts).not.toBeNull()
+    expect(thirstEntryMocks.votable.alreadyVoted).toBe(false)
+  })
+
+  it('voted carries a bumped web tally and alreadyVoted true', () => {
+    expect(thirstEntryMocks.voted.alreadyVoted).toBe(true)
+    expect(thirstEntryMocks.voted.counts?.perPlatform.web).toBe(1)
+  })
+
+  it('unavailableSignedOut carries the notSignedIn exception', () => {
+    expect(thirstEntryMocks.unavailableSignedOut.voteStateException?.kind).toBe(
+      'notSignedIn',
+    )
+  })
+
+  it('unavailableOffline carries the offline exception with no counts loaded — offline before anything resolved', () => {
+    expect(thirstEntryMocks.unavailableOffline.voteStateException?.kind).toBe('offline')
+    expect(thirstEntryMocks.unavailableOffline.counts).toBeNull()
+  })
+
+  it('voting flags a vote in flight', () => {
+    expect(thirstEntryMocks.voting.isVoting).toBe(true)
+  })
+
+  it('voteFailed carries a retry-able vote exception and stays not-voted', () => {
+    expect(thirstEntryMocks.voteFailed.voteException).not.toBeNull()
+    expect(thirstEntryMocks.voteFailed.alreadyVoted).toBe(false)
+  })
+})
+
+describe('thirstStateMocks — composed against the real Selectors', () => {
+  it('matrixVotable resolves to a votable status through selectThirstVoteStatus', () => {
+    const state = rootWith(thirstStateMocks.matrixVotable)
+    expect(selectThirstVoteStatus(state, THIRST_MOCK_FEATURE_KEY)).toEqual({
+      kind: 'votable',
+    })
+  })
+
+  it('matrixVoted resolves to a voted status', () => {
+    const state = rootWith(thirstStateMocks.matrixVoted)
+    expect(selectThirstVoteStatus(state, THIRST_MOCK_FEATURE_KEY)).toEqual({
+      kind: 'voted',
+    })
+  })
+
+  it('empty resolves to loading before either check has started', () => {
+    const state = rootWith(thirstStateMocks.empty)
+    // No entry yet ⇒ the initial-entry defaults; a votable key that has not
+    // started checking reads as votable (nothing in flight, nothing failed).
+    expect(selectThirstVoteStatus(state, THIRST_MOCK_FEATURE_KEY)).toEqual({
+      kind: 'votable',
+    })
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ThirstMocks.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstMocks.test.ts
@@ -86,10 +86,12 @@ describe('thirstStateMocks — composed against the real Selectors', () => {
 
   it('empty resolves to loading before either check has started', () => {
     const state = rootWith(thirstStateMocks.empty)
-    // No entry yet ⇒ the initial-entry defaults; a votable key that has not
-    // started checking reads as votable (nothing in flight, nothing failed).
+    // No entry yet ⇒ the initial-entry defaults, which start
+    // `isCheckingVoteState: true` for exactly this reason (found in review:
+    // the pre-mount first paint must never read as a transiently-votable
+    // false positive for a signed-out visitor).
     expect(selectThirstVoteStatus(state, THIRST_MOCK_FEATURE_KEY)).toEqual({
-      kind: 'votable',
+      kind: 'loading',
     })
   })
 })

--- a/packages/app/src/features/thirst/__tests__/ThirstModels.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstModels.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ALL_VOTE_PLATFORMS,
+  VotePlatform,
+  bumpVotePlatform,
+  countFor,
+  emptyFeatureVoteCounts,
+  perPlatformTalliesFor,
+  votePlatformLabel,
+} from '../ThirstModels'
+
+describe('emptyFeatureVoteCounts', () => {
+  it('has a zero total and no per-platform entries', () => {
+    const counts = emptyFeatureVoteCounts('matrix')
+    expect(counts).toEqual({ featureKey: 'matrix', total: 0, perPlatform: {} })
+  })
+})
+
+describe('countFor', () => {
+  it('reads a platform present in the map', () => {
+    const counts = { featureKey: 'matrix', total: 5, perPlatform: { ios: 5 } }
+    expect(countFor(counts, VotePlatform.ios)).toBe(5)
+  })
+
+  it('reports 0 for a platform absent from the map', () => {
+    const counts = emptyFeatureVoteCounts('matrix')
+    expect(countFor(counts, VotePlatform.web)).toBe(0)
+  })
+})
+
+describe('bumpVotePlatform', () => {
+  it('increments the total and the platform tally together', () => {
+    const before = { featureKey: 'matrix', total: 10, perPlatform: { ios: 10 } }
+    const after = bumpVotePlatform(before, 'matrix', VotePlatform.web)
+    expect(after.total).toBe(11)
+    expect(after.perPlatform.web).toBe(1)
+    expect(after.perPlatform.ios).toBe(10)
+  })
+
+  it('starts from empty when counts have never loaded (a vote confirmed before any fetch)', () => {
+    const after = bumpVotePlatform(null, 'matrix', VotePlatform.web)
+    expect(after).toEqual({ featureKey: 'matrix', total: 1, perPlatform: { web: 1 } })
+  })
+
+  it('adds to an existing web tally rather than overwriting it', () => {
+    const before = { featureKey: 'matrix', total: 3, perPlatform: { web: 2, ios: 1 } }
+    const after = bumpVotePlatform(before, 'matrix', VotePlatform.web)
+    expect(after.perPlatform.web).toBe(3)
+  })
+})
+
+describe('perPlatformTalliesFor', () => {
+  it('omits platforms with zero votes', () => {
+    const counts = { featureKey: 'matrix', total: 30, perPlatform: { ios: 30, android: 0 } }
+    expect(perPlatformTalliesFor(counts)).toEqual([{ platform: 'ios', count: 30 }])
+  })
+
+  it('orders tallies by the canon platform order, not insertion order', () => {
+    const counts = {
+      featureKey: 'matrix',
+      total: 3,
+      perPlatform: { windows: 1, ios: 1, web: 1 },
+    }
+    expect(perPlatformTalliesFor(counts).map((tally) => tally.platform)).toEqual([
+      'ios',
+      'web',
+      'windows',
+    ])
+  })
+
+  it('returns an empty list for a feature with no votes at all', () => {
+    expect(perPlatformTalliesFor(emptyFeatureVoteCounts('matrix'))).toEqual([])
+  })
+})
+
+describe('votePlatformLabel', () => {
+  it.each(ALL_VOTE_PLATFORMS)('gives %s a non-empty label', (platform) => {
+    expect(votePlatformLabel(platform).length).toBeGreaterThan(0)
+  })
+
+  it('reads "Web" for the platform this app always casts', () => {
+    expect(votePlatformLabel(VotePlatform.web)).toBe('Web')
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ThirstProducer.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstProducer.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The Thirst Producers, driven through the real slice against a stubbed
+ * `thirstService` injected via `extra` (`RC-54`, `RC-35`). No suite here
+ * mocks `fetch`; the stub records every call it is given and the assertions
+ * read that record.
+ */
+import { describe, expect, it } from 'vitest'
+import { makeStore, stubbedThunkExtra, type ThunkExtra } from '../../../library/store'
+import { makeStubbedThirstService } from '../../../services/thirst/ThirstService'
+import { THIRST_MOCK_FEATURE_KEY, thirstCountsFixture } from '../ThirstMocks'
+import { castVoteThunk, checkVoteStateThunk, fetchCountsThunk } from '../ThirstProducer'
+
+const key = THIRST_MOCK_FEATURE_KEY
+
+const harness = (overrides: Partial<Parameters<typeof makeStubbedThirstService>[0]> = {}) => {
+  const thirstService = makeStubbedThirstService(overrides)
+  const extra: ThunkExtra = { ...stubbedThunkExtra, thirstService }
+  return { store: makeStore(extra), thirstService }
+}
+
+describe('checkVoteStateThunk', () => {
+  it('resolves ok(true) once the stub has recorded a vote for this signed-in user', async () => {
+    const { store } = harness({ signedIn: true, initialVotedFeatureKeys: [key] })
+    await store.dispatch(checkVoteStateThunk({ featureKey: key }))
+    expect(store.getState().thirst.byFeatureKey[key]?.alreadyVoted).toBe(true)
+  })
+
+  it('resolves ok(false) for a signed-in user who has not voted yet', async () => {
+    const { store } = harness({ signedIn: true })
+    await store.dispatch(checkVoteStateThunk({ featureKey: key }))
+    expect(store.getState().thirst.byFeatureKey[key]?.alreadyVoted).toBe(false)
+  })
+
+  it('resolves the typed notSignedIn failure when signed out — this is what blocks voting', async () => {
+    const { store } = harness({ signedIn: false })
+    await store.dispatch(checkVoteStateThunk({ featureKey: key }))
+    expect(store.getState().thirst.byFeatureKey[key]?.voteStateException?.kind).toBe(
+      'notSignedIn',
+    )
+  })
+})
+
+describe('fetchCountsThunk', () => {
+  it('installs the stub\'s seeded counts', async () => {
+    const { store } = harness({ initialCounts: { [key]: thirstCountsFixture } })
+    await store.dispatch(fetchCountsThunk({ featureKey: key }))
+    expect(store.getState().thirst.byFeatureKey[key]?.counts).toEqual(thirstCountsFixture)
+  })
+
+  it('installs an empty count for a feature with no seeded votes — public, no session needed', async () => {
+    const { store } = harness({ signedIn: false })
+    await store.dispatch(fetchCountsThunk({ featureKey: key }))
+    expect(store.getState().thirst.byFeatureKey[key]?.counts?.total).toBe(0)
+  })
+
+  it('degrades a scripted failure to the typed unknown exception, never throwing out of the thunk', async () => {
+    const { store } = harness({ failures: { fetchCounts: new Error('rpc down') } })
+    const action = await store.dispatch(fetchCountsThunk({ featureKey: key }))
+    expect(fetchCountsThunk.fulfilled.match(action)).toBe(true)
+  })
+})
+
+describe('castVoteThunk', () => {
+  it('locks to voted and bumps the web tally on success', async () => {
+    const { store } = harness({ signedIn: true })
+    await store.dispatch(castVoteThunk({ featureKey: key, id: 'vote-1' }))
+    const entry = store.getState().thirst.byFeatureKey[key]
+    expect(entry?.alreadyVoted).toBe(true)
+    expect(entry?.counts?.perPlatform.web).toBe(1)
+  })
+
+  it('resolves the typed notSignedIn failure when signed out', async () => {
+    const { store } = harness({ signedIn: false })
+    await store.dispatch(castVoteThunk({ featureKey: key, id: 'vote-1' }))
+    expect(store.getState().thirst.byFeatureKey[key]?.voteException?.kind).toBe(
+      'notSignedIn',
+    )
+  })
+
+  /**
+   * The optimistic-vote race: two taps land while the first request is still
+   * in flight (a slow network, a double-click before the CTA disables). The
+   * server's vote-once guarantee — mirrored by the stub — means only the
+   * first actually records a vote; the count must bump exactly once, never
+   * twice, however the two responses interleave.
+   */
+  it('two concurrent votes for the same feature only ever bump the count once', async () => {
+    const { store, thirstService } = harness({ signedIn: true })
+    const first = store.dispatch(castVoteThunk({ featureKey: key, id: 'vote-1' }))
+    const second = store.dispatch(castVoteThunk({ featureKey: key, id: 'vote-2' }))
+    await Promise.all([first, second])
+
+    const entry = store.getState().thirst.byFeatureKey[key]
+    expect(entry?.counts?.total).toBe(1)
+    expect(entry?.counts?.perPlatform.web).toBe(1)
+    expect(entry?.alreadyVoted).toBe(true)
+    expect(thirstService.votedFeatureKeys()).toEqual([key])
+  })
+
+  it('a second vote for an already-voted feature (server convergence) reports a no-op success', async () => {
+    const { store } = harness({ signedIn: true, initialVotedFeatureKeys: [key] })
+    const action = await store.dispatch(castVoteThunk({ featureKey: key, id: 'vote-2' }))
+    expect(castVoteThunk.fulfilled.match(action)).toBe(true)
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ThirstProducer.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstProducer.test.ts
@@ -102,4 +102,57 @@ describe('castVoteThunk', () => {
     const action = await store.dispatch(castVoteThunk({ featureKey: key, id: 'vote-2' }))
     expect(castVoteThunk.fulfilled.match(action)).toBe(true)
   })
+
+  /**
+   * The stale-counts race (found in review): a counts fetch dispatched
+   * *before* the vote, but resolving *after* it, must never overwrite the
+   * optimistic bump with its now-outdated snapshot — the scenario is a
+   * remount re-firing `fetchCountsThunk` while the vote lands before that
+   * refetch resolves. Driven end to end through real thunks: seed the
+   * counts with one ordinary fetch, then dispatch a second, deliberately
+   * delayed one that is still in flight when the (fast, real) vote resolves.
+   */
+  it('a slower in-flight counts fetch never overwrites an optimistic vote that resolves first', async () => {
+    let releaseFetch: (() => void) | undefined
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve
+    })
+    let gateNextFetch = false
+    const base = makeStubbedThirstService({
+      signedIn: true,
+      initialCounts: { [key]: thirstCountsFixture },
+    })
+    const delayedService = {
+      ...base,
+      async fetchCounts(featureKey: string, options?: { signal?: AbortSignal }) {
+        if (gateNextFetch) await fetchGate
+        return base.fetchCounts(featureKey, options)
+      },
+    }
+    const extra: ThunkExtra = { ...stubbedThunkExtra, thirstService: delayedService }
+    const store = makeStore(extra)
+
+    // The ordinary first mount's fetch — resolves immediately and installs
+    // the seeded counts.
+    await store.dispatch(fetchCountsThunk({ featureKey: key }))
+    expect(store.getState().thirst.byFeatureKey[key]?.counts?.total).toBe(
+      thirstCountsFixture.total,
+    )
+
+    // A remount re-fires the fetch; gate this one so it stays in flight.
+    gateNextFetch = true
+    const refetching = store.dispatch(fetchCountsThunk({ featureKey: key }))
+
+    await store.dispatch(castVoteThunk({ featureKey: key, id: 'vote-1' }))
+    const bumpedTotal = store.getState().thirst.byFeatureKey[key]?.counts?.total
+    expect(bumpedTotal).toBe(thirstCountsFixture.total + 1)
+
+    // The stale, gated fetch finally resolves with its pre-vote snapshot.
+    releaseFetch?.()
+    await refetching
+
+    const entry = store.getState().thirst.byFeatureKey[key]
+    expect(entry?.counts?.total).toBe(bumpedTotal)
+    expect(entry?.alreadyVoted).toBe(true)
+  })
 })

--- a/packages/app/src/features/thirst/__tests__/ThirstRegistry.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstRegistry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { isThirstVotable, thirstFeatureBlurb, thirstFeatureTitle } from '../ThirstRegistry'
+
+describe('isThirstVotable', () => {
+  it.each(['matrix', 'board', 'blueprints', 'habits'])(
+    '%s is votable — one of #35\'s four routes',
+    (key) => {
+      expect(isThirstVotable(key)).toBe(true)
+    },
+  )
+
+  it('is false for the generic Unknown fallback — no vote for a non-existent feature', () => {
+    expect(isThirstVotable('unknown')).toBe(false)
+  })
+
+  it('is false for an arbitrary unmapped key', () => {
+    expect(isThirstVotable('some-future-destination')).toBe(false)
+  })
+})
+
+describe('thirstFeatureTitle', () => {
+  it('returns the registry title for a votable key', () => {
+    expect(thirstFeatureTitle('matrix')).toBe('Priority Matrix')
+  })
+
+  it('returns null for an unmapped key, so the caller supplies its own copy', () => {
+    expect(thirstFeatureTitle('unknown')).toBeNull()
+  })
+})
+
+describe('thirstFeatureBlurb', () => {
+  it('returns the registry blurb for a votable key', () => {
+    expect(thirstFeatureBlurb('habits')).toBe(
+      'Build routines and keep your streaks alive.',
+    )
+  })
+
+  it('returns null for an unmapped key', () => {
+    expect(thirstFeatureBlurb('unknown')).toBeNull()
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ThirstRegistry.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstRegistry.test.ts
@@ -16,6 +16,13 @@ describe('isThirstVotable', () => {
   it('is false for an arbitrary unmapped key', () => {
     expect(isThirstVotable('some-future-destination')).toBe(false)
   })
+
+  it.each(['toString', 'constructor', 'hasOwnProperty', 'valueOf'])(
+    'is false for %s — an inherited Object.prototype member, not a registry key (found in review)',
+    (key) => {
+      expect(isThirstVotable(key)).toBe(false)
+    },
+  )
 })
 
 describe('thirstFeatureTitle', () => {

--- a/packages/app/src/features/thirst/__tests__/ThirstSelectors.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstSelectors.test.ts
@@ -14,7 +14,7 @@ import { initialSessionState } from '../../session/SessionState'
 import { initialTriageState } from '../../triage/TriageFeature'
 import type { RootState } from '../../../library/store'
 import { THIRST_MOCK_FEATURE_KEY, thirstCountsFixture, thirstStateMocks } from '../ThirstMocks'
-import type { ThirstState } from '../ThirstFeature'
+import { initialThirstVoteEntry, type ThirstState, type ThirstVoteEntryState } from '../ThirstFeature'
 import {
   selectThirstHasLoadedCounts,
   selectThirstPerPlatformTallies,
@@ -43,6 +43,14 @@ const rootWith = (thirst: ThirstState): RootState => ({
   thirst,
 })
 
+/** A resolved entry — the base every scenario below overrides from, so a
+ * test only ever states the fields that matter for it. */
+const resolved: ThirstVoteEntryState = { ...initialThirstVoteEntry, isCheckingVoteState: false }
+
+const stateWith = (entry: ThirstVoteEntryState): ThirstState => ({
+  byFeatureKey: { [key]: entry },
+})
+
 describe('selectThirstVoteStatus', () => {
   it('is notVotable for an unmapped dead-end regardless of stored state', () => {
     const state = rootWith(thirstStateMocks.matrixVotable)
@@ -50,36 +58,19 @@ describe('selectThirstVoteStatus', () => {
   })
 
   it('is voted once already-voted, even while counts are still loading', () => {
-    const state = rootWith({
-      byFeatureKey: {
-        [key]: {
-          counts: null,
-          alreadyVoted: true,
-          isVoting: false,
-          isLoadingCounts: true,
-          isCheckingVoteState: false,
-          voteStateException: null,
-          voteException: null,
-        },
-      },
-    })
+    const state = rootWith(
+      stateWith({ ...resolved, alreadyVoted: true, isLoadingCounts: true }),
+    )
     expect(selectThirstVoteStatus(state, key)).toEqual({ kind: 'voted' })
   })
 
   it('is unavailable with the typed copy when the auth check failed', () => {
-    const state = rootWith({
-      byFeatureKey: {
-        [key]: {
-          counts: null,
-          alreadyVoted: false,
-          isVoting: false,
-          isLoadingCounts: false,
-          isCheckingVoteState: false,
-          voteStateException: { kind: 'notSignedIn', message: 'x', recoverable: false },
-          voteException: null,
-        },
-      },
-    })
+    const state = rootWith(
+      stateWith({
+        ...resolved,
+        voteStateException: { kind: 'notSignedIn', message: 'x', recoverable: false },
+      }),
+    )
     expect(selectThirstVoteStatus(state, key)).toEqual({
       kind: 'unavailable',
       message: 'Sign in to vote for upcoming features.',
@@ -87,36 +78,22 @@ describe('selectThirstVoteStatus', () => {
   })
 
   it('is loading while the auth check is in flight, even if counts already arrived', () => {
-    const state = rootWith({
-      byFeatureKey: {
-        [key]: {
-          counts: thirstCountsFixture,
-          alreadyVoted: false,
-          isVoting: false,
-          isLoadingCounts: false,
-          isCheckingVoteState: true,
-          voteStateException: null,
-          voteException: null,
-        },
-      },
-    })
+    const state = rootWith(
+      stateWith({ ...resolved, counts: thirstCountsFixture, isCheckingVoteState: true }),
+    )
     expect(selectThirstVoteStatus(state, key)).toEqual({ kind: 'loading' })
   })
 
   it('is loading while counts are in flight and none has ever loaded', () => {
-    const state = rootWith({
-      byFeatureKey: {
-        [key]: {
-          counts: null,
-          alreadyVoted: false,
-          isVoting: false,
-          isLoadingCounts: true,
-          isCheckingVoteState: false,
-          voteStateException: null,
-          voteException: null,
-        },
-      },
-    })
+    const state = rootWith(stateWith({ ...resolved, isLoadingCounts: true }))
+    expect(selectThirstVoteStatus(state, key)).toEqual({ kind: 'loading' })
+  })
+
+  it('is loading before the check has ever started — no entry at all yet (the pre-mount first paint)', () => {
+    // No entry in `byFeatureKey` ⇒ the initial-entry defaults, which start
+    // `isCheckingVoteState: true` specifically so this reads as loading, not
+    // a transiently-votable false positive (found in review).
+    const state = rootWith(thirstStateMocks.empty)
     expect(selectThirstVoteStatus(state, key)).toEqual({ kind: 'loading' })
   })
 
@@ -152,7 +129,7 @@ describe('selectThirstPerPlatformTallies', () => {
 })
 
 describe('selectThirstVoteErrorMessage', () => {
-  it('is null while the surface has not loaded any counts yet', () => {
+  it('is null before any vote has ever been attempted', () => {
     expect(selectThirstVoteErrorMessage(rootWith(thirstStateMocks.empty), key)).toBeNull()
   })
 
@@ -163,21 +140,26 @@ describe('selectThirstVoteErrorMessage', () => {
   })
 
   it('surfaces the typed copy for a failed vote attempt', () => {
-    const state = rootWith({
-      byFeatureKey: {
-        [key]: {
-          counts: thirstCountsFixture,
-          alreadyVoted: false,
-          isVoting: false,
-          isLoadingCounts: false,
-          isCheckingVoteState: false,
-          voteStateException: null,
-          voteException: { kind: 'offline', message: 'x', recoverable: true },
-        },
-      },
-    })
+    const state = rootWith(
+      stateWith({
+        ...resolved,
+        counts: thirstCountsFixture,
+        voteException: { kind: 'offline', message: 'x', recoverable: true },
+      }),
+    )
     expect(selectThirstVoteErrorMessage(state, key)).toBe(
       'No internet connection. Please try again.',
     )
+  })
+
+  it('still surfaces a failed-vote error even when public counts never loaded (found in review: voting never depends on counts)', () => {
+    const state = rootWith(
+      stateWith({
+        ...resolved,
+        counts: null,
+        voteException: { kind: 'unknown', message: 'insert failed', recoverable: true },
+      }),
+    )
+    expect(selectThirstVoteErrorMessage(state, key)).toBe('Something went wrong while voting.')
   })
 })

--- a/packages/app/src/features/thirst/__tests__/ThirstSelectors.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstSelectors.test.ts
@@ -1,0 +1,183 @@
+/** Selectors run against a hand-built root state, never a live store (`RC-55`). */
+import { describe, expect, it } from 'vitest'
+import { initialAuthState } from '../../auth/AuthState'
+import { initialCaptureState } from '../../capture/CaptureFeature'
+import { initialDoState } from '../../do/DoFeature'
+import { initialEarnState } from '../../earn/EarnFeature'
+import { initialEndeavorDetailState } from '../../endeavorDetail/EndeavorDetailState'
+import { initialFindState } from '../../find/FindState'
+import { initialGreetingState } from '../../greeting/GreetingFeature'
+import { initialMainState } from '../../main/MainFeature'
+import { initialPlanState } from '../../plan/PlanState'
+import { initialPlatformState } from '../../platform/PlatformFeature'
+import { initialSessionState } from '../../session/SessionState'
+import { initialTriageState } from '../../triage/TriageFeature'
+import type { RootState } from '../../../library/store'
+import { THIRST_MOCK_FEATURE_KEY, thirstCountsFixture, thirstStateMocks } from '../ThirstMocks'
+import type { ThirstState } from '../ThirstFeature'
+import {
+  selectThirstHasLoadedCounts,
+  selectThirstPerPlatformTallies,
+  selectThirstTotalCount,
+  selectThirstVoteErrorMessage,
+  selectThirstVoteStatus,
+} from '../ThirstSelectors'
+
+const key = THIRST_MOCK_FEATURE_KEY
+
+const rootWith = (thirst: ThirstState): RootState => ({
+  greeting: initialGreetingState,
+  // Present only because `RootState` names every registered slice; this
+  // suite asserts nothing about the other features.
+  do: initialDoState,
+  capture: initialCaptureState,
+  triage: initialTriageState,
+  plan: initialPlanState,
+  find: initialFindState,
+  endeavorDetail: initialEndeavorDetailState,
+  earn: initialEarnState,
+  platform: initialPlatformState,
+  session: initialSessionState,
+  auth: initialAuthState,
+  main: initialMainState,
+  thirst,
+})
+
+describe('selectThirstVoteStatus', () => {
+  it('is notVotable for an unmapped dead-end regardless of stored state', () => {
+    const state = rootWith(thirstStateMocks.matrixVotable)
+    expect(selectThirstVoteStatus(state, 'unknown')).toEqual({ kind: 'notVotable' })
+  })
+
+  it('is voted once already-voted, even while counts are still loading', () => {
+    const state = rootWith({
+      byFeatureKey: {
+        [key]: {
+          counts: null,
+          alreadyVoted: true,
+          isVoting: false,
+          isLoadingCounts: true,
+          isCheckingVoteState: false,
+          voteStateException: null,
+          voteException: null,
+        },
+      },
+    })
+    expect(selectThirstVoteStatus(state, key)).toEqual({ kind: 'voted' })
+  })
+
+  it('is unavailable with the typed copy when the auth check failed', () => {
+    const state = rootWith({
+      byFeatureKey: {
+        [key]: {
+          counts: null,
+          alreadyVoted: false,
+          isVoting: false,
+          isLoadingCounts: false,
+          isCheckingVoteState: false,
+          voteStateException: { kind: 'notSignedIn', message: 'x', recoverable: false },
+          voteException: null,
+        },
+      },
+    })
+    expect(selectThirstVoteStatus(state, key)).toEqual({
+      kind: 'unavailable',
+      message: 'Sign in to vote for upcoming features.',
+    })
+  })
+
+  it('is loading while the auth check is in flight, even if counts already arrived', () => {
+    const state = rootWith({
+      byFeatureKey: {
+        [key]: {
+          counts: thirstCountsFixture,
+          alreadyVoted: false,
+          isVoting: false,
+          isLoadingCounts: false,
+          isCheckingVoteState: true,
+          voteStateException: null,
+          voteException: null,
+        },
+      },
+    })
+    expect(selectThirstVoteStatus(state, key)).toEqual({ kind: 'loading' })
+  })
+
+  it('is loading while counts are in flight and none has ever loaded', () => {
+    const state = rootWith({
+      byFeatureKey: {
+        [key]: {
+          counts: null,
+          alreadyVoted: false,
+          isVoting: false,
+          isLoadingCounts: true,
+          isCheckingVoteState: false,
+          voteStateException: null,
+          voteException: null,
+        },
+      },
+    })
+    expect(selectThirstVoteStatus(state, key)).toEqual({ kind: 'loading' })
+  })
+
+  it('is votable once both checks resolved cleanly', () => {
+    const state = rootWith(thirstStateMocks.matrixVotable)
+    expect(selectThirstVoteStatus(state, key)).toEqual({ kind: 'votable' })
+  })
+})
+
+describe('selectThirstHasLoadedCounts / selectThirstTotalCount', () => {
+  it('reports no counts loaded before any fetch resolves', () => {
+    const state = rootWith(thirstStateMocks.empty)
+    expect(selectThirstHasLoadedCounts(state, key)).toBe(false)
+    expect(selectThirstTotalCount(state, key)).toBe(0)
+  })
+
+  it('reports the loaded total once counts arrive', () => {
+    const state = rootWith(thirstStateMocks.matrixVotable)
+    expect(selectThirstHasLoadedCounts(state, key)).toBe(true)
+    expect(selectThirstTotalCount(state, key)).toBe(thirstCountsFixture.total)
+  })
+})
+
+describe('selectThirstPerPlatformTallies', () => {
+  it('is empty before counts load', () => {
+    expect(selectThirstPerPlatformTallies(rootWith(thirstStateMocks.empty), key)).toEqual([])
+  })
+
+  it('omits zero-vote platforms once counts load', () => {
+    const tallies = selectThirstPerPlatformTallies(rootWith(thirstStateMocks.matrixVotable), key)
+    expect(tallies.every((tally) => tally.count > 0)).toBe(true)
+  })
+})
+
+describe('selectThirstVoteErrorMessage', () => {
+  it('is null while the surface has not loaded any counts yet', () => {
+    expect(selectThirstVoteErrorMessage(rootWith(thirstStateMocks.empty), key)).toBeNull()
+  })
+
+  it('is null once already voted — no retry affordance to explain', () => {
+    expect(
+      selectThirstVoteErrorMessage(rootWith(thirstStateMocks.matrixVoted), key),
+    ).toBeNull()
+  })
+
+  it('surfaces the typed copy for a failed vote attempt', () => {
+    const state = rootWith({
+      byFeatureKey: {
+        [key]: {
+          counts: thirstCountsFixture,
+          alreadyVoted: false,
+          isVoting: false,
+          isLoadingCounts: false,
+          isCheckingVoteState: false,
+          voteStateException: null,
+          voteException: { kind: 'offline', message: 'x', recoverable: true },
+        },
+      },
+    })
+    expect(selectThirstVoteErrorMessage(state, key)).toBe(
+      'No internet connection. Please try again.',
+    )
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ThirstShifters.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstShifters.test.ts
@@ -1,0 +1,161 @@
+import { err, ok } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { ThirstExceptions } from '../ThirstException'
+import { initialThirstState } from '../ThirstFeature'
+import { THIRST_MOCK_FEATURE_KEY, thirstCountsFixture, thirstStateMocks } from '../ThirstMocks'
+import { VotePlatform } from '../ThirstModels'
+import {
+  withCountsFetchStarted,
+  withCountsResult,
+  withVoteResult,
+  withVoteStarted,
+  withVoteStateCheckStarted,
+  withVoteStateResult,
+} from '../ThirstShifters'
+
+const key = THIRST_MOCK_FEATURE_KEY
+
+describe('withVoteStateCheckStarted', () => {
+  it('flags the check in flight for a fresh feature key', () => {
+    const next = withVoteStateCheckStarted(initialThirstState, key)
+    expect(next.byFeatureKey[key]?.isCheckingVoteState).toBe(true)
+  })
+
+  it('clears a stale exception so a retry surfaces loading, not the old failure', () => {
+    const failed = withVoteStateResult(
+      initialThirstState,
+      key,
+      err(ThirstExceptions.offline()),
+    )
+    const next = withVoteStateCheckStarted(failed, key)
+    expect(next.byFeatureKey[key]?.voteStateException).toBeNull()
+  })
+
+  it('is a no-op on every other feature key already in state', () => {
+    const withOther = withVoteStateCheckStarted(initialThirstState, 'board')
+    const next = withVoteStateCheckStarted(withOther, key)
+    expect(next.byFeatureKey.board?.isCheckingVoteState).toBe(true)
+  })
+})
+
+describe('withVoteStateResult', () => {
+  it('records already-voted on a true success', () => {
+    const next = withVoteStateResult(initialThirstState, key, ok(true))
+    expect(next.byFeatureKey[key]).toMatchObject({
+      alreadyVoted: true,
+      isCheckingVoteState: false,
+      voteStateException: null,
+    })
+  })
+
+  it('leaves alreadyVoted false on a false success — not yet voted', () => {
+    const next = withVoteStateResult(initialThirstState, key, ok(false))
+    expect(next.byFeatureKey[key]?.alreadyVoted).toBe(false)
+  })
+
+  it('records the typed failure — this is what blocks voting', () => {
+    const next = withVoteStateResult(
+      initialThirstState,
+      key,
+      err(ThirstExceptions.notSignedIn()),
+    )
+    expect(next.byFeatureKey[key]?.voteStateException?.kind).toBe('notSignedIn')
+  })
+})
+
+describe('withCountsFetchStarted / withCountsResult', () => {
+  it('flags the fetch in flight', () => {
+    const next = withCountsFetchStarted(initialThirstState, key)
+    expect(next.byFeatureKey[key]?.isLoadingCounts).toBe(true)
+  })
+
+  it('installs the counts on success', () => {
+    const next = withCountsResult(initialThirstState, key, ok(thirstCountsFixture))
+    expect(next.byFeatureKey[key]?.counts).toEqual(thirstCountsFixture)
+    expect(next.byFeatureKey[key]?.isLoadingCounts).toBe(false)
+  })
+
+  it('a counts failure is non-blocking — leaves prior counts and voteStateException untouched', () => {
+    const loaded = withCountsResult(initialThirstState, key, ok(thirstCountsFixture))
+    const next = withCountsResult(loaded, key, err(ThirstExceptions.unknown('boom')))
+    expect(next.byFeatureKey[key]?.counts).toEqual(thirstCountsFixture)
+    expect(next.byFeatureKey[key]?.voteStateException).toBeNull()
+  })
+})
+
+describe('withVoteStarted', () => {
+  it('flags voting in flight and clears a prior retry error', () => {
+    const failed = withVoteResult(
+      initialThirstState,
+      key,
+      err(ThirstExceptions.unknown('x')),
+    )
+    const next = withVoteStarted(failed, key)
+    expect(next.byFeatureKey[key]).toMatchObject({ isVoting: true, voteException: null })
+  })
+})
+
+describe('withVoteResult — the atomic one', () => {
+  it('locks to voted and bumps the web tally on a confirmed vote', () => {
+    const votable = withCountsResult(initialThirstState, key, ok(thirstCountsFixture))
+    const next = withVoteResult(votable, key, ok(true))
+    const entry = next.byFeatureKey[key]
+    expect(entry?.alreadyVoted).toBe(true)
+    expect(entry?.isVoting).toBe(false)
+    expect(entry?.counts?.total).toBe(thirstCountsFixture.total + 1)
+    expect(entry?.counts?.perPlatform[VotePlatform.web]).toBe(1)
+  })
+
+  it('bumps the total without disturbing other platforms\' tallies', () => {
+    const votable = withCountsResult(initialThirstState, key, ok(thirstCountsFixture))
+    const next = withVoteResult(votable, key, ok(true))
+    expect(next.byFeatureKey[key]?.counts?.perPlatform[VotePlatform.ios]).toBe(
+      thirstCountsFixture.perPlatform.ios,
+    )
+  })
+
+  it('ok(false) — no vote recorded — leaves the surface votable, unchanged otherwise', () => {
+    const votable = withVoteStarted(
+      withCountsResult(initialThirstState, key, ok(thirstCountsFixture)),
+      key,
+    )
+    const next = withVoteResult(votable, key, ok(false))
+    expect(next.byFeatureKey[key]?.alreadyVoted).toBe(false)
+    expect(next.byFeatureKey[key]?.isVoting).toBe(false)
+  })
+
+  it('on failure keeps the surface votable and surfaces the retry error', () => {
+    const votable = withVoteStarted(
+      withCountsResult(initialThirstState, key, ok(thirstCountsFixture)),
+      key,
+    )
+    const next = withVoteResult(votable, key, err(ThirstExceptions.offline()))
+    expect(next.byFeatureKey[key]?.alreadyVoted).toBe(false)
+    expect(next.byFeatureKey[key]?.voteException?.kind).toBe('offline')
+  })
+
+  it('starts from empty counts when a vote is confirmed before any fetch ever landed', () => {
+    const next = withVoteResult(initialThirstState, key, ok(true))
+    expect(next.byFeatureKey[key]?.counts).toEqual({
+      featureKey: key,
+      total: 1,
+      perPlatform: { web: 1 },
+    })
+  })
+
+  it('never disturbs a sibling feature key\'s entry', () => {
+    const seeded = thirstStateMocks.matrixVotable
+    const next = withVoteResult(seeded, 'board', ok(true))
+    expect(next.byFeatureKey[key]).toEqual(seeded.byFeatureKey[key])
+  })
+
+  it('a second ok(true) for an already-voted entry does not double-bump the count — the race case', () => {
+    const votable = withCountsResult(initialThirstState, key, ok(thirstCountsFixture))
+    const votedOnce = withVoteResult(votable, key, ok(true))
+    const votedAgain = withVoteResult(votedOnce, key, ok(true))
+    expect(votedAgain.byFeatureKey[key]?.counts?.total).toBe(
+      votedOnce.byFeatureKey[key]?.counts?.total,
+    )
+    expect(votedAgain.byFeatureKey[key]?.counts?.perPlatform.web).toBe(1)
+  })
+})

--- a/packages/app/src/features/thirst/__tests__/ThirstShifters.test.ts
+++ b/packages/app/src/features/thirst/__tests__/ThirstShifters.test.ts
@@ -14,33 +14,32 @@ import {
 } from '../ThirstShifters'
 
 const key = THIRST_MOCK_FEATURE_KEY
+const REQ = 'req-1'
 
 describe('withVoteStateCheckStarted', () => {
   it('flags the check in flight for a fresh feature key', () => {
-    const next = withVoteStateCheckStarted(initialThirstState, key)
+    const next = withVoteStateCheckStarted(initialThirstState, key, REQ)
     expect(next.byFeatureKey[key]?.isCheckingVoteState).toBe(true)
   })
 
   it('clears a stale exception so a retry surfaces loading, not the old failure', () => {
-    const failed = withVoteStateResult(
-      initialThirstState,
-      key,
-      err(ThirstExceptions.offline()),
-    )
-    const next = withVoteStateCheckStarted(failed, key)
+    const started = withVoteStateCheckStarted(initialThirstState, key, REQ)
+    const failed = withVoteStateResult(started, key, REQ, err(ThirstExceptions.offline()))
+    const next = withVoteStateCheckStarted(failed, key, 'req-2')
     expect(next.byFeatureKey[key]?.voteStateException).toBeNull()
   })
 
   it('is a no-op on every other feature key already in state', () => {
-    const withOther = withVoteStateCheckStarted(initialThirstState, 'board')
-    const next = withVoteStateCheckStarted(withOther, key)
+    const withOther = withVoteStateCheckStarted(initialThirstState, 'board', REQ)
+    const next = withVoteStateCheckStarted(withOther, key, REQ)
     expect(next.byFeatureKey.board?.isCheckingVoteState).toBe(true)
   })
 })
 
 describe('withVoteStateResult', () => {
   it('records already-voted on a true success', () => {
-    const next = withVoteStateResult(initialThirstState, key, ok(true))
+    const started = withVoteStateCheckStarted(initialThirstState, key, REQ)
+    const next = withVoteStateResult(started, key, REQ, ok(true))
     expect(next.byFeatureKey[key]).toMatchObject({
       alreadyVoted: true,
       isCheckingVoteState: false,
@@ -49,47 +48,102 @@ describe('withVoteStateResult', () => {
   })
 
   it('leaves alreadyVoted false on a false success — not yet voted', () => {
-    const next = withVoteStateResult(initialThirstState, key, ok(false))
+    const started = withVoteStateCheckStarted(initialThirstState, key, REQ)
+    const next = withVoteStateResult(started, key, REQ, ok(false))
     expect(next.byFeatureKey[key]?.alreadyVoted).toBe(false)
   })
 
   it('records the typed failure — this is what blocks voting', () => {
-    const next = withVoteStateResult(
-      initialThirstState,
-      key,
-      err(ThirstExceptions.notSignedIn()),
-    )
+    const started = withVoteStateCheckStarted(initialThirstState, key, REQ)
+    const next = withVoteStateResult(started, key, REQ, err(ThirstExceptions.notSignedIn()))
     expect(next.byFeatureKey[key]?.voteStateException?.kind).toBe('notSignedIn')
+  })
+
+  it('drops a response whose requestId does not match the currently-tracked one — superseded by a newer dispatch', () => {
+    const started = withVoteStateCheckStarted(initialThirstState, key, REQ)
+    const restarted = withVoteStateCheckStarted(started, key, 'req-2')
+    // The OLD request's late response arrives after a newer one was dispatched.
+    const next = withVoteStateResult(restarted, key, REQ, ok(true))
+    expect(next).toBe(restarted)
+  })
+
+  it('a response that predates a vote confirmed while it was in flight never reverts alreadyVoted', () => {
+    const started = withVoteStateCheckStarted(initialThirstState, key, REQ)
+    const votedWhileChecking = withVoteResult(started, key, ok(true))
+    // The check's own (now-stale) "not yet voted" answer lands after.
+    const next = withVoteStateResult(votedWhileChecking, key, REQ, ok(false))
+    expect(next.byFeatureKey[key]?.alreadyVoted).toBe(true)
+    expect(next.byFeatureKey[key]?.isCheckingVoteState).toBe(false)
   })
 })
 
 describe('withCountsFetchStarted / withCountsResult', () => {
   it('flags the fetch in flight', () => {
-    const next = withCountsFetchStarted(initialThirstState, key)
+    const next = withCountsFetchStarted(initialThirstState, key, REQ)
     expect(next.byFeatureKey[key]?.isLoadingCounts).toBe(true)
   })
 
   it('installs the counts on success', () => {
-    const next = withCountsResult(initialThirstState, key, ok(thirstCountsFixture))
+    const started = withCountsFetchStarted(initialThirstState, key, REQ)
+    const next = withCountsResult(started, key, REQ, ok(thirstCountsFixture))
     expect(next.byFeatureKey[key]?.counts).toEqual(thirstCountsFixture)
     expect(next.byFeatureKey[key]?.isLoadingCounts).toBe(false)
   })
 
   it('a counts failure is non-blocking — leaves prior counts and voteStateException untouched', () => {
-    const loaded = withCountsResult(initialThirstState, key, ok(thirstCountsFixture))
-    const next = withCountsResult(loaded, key, err(ThirstExceptions.unknown('boom')))
+    const loaded = withCountsResult(
+      withCountsFetchStarted(initialThirstState, key, REQ),
+      key,
+      REQ,
+      ok(thirstCountsFixture),
+    )
+    const reFetching = withCountsFetchStarted(loaded, key, 'req-2')
+    const next = withCountsResult(
+      reFetching,
+      key,
+      'req-2',
+      err(ThirstExceptions.unknown('boom')),
+    )
     expect(next.byFeatureKey[key]?.counts).toEqual(thirstCountsFixture)
     expect(next.byFeatureKey[key]?.voteStateException).toBeNull()
+  })
+
+  it('drops a response whose requestId does not match the currently-tracked one — a stale fetch from before a remount', () => {
+    const started = withCountsFetchStarted(initialThirstState, key, REQ)
+    const remounted = withCountsFetchStarted(started, key, 'req-2')
+    const next = withCountsResult(remounted, key, REQ, ok(thirstCountsFixture))
+    expect(next).toBe(remounted)
+  })
+
+  it('a response that predates a vote confirmed while it was in flight never overwrites the optimistic bump', () => {
+    const votable = withCountsResult(
+      withCountsFetchStarted(initialThirstState, key, REQ),
+      key,
+      REQ,
+      ok(thirstCountsFixture),
+    )
+    const refetching = withCountsFetchStarted(votable, key, 'req-2')
+    const votedWhileFetching = withVoteResult(refetching, key, ok(true))
+    const bumpedTotal = votedWhileFetching.byFeatureKey[key]?.counts?.total
+    // The slower fetch (dispatched before the vote) finally resolves with
+    // its stale, pre-vote snapshot.
+    const next = withCountsResult(votedWhileFetching, key, 'req-2', ok(thirstCountsFixture))
+    expect(next.byFeatureKey[key]?.counts?.total).toBe(bumpedTotal)
+    expect(next.byFeatureKey[key]?.isLoadingCounts).toBe(false)
+  })
+
+  it('a fetch dispatched AFTER the vote confirms is trusted normally — its answer is genuinely fresher', () => {
+    const votedFirst = withVoteResult(initialThirstState, key, ok(true))
+    const fetchedAfter = withCountsFetchStarted(votedFirst, key, REQ)
+    const serverConfirmedTotal = { ...thirstCountsFixture, total: 99 }
+    const next = withCountsResult(fetchedAfter, key, REQ, ok(serverConfirmedTotal))
+    expect(next.byFeatureKey[key]?.counts?.total).toBe(99)
   })
 })
 
 describe('withVoteStarted', () => {
   it('flags voting in flight and clears a prior retry error', () => {
-    const failed = withVoteResult(
-      initialThirstState,
-      key,
-      err(ThirstExceptions.unknown('x')),
-    )
+    const failed = withVoteResult(initialThirstState, key, err(ThirstExceptions.unknown('x')))
     const next = withVoteStarted(failed, key)
     expect(next.byFeatureKey[key]).toMatchObject({ isVoting: true, voteException: null })
   })
@@ -97,7 +151,12 @@ describe('withVoteStarted', () => {
 
 describe('withVoteResult — the atomic one', () => {
   it('locks to voted and bumps the web tally on a confirmed vote', () => {
-    const votable = withCountsResult(initialThirstState, key, ok(thirstCountsFixture))
+    const votable = withCountsResult(
+      withCountsFetchStarted(initialThirstState, key, REQ),
+      key,
+      REQ,
+      ok(thirstCountsFixture),
+    )
     const next = withVoteResult(votable, key, ok(true))
     const entry = next.byFeatureKey[key]
     expect(entry?.alreadyVoted).toBe(true)
@@ -106,8 +165,18 @@ describe('withVoteResult — the atomic one', () => {
     expect(entry?.counts?.perPlatform[VotePlatform.web]).toBe(1)
   })
 
+  it('bumps voteEpoch so an in-flight fetch/check dispatched before it recognizes its own stale response', () => {
+    const next = withVoteResult(initialThirstState, key, ok(true))
+    expect(next.byFeatureKey[key]?.voteEpoch).toBe(1)
+  })
+
   it('bumps the total without disturbing other platforms\' tallies', () => {
-    const votable = withCountsResult(initialThirstState, key, ok(thirstCountsFixture))
+    const votable = withCountsResult(
+      withCountsFetchStarted(initialThirstState, key, REQ),
+      key,
+      REQ,
+      ok(thirstCountsFixture),
+    )
     const next = withVoteResult(votable, key, ok(true))
     expect(next.byFeatureKey[key]?.counts?.perPlatform[VotePlatform.ios]).toBe(
       thirstCountsFixture.perPlatform.ios,
@@ -116,7 +185,12 @@ describe('withVoteResult — the atomic one', () => {
 
   it('ok(false) — no vote recorded — leaves the surface votable, unchanged otherwise', () => {
     const votable = withVoteStarted(
-      withCountsResult(initialThirstState, key, ok(thirstCountsFixture)),
+      withCountsResult(
+        withCountsFetchStarted(initialThirstState, key, REQ),
+        key,
+        REQ,
+        ok(thirstCountsFixture),
+      ),
       key,
     )
     const next = withVoteResult(votable, key, ok(false))
@@ -126,7 +200,12 @@ describe('withVoteResult — the atomic one', () => {
 
   it('on failure keeps the surface votable and surfaces the retry error', () => {
     const votable = withVoteStarted(
-      withCountsResult(initialThirstState, key, ok(thirstCountsFixture)),
+      withCountsResult(
+        withCountsFetchStarted(initialThirstState, key, REQ),
+        key,
+        REQ,
+        ok(thirstCountsFixture),
+      ),
       key,
     )
     const next = withVoteResult(votable, key, err(ThirstExceptions.offline()))
@@ -150,7 +229,12 @@ describe('withVoteResult — the atomic one', () => {
   })
 
   it('a second ok(true) for an already-voted entry does not double-bump the count — the race case', () => {
-    const votable = withCountsResult(initialThirstState, key, ok(thirstCountsFixture))
+    const votable = withCountsResult(
+      withCountsFetchStarted(initialThirstState, key, REQ),
+      key,
+      REQ,
+      ok(thirstCountsFixture),
+    )
     const votedOnce = withVoteResult(votable, key, ok(true))
     const votedAgain = withVoteResult(votedOnce, key, ok(true))
     expect(votedAgain.byFeatureKey[key]?.counts?.total).toBe(

--- a/packages/app/src/features/thirst/index.ts
+++ b/packages/app/src/features/thirst/index.ts
@@ -1,0 +1,17 @@
+/**
+ * The Thirst feature's public surface — a pure re-export barrel, consumed by
+ * `apps/web`'s route wrappers via the `@kro/app/thirst` subpath
+ * (`packages/app/package.json`).
+ */
+export * from './ComingSoonFragment'
+export * from './ComingSoonPage'
+export * from './HelpFeedbackFragment'
+export * from './ThirstDestinationPage'
+export * from './ThirstException'
+export * from './ThirstFeature'
+export * from './ThirstMocks'
+export * from './ThirstModels'
+export * from './ThirstProducer'
+export * from './ThirstRegistry'
+export * from './ThirstSelectors'
+export * from './ThirstShifters'

--- a/packages/app/src/features/triage/__tests__/TriageSelectors.test.ts
+++ b/packages/app/src/features/triage/__tests__/TriageSelectors.test.ts
@@ -57,6 +57,7 @@ import {
 import { triageSessionSeed, triageEndeavorFixtures } from '../TriageMocks'
 import { initialTriageState } from '../TriageFeature'
 import { initialMainState } from '../../main/MainFeature'
+import { initialThirstState } from '../../thirst/ThirstFeature'
 
 /** Selectors run against a hand-built root state, never a live store. */
 const rootWith = (slice: TriageState): RootState => ({
@@ -75,6 +76,7 @@ const rootWith = (slice: TriageState): RootState => ({
   session: initialSessionState,
   auth: initialAuthState,
   main: initialMainState,
+  thirst: initialThirstState,
 })
 
 describe('lifecycle selectors', () => {

--- a/packages/app/src/library/store.ts
+++ b/packages/app/src/library/store.ts
@@ -32,6 +32,7 @@ import { mainSlice } from '../features/main/MainFeature'
 import { planSlice } from '../features/plan/PlanFeature'
 import { platformSlice } from '../features/platform/PlatformFeature'
 import { sessionSlice } from '../features/session/SessionFeature'
+import { thirstSlice } from '../features/thirst/ThirstFeature'
 import { triageSlice } from '../features/triage/TriageFeature'
 import {
   type AuthService,
@@ -90,6 +91,11 @@ import {
   makeLiveSettingsSyncService,
   stubbedSettingsSyncService,
 } from '../services/sync/SettingsSyncService'
+import {
+  type ThirstService,
+  makeLiveThirstService,
+  stubbedThirstService,
+} from '../services/thirst/ThirstService'
 
 /**
  * Every injectable Service in the app, in one closed manifest. A Producer reads
@@ -176,6 +182,14 @@ export interface ThunkExtra {
    * records the same reasoning from the other side.
    */
   readonly googleCalendarPlanHost: PlanHost
+  /**
+   * Thirst feature-demand voting (#35) — reads/writes the canon
+   * `public.votes`/`public.features` tables + the `get_feature_vote_counts`
+   * RPC directly, tagged `web`. Behind `SupabaseClientProvider` the same way
+   * `authService`/`settingsSync` are: an unconfigured project degrades to
+   * "no counts, sign-in required to vote" rather than a crash.
+   */
+  readonly thirstService: ThirstService
 }
 
 /**
@@ -221,6 +235,7 @@ export const liveThunkExtra: ThunkExtra = {
   navigation: stubbedNavigationService,
   googleCalendar: liveGoogleCalendar,
   googleCalendarPlanHost: makeGoogleCalendarPlanHost(liveGoogleCalendar),
+  thirstService: makeLiveThirstService({ clientProvider: liveSupabaseClientProvider }),
 }
 
 /**
@@ -257,6 +272,11 @@ export const stubbedThunkExtra: ThunkExtra = {
   // its own binding with `makeStubbedGoogleCalendarService({ connection: … })`.
   googleCalendar: stubbedGoogleCalendarService,
   googleCalendarPlanHost: makeGoogleCalendarPlanHost(stubbedGoogleCalendarService),
+  // Signed out, no counts anywhere — a suite that asserts on shipping
+  // behaviour sees the same "sign in to vote" state a fresh visitor does. A
+  // suite that wants a votable/voted surface builds its own binding with
+  // `makeStubbedThirstService({ signedIn: true, ... })`.
+  thirstService: stubbedThirstService,
 }
 
 export const makeStore = (extra: ThunkExtra = liveThunkExtra) =>
@@ -274,6 +294,7 @@ export const makeStore = (extra: ThunkExtra = liveThunkExtra) =>
       session: sessionSlice.reducer,
       auth: authSlice.reducer,
       main: mainSlice.reducer,
+      thirst: thirstSlice.reducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({

--- a/packages/app/src/services/thirst/ThirstService.ts
+++ b/packages/app/src/services/thirst/ThirstService.ts
@@ -1,0 +1,276 @@
+/**
+ * `ThirstService` — port of KroApple's `ThirstClient.swift` (epic #83,
+ * sub-issue #87) to the web, tagged with the `web` `VotePlatform`.
+ *
+ * ## The `web` platform tag needs no KroApple-side change
+ *
+ * The issue that scoped this PR asked to check the canon migration's
+ * platform enum and name any needed KroApple-side addition. Checked against
+ * `zheref/KroApple@2117efc` (re-fetched at build time; the epic's pin was
+ * `2c1ee45`, an ancestor with no Thirst-relevant diff):
+ *
+ *   - `supabase/migrations/20260607000000_thirst_backend.sql`'s
+ *     `votes_platform_check` constraint already accepts
+ *     `'ios' | 'android' | 'web' | 'windows'`.
+ *   - `KroCore/Model/VotePlatform.swift`'s client-side enum already declares
+ *     `case web`.
+ *
+ * So **no KroApple-side enum addition is needed** for this PR — the
+ * assumption in the issue's "Note" does not hold for the canon this repo
+ * pinned. `castVote` below writes `platform: 'web'` directly against the
+ * live constraint; `ThirstService.test.ts`'s "unexpected platform-check
+ * failure" case still proves the failure-shape handling exists (a rejected
+ * insert degrades to a typed `unknown` exception, never a crash) for the
+ * hypothetical the issue asked about, using the stub's scriptable failure —
+ * see that test for the citation.
+ *
+ * ## No local vote-once cache
+ *
+ * Canon's `ThirstLocalCache` (a `UserDefaults` dictionary) exists so a
+ * repeat tap is a no-op without a round-trip. This port skips it: the
+ * server's `unique(feature_key, user_id)` constraint plus `hasVoted` already
+ * make a repeat vote a no-op (`castVote`'s `23505` branch below), and a
+ * second, browser-local cache would be new state to keep honest for no
+ * behavior this issue's acceptance criteria ask for.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { ThirstExceptions, toThirstException } from '../../features/thirst/ThirstException'
+import {
+  type FeatureVoteCounts,
+  type VotePlatform,
+  emptyFeatureVoteCounts,
+} from '../../features/thirst/ThirstModels'
+import { thirstFeatureTitle } from '../../features/thirst/ThirstRegistry'
+import type { SupabaseClientProvider } from '../supabase/SupabaseClientProvider'
+
+const VOTES_TABLE = 'votes'
+const VOTE_COUNTS_RPC = 'get_feature_vote_counts'
+/** This app always casts from the web — canon's own accepted enum value. */
+const WEB_VOTE_PLATFORM: VotePlatform = 'web'
+/** Postgres `unique_violation` — the server's own vote-once guarantee
+ * (`votes_feature_user_unique`). */
+const UNIQUE_VIOLATION = '23505'
+
+export interface ThirstServiceOperationOptions {
+  readonly signal?: AbortSignal
+}
+
+export interface ThirstService {
+  /** Casts the signed-in user's vote for `featureKey`, tagged `web`. `id` is
+   * caller-minted (`RC-4`: a Service reads no random source — the Page
+   * mints it). A vote already on the server (unique-constraint conflict)
+   * converges quietly, matching canon's `castVote`. */
+  castVote(
+    featureKey: string,
+    id: string,
+    options?: ThirstServiceOperationOptions,
+  ): Promise<void>
+  /** Whether the signed-in user has already voted for `featureKey`. */
+  hasVoted(
+    featureKey: string,
+    options?: ThirstServiceOperationOptions,
+  ): Promise<boolean>
+  /** Total + per-platform counts. Public — no session required. */
+  fetchCounts(
+    featureKey: string,
+    options?: ThirstServiceOperationOptions,
+  ): Promise<FeatureVoteCounts>
+}
+
+/** The `get_feature_vote_counts` RPC's row shape — wire, snake_case, exactly
+ * as PostgREST returns it. */
+interface VoteCountRow {
+  readonly feature_key: string
+  readonly platform: string
+  readonly vote_count: number
+  readonly total_count: number
+}
+
+const isVotePlatform = (value: string): value is VotePlatform =>
+  value === 'ios' || value === 'android' || value === 'web' || value === 'windows'
+
+const foldVoteCountRows = (
+  featureKey: string,
+  rows: readonly VoteCountRow[],
+): FeatureVoteCounts => {
+  if (rows.length === 0) return emptyFeatureVoteCounts(featureKey)
+  const perPlatform: Partial<Record<VotePlatform, number>> = {}
+  for (const row of rows) {
+    if (!isVotePlatform(row.platform)) continue
+    perPlatform[row.platform] = (perPlatform[row.platform] ?? 0) + row.vote_count
+  }
+  return { featureKey, total: rows[0]?.total_count ?? 0, perPlatform }
+}
+
+// ---------------------------------------------------------------------------
+// Live
+// ---------------------------------------------------------------------------
+
+export interface LiveThirstServiceOptions {
+  readonly clientProvider: SupabaseClientProvider
+}
+
+/**
+ * A signed-in client, or the typed "sign in to vote" failure — canon's
+ * `guard let currentUser else { throw .notSignedIn }`, widened to also cover
+ * an unconfigured project: with no client at all there is no session to
+ * have, which reads identically to this surface.
+ */
+const requireSignedInClient = async (
+  provider: SupabaseClientProvider,
+): Promise<{ readonly client: SupabaseClient; readonly username: string }> => {
+  const client = provider.client()
+  if (client === null) throw ThirstExceptions.notSignedIn()
+  const { data, error } = await client.auth.getSession()
+  if (error !== null) throw error
+  const user = data.session?.user
+  if (user === undefined) throw ThirstExceptions.notSignedIn()
+  return { client, username: user.email ?? user.id }
+}
+
+export const makeLiveThirstService = (options: LiveThirstServiceOptions): ThirstService => {
+  const { clientProvider } = options
+
+  return {
+    async castVote(featureKey, id) {
+      const { client, username } = await requireSignedInClient(clientProvider)
+      try {
+        const { error } = await client.from(VOTES_TABLE).insert({
+          id,
+          feature_title: thirstFeatureTitle(featureKey) ?? featureKey,
+          feature_key: featureKey,
+          username,
+          platform: WEB_VOTE_PLATFORM,
+        })
+        if (error !== null) {
+          if (error.code === UNIQUE_VIOLATION) return
+          throw error
+        }
+      } catch (error) {
+        throw toThirstException(error)
+      }
+    },
+
+    async hasVoted(featureKey) {
+      const { client } = await requireSignedInClient(clientProvider)
+      try {
+        // RLS scopes SELECT to the caller's own rows (`votes_select_self`),
+        // so any match means the current user has voted.
+        const { data, error } = await client
+          .from(VOTES_TABLE)
+          .select('id')
+          .eq('feature_key', featureKey)
+        if (error !== null) throw error
+        return (data ?? []).length > 0
+      } catch (error) {
+        throw toThirstException(error)
+      }
+    },
+
+    async fetchCounts(featureKey) {
+      const client = clientProvider.client()
+      // Public data; an unconfigured project simply has none to show — not
+      // a failure (mirrors `AuthService.signOut`'s "no client, nothing to
+      // do" shape).
+      if (client === null) return emptyFeatureVoteCounts(featureKey)
+      try {
+        const { data, error } = await client.rpc(VOTE_COUNTS_RPC, {
+          p_feature_key: featureKey,
+        })
+        if (error !== null) throw error
+        return foldVoteCountRows(featureKey, (data ?? []) as readonly VoteCountRow[])
+      } catch (error) {
+        throw toThirstException(error)
+      }
+    },
+  }
+}
+
+// `library/store.ts` builds the live binding itself — `makeLiveThirstService({
+// clientProvider: liveSupabaseClientProvider })` — the same shape
+// `makeLiveAuthService` uses, rather than this module exporting a
+// module-scoped singleton (which would have to guess which provider to
+// close over).
+
+// ---------------------------------------------------------------------------
+// Stub
+// ---------------------------------------------------------------------------
+
+export type ThirstOperation = 'castVote' | 'hasVoted' | 'fetchCounts'
+
+export interface StubbedThirstServiceOptions {
+  /** Whether the stub reports a signed-in session. Defaults to `false` — the
+   * honest default for a build with no project, matching
+   * `stubbedAuthService`. */
+  readonly signedIn?: boolean
+  readonly initialCounts?: Readonly<Record<string, FeatureVoteCounts>>
+  readonly initialVotedFeatureKeys?: readonly string[]
+  /** Operations that should fail, and with what. */
+  readonly failures?: Partial<Record<ThirstOperation, unknown>>
+}
+
+/** A stub that also records what was asked of it. */
+export interface StubbedThirstService extends ThirstService {
+  /** Every operation invoked, in order — the spy half of the double. */
+  operations(): readonly ThirstOperation[]
+  votedFeatureKeys(): readonly string[]
+}
+
+/**
+ * The test/preview binding (`RC-33`).
+ *
+ * A real little state machine, not a bag of constants: `castVote` records
+ * the id and bumps the `web` tally, `hasVoted` reports it back, so the
+ * slice's arms are driven end to end without a network.
+ */
+export const makeStubbedThirstService = (
+  options: StubbedThirstServiceOptions = {},
+): StubbedThirstService => {
+  const signedIn = options.signedIn ?? false
+  const voted = new Set(options.initialVotedFeatureKeys ?? [])
+  const counts = new Map<string, FeatureVoteCounts>(
+    Object.entries(options.initialCounts ?? {}),
+  )
+  const invoked: ThirstOperation[] = []
+
+  const record = (operation: ThirstOperation): void => {
+    invoked.push(operation)
+    const failure = options.failures?.[operation]
+    if (failure !== undefined) throw failure
+  }
+
+  return {
+    operations: () => [...invoked],
+    votedFeatureKeys: () => [...voted],
+
+    async castVote(featureKey, _id) {
+      record('castVote')
+      if (!signedIn) throw ThirstExceptions.notSignedIn()
+      if (voted.has(featureKey)) return
+      voted.add(featureKey)
+      const current = counts.get(featureKey) ?? emptyFeatureVoteCounts(featureKey)
+      counts.set(featureKey, {
+        ...current,
+        total: current.total + 1,
+        perPlatform: {
+          ...current.perPlatform,
+          [WEB_VOTE_PLATFORM]: (current.perPlatform[WEB_VOTE_PLATFORM] ?? 0) + 1,
+        },
+      })
+    },
+
+    async hasVoted(featureKey) {
+      record('hasVoted')
+      if (!signedIn) throw ThirstExceptions.notSignedIn()
+      return voted.has(featureKey)
+    },
+
+    async fetchCounts(featureKey) {
+      record('fetchCounts')
+      return counts.get(featureKey) ?? emptyFeatureVoteCounts(featureKey)
+    },
+  }
+}
+
+/** The default stub — signed out, no counts anywhere. */
+export const stubbedThirstService: ThirstService = makeStubbedThirstService()

--- a/packages/app/src/services/thirst/ThirstService.ts
+++ b/packages/app/src/services/thirst/ThirstService.ts
@@ -122,7 +122,10 @@ const requireSignedInClient = async (
   const client = provider.client()
   if (client === null) throw ThirstExceptions.notSignedIn()
   const { data, error } = await client.auth.getSession()
-  if (error !== null) throw error
+  // `getSession()` failing is not itself "no session" — it is a transport/
+  // server failure, so it goes through the same mapping every other caught
+  // error does rather than escaping as a raw Supabase error.
+  if (error !== null) throw toThirstException(error)
   const user = data.session?.user
   if (user === undefined) throw ThirstExceptions.notSignedIn()
   return { client, username: user.email ?? user.id }
@@ -132,16 +135,18 @@ export const makeLiveThirstService = (options: LiveThirstServiceOptions): Thirst
   const { clientProvider } = options
 
   return {
-    async castVote(featureKey, id) {
+    async castVote(featureKey, id, callOptions) {
       const { client, username } = await requireSignedInClient(clientProvider)
       try {
-        const { error } = await client.from(VOTES_TABLE).insert({
+        let query = client.from(VOTES_TABLE).insert({
           id,
           feature_title: thirstFeatureTitle(featureKey) ?? featureKey,
           feature_key: featureKey,
           username,
           platform: WEB_VOTE_PLATFORM,
         })
+        if (callOptions?.signal !== undefined) query = query.abortSignal(callOptions.signal)
+        const { error } = await query
         if (error !== null) {
           if (error.code === UNIQUE_VIOLATION) return
           throw error
@@ -151,15 +156,14 @@ export const makeLiveThirstService = (options: LiveThirstServiceOptions): Thirst
       }
     },
 
-    async hasVoted(featureKey) {
+    async hasVoted(featureKey, callOptions) {
       const { client } = await requireSignedInClient(clientProvider)
       try {
         // RLS scopes SELECT to the caller's own rows (`votes_select_self`),
         // so any match means the current user has voted.
-        const { data, error } = await client
-          .from(VOTES_TABLE)
-          .select('id')
-          .eq('feature_key', featureKey)
+        let query = client.from(VOTES_TABLE).select('id').eq('feature_key', featureKey)
+        if (callOptions?.signal !== undefined) query = query.abortSignal(callOptions.signal)
+        const { data, error } = await query
         if (error !== null) throw error
         return (data ?? []).length > 0
       } catch (error) {
@@ -167,16 +171,16 @@ export const makeLiveThirstService = (options: LiveThirstServiceOptions): Thirst
       }
     },
 
-    async fetchCounts(featureKey) {
+    async fetchCounts(featureKey, callOptions) {
       const client = clientProvider.client()
       // Public data; an unconfigured project simply has none to show — not
       // a failure (mirrors `AuthService.signOut`'s "no client, nothing to
       // do" shape).
       if (client === null) return emptyFeatureVoteCounts(featureKey)
       try {
-        const { data, error } = await client.rpc(VOTE_COUNTS_RPC, {
-          p_feature_key: featureKey,
-        })
+        let query = client.rpc(VOTE_COUNTS_RPC, { p_feature_key: featureKey })
+        if (callOptions?.signal !== undefined) query = query.abortSignal(callOptions.signal)
+        const { data, error } = await query
         if (error !== null) throw error
         return foldVoteCountRows(featureKey, (data ?? []) as readonly VoteCountRow[])
       } catch (error) {

--- a/packages/app/src/services/thirst/__tests__/ThirstService.test.ts
+++ b/packages/app/src/services/thirst/__tests__/ThirstService.test.ts
@@ -123,6 +123,35 @@ interface FakeClientConfig {
   readonly selectError?: { readonly message: string } | null
   readonly rpcRows?: readonly Record<string, unknown>[]
   readonly rpcError?: { readonly message: string } | null
+  /** Called with whatever `AbortSignal` a query's `.abortSignal(...)` chain
+   * was given — the way to prove signal forwarding actually reached the
+   * query builder, not just that the Service accepted the option. */
+  readonly onAbortSignal?: (signal: AbortSignal) => void
+}
+
+/**
+ * A minimal thenable + chainable double for a Postgrest/RPC query builder:
+ * `await` resolves it (matching how the live Service awaits the builder
+ * directly), and `.abortSignal(signal)` is chainable and observable, the
+ * same shape real supabase-js query builders expose.
+ */
+const fakeQuery = (
+  result: { readonly data?: unknown; readonly error: unknown },
+  onAbortSignal?: (signal: AbortSignal) => void,
+) => {
+  const query = {
+    abortSignal(signal: AbortSignal) {
+      onAbortSignal?.(signal)
+      return query
+    },
+    then(
+      resolve: (value: typeof result) => void,
+      reject?: (reason: unknown) => void,
+    ) {
+      return Promise.resolve(result).then(resolve, reject)
+    },
+  }
+  return query
 }
 
 const fakeClient = (config: FakeClientConfig): SupabaseClient => {
@@ -134,21 +163,23 @@ const fakeClient = (config: FakeClientConfig): SupabaseClient => {
       }),
     },
     from: (_table: string) => ({
-      insert: async (payload: unknown) => {
+      insert: (payload: unknown) => {
         config.onInsert?.(payload)
-        return { error: config.insertError ?? null }
+        return fakeQuery({ error: config.insertError ?? null }, config.onAbortSignal)
       },
       select: (_columns: string) => ({
-        eq: async (_column: string, _value: string) => ({
-          data: config.selectRows ?? [],
-          error: config.selectError ?? null,
-        }),
+        eq: (_column: string, _value: string) =>
+          fakeQuery(
+            { data: config.selectRows ?? [], error: config.selectError ?? null },
+            config.onAbortSignal,
+          ),
       }),
     }),
-    rpc: async (_fn: string, _params: Record<string, unknown>) => ({
-      data: config.rpcRows ?? [],
-      error: config.rpcError ?? null,
-    }),
+    rpc: (_fn: string, _params: Record<string, unknown>) =>
+      fakeQuery(
+        { data: config.rpcRows ?? [], error: config.rpcError ?? null },
+        config.onAbortSignal,
+      ),
   }
   return client as unknown as SupabaseClient
 }
@@ -159,6 +190,24 @@ const providerFor = (client: SupabaseClient): SupabaseClientProvider => ({
 })
 
 const SESSION = { user: { id: 'user-1', email: 'ada@example.com' } }
+
+describe('requireSignedInClient — getSession() failing is a transport error, not "signed out"', () => {
+  it('maps a getSession() failure to a typed exception rather than throwing the raw Supabase error', async () => {
+    const client = {
+      auth: {
+        getSession: async () => ({
+          data: { session: null },
+          error: Object.assign(new Error('network unreachable'), { code: 'unreachable' }),
+        }),
+      },
+    } as unknown as SupabaseClient
+    const service = makeLiveThirstService({ clientProvider: providerFor(client) })
+    await expect(service.castVote('matrix', 'vote-1')).rejects.toMatchObject({
+      kind: 'unknown',
+      message: 'network unreachable',
+    })
+  })
+})
 
 describe('the live service, configured, signed in', () => {
   it('castVote writes the web platform tag against the canon table — no KroApple change needed', async () => {
@@ -215,6 +264,16 @@ describe('the live service, configured, signed in', () => {
     })
   })
 
+  it('forwards the caller\'s AbortSignal to the insert — a cancelled thunk actually cancels the request', async () => {
+    const controller = new AbortController()
+    const onAbortSignal = vi.fn()
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(fakeClient({ session: SESSION, onAbortSignal })),
+    })
+    await service.castVote('matrix', 'vote-1', { signal: controller.signal })
+    expect(onAbortSignal).toHaveBeenCalledWith(controller.signal)
+  })
+
   it('hasVoted reports true when RLS returns a matching row', async () => {
     const service = makeLiveThirstService({
       clientProvider: providerFor(fakeClient({ session: SESSION, selectRows: [{ id: 'v1' }] })),
@@ -236,6 +295,16 @@ describe('the live service, configured, signed in', () => {
       ),
     })
     await expect(service.hasVoted('matrix')).rejects.toMatchObject({ kind: 'unknown' })
+  })
+
+  it('forwards the caller\'s AbortSignal to the select', async () => {
+    const controller = new AbortController()
+    const onAbortSignal = vi.fn()
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(fakeClient({ session: SESSION, onAbortSignal })),
+    })
+    await service.hasVoted('matrix', { signal: controller.signal })
+    expect(onAbortSignal).toHaveBeenCalledWith(controller.signal)
   })
 })
 
@@ -289,6 +358,16 @@ describe('the live service, fetchCounts (public, no session required)', () => {
       clientProvider: providerFor(fakeClient({ rpcError: { message: 'function not found' } })),
     })
     await expect(service.fetchCounts('matrix')).rejects.toMatchObject({ kind: 'unknown' })
+  })
+
+  it('forwards the caller\'s AbortSignal to the RPC call', async () => {
+    const controller = new AbortController()
+    const onAbortSignal = vi.fn()
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(fakeClient({ onAbortSignal })),
+    })
+    await service.fetchCounts('matrix', { signal: controller.signal })
+    expect(onAbortSignal).toHaveBeenCalledWith(controller.signal)
   })
 
   it('a browser transport failure (TypeError) degrades to offline', async () => {

--- a/packages/app/src/services/thirst/__tests__/ThirstService.test.ts
+++ b/packages/app/src/services/thirst/__tests__/ThirstService.test.ts
@@ -1,0 +1,303 @@
+/**
+ * `ThirstService` — the stub as a little state machine (mirrors
+ * `AuthService.test.ts`'s own section), plus the live service against a
+ * minimal fake `SupabaseClient` for the wire-shape work no stub exercises:
+ * the `web`-tagged insert, the `23505` convergence, the RPC row fold, and
+ * the failure-shape handling this issue asked to prove.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { makeStubbedSupabaseClientProvider } from '../../supabase/SupabaseClientProvider'
+import type { SupabaseClientProvider } from '../../supabase/SupabaseClientProvider'
+import {
+  makeLiveThirstService,
+  makeStubbedThirstService,
+} from '../ThirstService'
+
+// ---------------------------------------------------------------------------
+// Stub — a little state machine, mirroring AuthService.test.ts
+// ---------------------------------------------------------------------------
+
+describe('the stubbed service as a vote-state machine', () => {
+  it('reports not-yet-voted for a signed-in user with no prior vote', async () => {
+    const service = makeStubbedThirstService({ signedIn: true })
+    expect(await service.hasVoted('matrix')).toBe(false)
+  })
+
+  it('records the vote so a later hasVoted check finds it', async () => {
+    const service = makeStubbedThirstService({ signedIn: true })
+    await service.castVote('matrix', 'vote-1')
+    expect(await service.hasVoted('matrix')).toBe(true)
+    expect(service.votedFeatureKeys()).toEqual(['matrix'])
+  })
+
+  it('a repeat vote for the same feature is a quiet no-op, not a second entry', async () => {
+    const service = makeStubbedThirstService({ signedIn: true })
+    await service.castVote('matrix', 'vote-1')
+    await service.castVote('matrix', 'vote-2')
+    expect((await service.fetchCounts('matrix')).total).toBe(1)
+  })
+
+  it('rejects castVote/hasVoted with notSignedIn when signed out', async () => {
+    const service = makeStubbedThirstService({ signedIn: false })
+    await expect(service.castVote('matrix', 'vote-1')).rejects.toMatchObject({
+      kind: 'notSignedIn',
+    })
+    await expect(service.hasVoted('matrix')).rejects.toMatchObject({
+      kind: 'notSignedIn',
+    })
+  })
+
+  it('fetchCounts never requires a session — public data', async () => {
+    const service = makeStubbedThirstService({ signedIn: false })
+    await expect(service.fetchCounts('matrix')).resolves.toMatchObject({
+      featureKey: 'matrix',
+      total: 0,
+    })
+  })
+
+  it('records every operation it was asked to perform, in order', async () => {
+    const service = makeStubbedThirstService({ signedIn: true })
+    await service.hasVoted('matrix')
+    await service.castVote('matrix', 'vote-1')
+    await service.fetchCounts('matrix')
+    expect(service.operations()).toEqual(['hasVoted', 'castVote', 'fetchCounts'])
+  })
+
+  it('can be scripted to fail one operation and not the others', async () => {
+    const service = makeStubbedThirstService({
+      signedIn: true,
+      failures: { fetchCounts: new Error('rpc unavailable') },
+    })
+    await expect(service.fetchCounts('matrix')).rejects.toThrow('rpc unavailable')
+    await expect(service.hasVoted('matrix')).resolves.toBe(false)
+  })
+
+  it('starts from a seeded counts fixture', async () => {
+    const service = makeStubbedThirstService({
+      initialCounts: { matrix: { featureKey: 'matrix', total: 5, perPlatform: { ios: 5 } } },
+    })
+    expect((await service.fetchCounts('matrix')).total).toBe(5)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Live — against the honest "no project configured" stub
+// ---------------------------------------------------------------------------
+
+describe('the live service with no project configured', () => {
+  const service = makeLiveThirstService({
+    clientProvider: makeStubbedSupabaseClientProvider(),
+  })
+
+  it('reports notSignedIn on castVote rather than crashing', async () => {
+    await expect(service.castVote('matrix', 'vote-1')).rejects.toMatchObject({
+      kind: 'notSignedIn',
+    })
+  })
+
+  it('reports notSignedIn on hasVoted', async () => {
+    await expect(service.hasVoted('matrix')).rejects.toMatchObject({
+      kind: 'notSignedIn',
+    })
+  })
+
+  it('fetchCounts degrades to an empty result — public data with nothing behind it', async () => {
+    await expect(service.fetchCounts('matrix')).resolves.toEqual({
+      featureKey: 'matrix',
+      total: 0,
+      perPlatform: {},
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Live — against a minimal fake, configured client
+// ---------------------------------------------------------------------------
+
+interface FakeClientConfig {
+  readonly session?: { readonly user: { readonly id: string; readonly email: string | null } } | null
+  readonly insertError?: { readonly code?: string; readonly message: string } | null
+  readonly onInsert?: (payload: unknown) => void
+  readonly selectRows?: readonly { readonly id: string }[]
+  readonly selectError?: { readonly message: string } | null
+  readonly rpcRows?: readonly Record<string, unknown>[]
+  readonly rpcError?: { readonly message: string } | null
+}
+
+const fakeClient = (config: FakeClientConfig): SupabaseClient => {
+  const client = {
+    auth: {
+      getSession: async () => ({
+        data: { session: config.session === undefined ? null : config.session },
+        error: null,
+      }),
+    },
+    from: (_table: string) => ({
+      insert: async (payload: unknown) => {
+        config.onInsert?.(payload)
+        return { error: config.insertError ?? null }
+      },
+      select: (_columns: string) => ({
+        eq: async (_column: string, _value: string) => ({
+          data: config.selectRows ?? [],
+          error: config.selectError ?? null,
+        }),
+      }),
+    }),
+    rpc: async (_fn: string, _params: Record<string, unknown>) => ({
+      data: config.rpcRows ?? [],
+      error: config.rpcError ?? null,
+    }),
+  }
+  return client as unknown as SupabaseClient
+}
+
+const providerFor = (client: SupabaseClient): SupabaseClientProvider => ({
+  availability: () => ({ kind: 'configured', configuration: { url: 'https://x', anonKey: 'x' } }),
+  client: () => client,
+})
+
+const SESSION = { user: { id: 'user-1', email: 'ada@example.com' } }
+
+describe('the live service, configured, signed in', () => {
+  it('castVote writes the web platform tag against the canon table — no KroApple change needed', async () => {
+    const onInsert = vi.fn()
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(fakeClient({ session: SESSION, onInsert })),
+    })
+    await service.castVote('matrix', 'vote-1')
+    expect(onInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'vote-1',
+        feature_key: 'matrix',
+        platform: 'web',
+        feature_title: 'Priority Matrix',
+        username: 'ada@example.com',
+      }),
+    )
+  })
+
+  it('a unique-constraint conflict (23505) converges quietly — the server\'s own vote-once guarantee', async () => {
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(
+        fakeClient({ session: SESSION, insertError: { code: '23505', message: 'dup' } }),
+      ),
+    })
+    await expect(service.castVote('matrix', 'vote-1')).resolves.toBeUndefined()
+  })
+
+  /**
+   * Proves the failure-shape handling the issue asked to check: IF the
+   * `web` platform value were ever rejected by the canon migration's CHECK
+   * constraint (it is not — see `ThirstService.ts`'s header, verified
+   * against `zheref/KroApple@2117efc`), a rejected insert degrades to a
+   * typed exception rather than throwing an opaque Postgrest error or
+   * crashing the vote flow. Scripted here via the same `23514`
+   * (`check_violation`) code Postgres would actually report.
+   */
+  it('an unexpected platform-check failure degrades to a typed exception, never a crash', async () => {
+    // A real Postgrest error is an `Error` subclass; build the fake the same
+    // way so `toThirstException`'s `instanceof Error` branch is genuinely
+    // exercised, not the plain-object fallback.
+    const checkViolation = Object.assign(
+      new Error('new row violates check constraint "votes_platform_check"'),
+      { code: '23514' },
+    )
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(
+        fakeClient({ session: SESSION, insertError: checkViolation }),
+      ),
+    })
+    await expect(service.castVote('matrix', 'vote-1')).rejects.toMatchObject({
+      kind: 'unknown',
+      message: expect.stringContaining('votes_platform_check'),
+    })
+  })
+
+  it('hasVoted reports true when RLS returns a matching row', async () => {
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(fakeClient({ session: SESSION, selectRows: [{ id: 'v1' }] })),
+    })
+    await expect(service.hasVoted('matrix')).resolves.toBe(true)
+  })
+
+  it('hasVoted reports false when no row matches', async () => {
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(fakeClient({ session: SESSION, selectRows: [] })),
+    })
+    await expect(service.hasVoted('matrix')).resolves.toBe(false)
+  })
+
+  it('a select failure degrades to a typed exception', async () => {
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(
+        fakeClient({ session: SESSION, selectError: { message: 'timeout' } }),
+      ),
+    })
+    await expect(service.hasVoted('matrix')).rejects.toMatchObject({ kind: 'unknown' })
+  })
+})
+
+describe('the live service, fetchCounts (public, no session required)', () => {
+  it('folds the RPC rows into total + per-platform counts', async () => {
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(
+        fakeClient({
+          rpcRows: [
+            { feature_key: 'matrix', platform: 'ios', vote_count: 30, total_count: 42 },
+            { feature_key: 'matrix', platform: 'android', vote_count: 12, total_count: 42 },
+          ],
+        }),
+      ),
+    })
+    await expect(service.fetchCounts('matrix')).resolves.toEqual({
+      featureKey: 'matrix',
+      total: 42,
+      perPlatform: { ios: 30, android: 12 },
+    })
+  })
+
+  it('ignores a row with an unrecognized platform string rather than crashing', async () => {
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(
+        fakeClient({
+          rpcRows: [
+            { feature_key: 'matrix', platform: 'ios', vote_count: 1, total_count: 2 },
+            { feature_key: 'matrix', platform: 'linux', vote_count: 1, total_count: 2 },
+          ],
+        }),
+      ),
+    })
+    const counts = await service.fetchCounts('matrix')
+    expect(counts.perPlatform).toEqual({ ios: 1 })
+  })
+
+  it('resolves the empty shape for a feature with no rows at all', async () => {
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(fakeClient({ rpcRows: [] })),
+    })
+    await expect(service.fetchCounts('matrix')).resolves.toEqual({
+      featureKey: 'matrix',
+      total: 0,
+      perPlatform: {},
+    })
+  })
+
+  it('an RPC failure degrades to a typed exception', async () => {
+    const service = makeLiveThirstService({
+      clientProvider: providerFor(fakeClient({ rpcError: { message: 'function not found' } })),
+    })
+    await expect(service.fetchCounts('matrix')).rejects.toMatchObject({ kind: 'unknown' })
+  })
+
+  it('a browser transport failure (TypeError) degrades to offline', async () => {
+    const client = {
+      rpc: async () => {
+        throw new TypeError('Failed to fetch')
+      },
+    } as unknown as SupabaseClient
+    const service = makeLiveThirstService({ clientProvider: providerFor(client) })
+    await expect(service.fetchCounts('matrix')).rejects.toMatchObject({ kind: 'offline' })
+  })
+})

--- a/packages/app/src/services/thirst/index.ts
+++ b/packages/app/src/services/thirst/index.ts
@@ -1,0 +1,1 @@
+export * from './ThirstService'


### PR DESCRIPTION
> **Ichigo — Shinigami** · the Thirst vote surface for gated destinations
> local, on your creds · handbook `v0.5`

# What this changes for you

Four sidebar dead-ends — Priority Matrix, Board, Blueprints, Habits — stop
showing a generic "not built yet" placeholder and start showing canon's real
Thirst surface: the feature's title/blurb, a live vote count (total +
per-platform), and a one-tap vote that locks to "voted" once cast. Votes from
this app are tagged `web`, a value the canon Kro Cloud schema already
accepts — **no change is needed on the KroApple side** (checked; see
"Divergences" below). Signed-out and offline visitors still see any public
count that loaded, with voting explained and disabled rather than crashing
or silently doing nothing. An unmapped dead-end (there are none among these
four, but the mechanism exists for a future one) falls back to a plain card
with no vote affordance, never a vote for a feature that doesn't exist.
Help & Feedback is also ported at canon parity — six rows, three sections,
every row genuinely inert (no invented destination) — built and tested, not
yet mounted on a route (see "Divergences").

**What you keep:** every other destination's placeholder is untouched; the
shared shell files (`DestinationPage.tsx`, `apps/web/src/index.ts`'s adjacent
routes) are not touched by this PR. **What changes:** these four routes stop
routing through the shared `DestinationPage` swap point and instead mount a
Thirst-specific wrapper that fires the identical sidebar-selection event —
see "Divergences" for why and how it's verified equivalent.

```mermaid
flowchart LR
    A["/matrix, /board, /blueprints, /habits"] --> B[ThirstDestinationPage]
    B -->|"same onDestinationRouteMounted\nDestinationPage.tsx fires"| C[main slice: sidebar highlight]
    B --> D[ComingSoonPage]
    D -->|checkVoteStateThunk + fetchCountsThunk| E[ThirstService]
    E -->|signed in| F[(canon votes / features tables)]
    E -->|signed out / unconfigured| G[typed notSignedIn exception]
    D -->|userDidTapVote| H[castVoteThunk]
    H --> E
```

## How to verify

### 1. The vote surface replaces the placeholder on all four routes
**Setup:** `make dev`, no `NEXT_PUBLIC_SUPABASE_*` env vars set (this repo's
default local state — an unconfigured project).
**Steps:** Visit `/matrix`, `/board`, `/blueprints`, `/habits` in turn.
**Expected:** Each shows the feature's title (Priority Matrix / Board /
Blueprints / Habits) and blurb from the canon registry, a `0` count (no
votes recorded yet), a "Sign in to vote for upcoming features." notice, and
a disabled "Vote to get it sooner" button — never the old "… is not built
yet." placeholder.

### 2. Loading, signed-out and voted states (`docs/Features/Thirst.md`'s five states)
**Setup:** none (pure-render evidence; also exercised end-to-end by
`ComingSoonPage.test.tsx` against a real store + a stubbed `thirstService`).
**Steps:** `pnpm --filter @kro/app exec vitest run src/features/thirst/__tests__/ComingSoonPage.test.tsx`.
**Expected:** all pass, including "reaches a seeded voted state through the
real Page → Producer → reducer loop" and "shows the honest signed-out state
once the auth check resolves" — the two states the live app cannot reach on
its own (no real Supabase project, no real account) but the stub proves are
correctly wired.

### 3. Optimistic vote, and the race it must survive
**Setup:** none.
**Steps:** `pnpm --filter @kro/app exec vitest run src/features/thirst/__tests__/ThirstProducer.test.ts`.
**Expected:** all pass, including "two concurrent votes for the same
feature only ever bump the count once" — two overlapping `castVoteThunk`
dispatches for one feature key (a slow network, a race before the UI's own
`isVoting`-disabled button can act) still land on `total: 1`, never `2`.

### 4. Unmapped dead-end renders the plain card
**Setup:** none — no route in this repo mounts an unmapped key today (all
four wired routes are registry features), so this is Storybook/unit
evidence rather than a live route.
**Steps:** `pnpm --filter @kro/app exec vitest run src/features/thirst/__tests__/ComingSoonFragment.test.tsx -t "unmapped"`; or open Storybook (`pnpm --filter @kro/web storybook`) → `Thirst/Coming soon` → `NotVotable`.
**Expected:** title only, no count, no vote button, no loading spinner.

### 5. Help & Feedback at canon parity
**Setup:** none.
**Steps:** `pnpm --filter @kro/app exec vitest run src/features/thirst/__tests__/HelpFeedbackFragment.test.tsx`; or Storybook → `Thirst/Help & feedback`.
**Expected:** six rows — Documentation, Community Forum, Contact Support,
Rate on App Store, Report a Problem, Suggest a Feature — grouped under
Resources/Support/Feedback, every row a real `<button>` with no `href` and
no handler (clicking does nothing, matching canon's own `{}` action).

### 6. The web platform tag against the canon tables
**Setup:** none — this is service-layer evidence; there is no live Kro Cloud
project in this environment to exercise the real INSERT against.
**Steps:** `pnpm --filter @kro/app exec vitest run src/services/thirst/__tests__/ThirstService.test.ts`.
**Expected:** all pass, including the insert-payload assertion (`platform:
'web'`) and the scripted `23514` check-violation case proving a rejected
insert degrades to a typed exception rather than a crash.

### 7. Whole-repo gate
**Setup:** none.
**Steps:** `make lint && make typecheck && make test && make build`.
**Expected:** all four green (verified locally before opening this PR).

## Screenshots

Captured from the running app (`next dev`, unconfigured Supabase — the
honest signed-out state is genuinely reachable this way) for the four real
routes, and from Storybook (this stack's `RC-11`/`UZF-26` visual-evidence
carrier) for the states the live, unconfigured app cannot reach on its own
(loading, voted, the unmapped card) plus Help & Feedback, which is built and
tested but not mounted on any route in this PR (see Divergences). Both
viewports (mobile 390×844, desktop 1440×900 for the live app; 390/900×700
for Storybook), light + dark.

### Priority Matrix — live app, signed out (`#35`)

| Mobile · light | Mobile · dark | Desktop · light | Desktop · dark |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/matrix-signedout-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/matrix-signedout-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/matrix-signedout-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/matrix-signedout-desktop-dark.png) |

### Coming Soon — loading (Storybook, `#35`)

| Mobile · light | Mobile · dark | Desktop · light | Desktop · dark |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-loading-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-loading-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-loading-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-loading-desktop-dark.png) |

### Coming Soon — voted, seeded via the stub (Storybook, `#35`)

| Mobile · light | Mobile · dark | Desktop · light | Desktop · dark |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-voted-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-voted-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-voted-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-voted-desktop-dark.png) |

### Coming Soon — unmapped dead-end, plain card (Storybook, `#35`)

| Mobile · light | Mobile · dark | Desktop · light | Desktop · dark |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-notvotable-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-notvotable-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-notvotable-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/coming-soon-notvotable-desktop-dark.png) |

### Help & Feedback (Storybook, `#35`)

| Mobile · light | Mobile · dark | Desktop · light | Desktop · dark |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/help-feedback-light-mobile.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/help-feedback-dark-mobile.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/help-feedback-light-desktop.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/35-thirst-ui/help-feedback-dark-desktop.png) |

## Divergences (named, reasoned)

1. **The `web` `VotePlatform` value needs no KroApple-side change.** The
   issue's own note flagged this as a possible blocker. Checked against
   `zheref/KroApple@2117efc` (re-fetched at build time): both the DB
   `votes_platform_check` constraint and the client `VotePlatform` enum
   already accept `ios | android | web | windows`. The "prove the
   failure-shape handling" ask is still satisfied defensively —
   `ThirstService.test.ts`'s scripted `23514` case proves a rejected insert
   (e.g. from a hypothetical future constraint narrowing) degrades to a
   typed exception rather than a crash — but no upstream change is needed or
   named.
2. **`ThirstDestinationPage.tsx` stands in for `packages/app/src/features/main/DestinationPage.tsx`'s
   documented swap point, for these four kinds only.** That shared file is
   explicitly "the swap point" every feature child edits, but it is a
   single file every concurrently in-flight feature PR would contend to
   touch, and this issue's declared file lane is its four `apps/web` route
   directories, not `features/main/**`. `ThirstDestinationPage` fires the
   identical `onDestinationRouteMounted` action `DestinationPage.tsx` fires,
   so the sidebar/tab-bar highlight is unaffected — verified in
   `ThirstDestinationPage.test.tsx` and in each route's own `page.spec.tsx`
   (asserts `store.getState().main.selected.kind`). Worth reconciling into
   `DestinationPage.tsx` proper in a later pass once these four kinds are
   the only ones still on the placeholder (i.e., once every sibling feature
   child has landed) — not blocking, no decision needed from you now.
3. **Domain models (`VotePlatform`, `FeatureVoteCounts`) live in
   `packages/app/src/features/thirst/ThirstModels.ts`, not `@kro/core`.**
   Canon's `07-models-mocks-mappers.md` puts a domain Model in
   `packages/core/models/` by default; that package is outside this issue's
   declared lane. Follow-up: promote these two types into `@kro/core`
   alongside `User`/`AuthProvider`, which prove the same pattern for Auth.
4. **Two small "shared-file, one line" touches beyond the granted lane**,
   both mechanically necessary and low-risk, mirroring the ThunkExtra/store.ts
   collision the task anticipated:
   - `packages/app/package.json`: one new `exports` subpath,
     `"./thirst": "./src/features/thirst/index.ts"`, mirroring the existing
     `./design` and `./google` entries — without it, nothing in `apps/web`
     can import the feature at all.
   - `apps/web/vitest.config.mts`: one matching alias entry (the file's own
     header already documents this as the pattern every subpath export
     requires — see its "Subpath exports come FIRST" comment).
   - Eleven sibling features' `__tests__/*Selectors.test.ts` files each
     needed one added line (`thirst: initialThirstState`) in their
     hand-built `rootWith(...)` root-state stand-in, purely because
     `RootState` now names one more registered slice — the same
     `TS2741`-shaped fallout every prior feature slice's own PR must have
     caused for its own line. No assertions changed.
5. **`HelpFeedbackFragment` is built, tested and story'd, but not mounted on
   any route.** Canon's Help & Feedback sheet lives on the Settings/Adjust
   surface, which is `#32`'s (Auth & Settings UI) lane, not this issue's
   four route directories. It's ready for `#32` to mount with one import.

## Parked / upstream candidates

None. The one thing the issue asked me to check upstream (the `web`
platform-enum question) resolved to "no change needed" — see Divergences
item 1. No handbook question filed; no gap found in `react-uzf-v1` canon
that this PR's shape needed to work around.

## Test coverage summary

- `ThirstFeature.test.ts` / `ThirstShifters.test.ts` / `ThirstSelectors.test.ts` /
  `ThirstProducer.test.ts`: ≥3 cases per reducer arm / Shifter / Selector /
  Producer (RC-12/54/55/56), including the optimistic-vote race case.
- `ThirstService.test.ts`: the stub as a state machine + the live service
  against a minimal fake `SupabaseClient` (insert/select/rpc), covering the
  `web` tag, the `23505` convergence, the `23514` failure-shape proof, RPC
  row folding, and the unconfigured-project path.
- `ComingSoonFragment.test.tsx` (9 cases) mirrors `ComingSoonFragment.stories.tsx`
  (8 stories) 1:1 — every `ThirstVoteStatus` state.
- `HelpFeedbackFragment.test.tsx` (9 cases, incl. one per row) mirrors
  `HelpFeedbackFragment.stories.tsx` (3 stories).
- `ComingSoonPage.test.tsx` / `ThirstDestinationPage.test.tsx`: driven
  through a real store against a stubbed `thirstService`, the same shape
  `DestinationPage.test.tsx` uses for the shell.
- `make lint && make typecheck && make test && make build` all green
  locally (248 test files / 5560 tests in `@kro/app` alone).

<!-- bankai agent=ichigo session=5ce76045 handbook=v0.5 trigger=local -->
