### PR TITLE
feat(capture): capture prompt, Inbox surfaces and undo toast

### DIFF
--- a/apps/web/src/app/(shell)/AppShellClient.tsx
+++ b/apps/web/src/app/(shell)/AppShellClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { MainShellPage } from '@kro/app'
+import { CaptureOverlays, MainShellPage } from '@kro/app'
 import type { ReactNode } from 'react'
 
 interface Props {
@@ -8,7 +8,20 @@ interface Props {
   readonly children: ReactNode
 }
 
-/** Client wrapper (`RC-39`): imports the Page, forwards props. Nothing else. */
+/**
+ * Client wrapper (`RC-39`): imports the Page, forwards props. Nothing else.
+ *
+ * The overlay area below the shell's children is the shared anchor every
+ * feature that owns a global surface adds one line to. Each mount is its own
+ * feature's composition (`CaptureOverlays` is KC-IS-#24's), so this file never
+ * grows logic — only the list.
+ */
 export function AppShellClient({ isDevelopment, children }: Props) {
-  return <MainShellPage isDevelopment={isDevelopment}>{children}</MainShellPage>
+  return (
+    <MainShellPage isDevelopment={isDevelopment}>
+      {children}
+      {/* --- overlay area --- */}
+      <CaptureOverlays />
+    </MainShellPage>
+  )
 }

--- a/apps/web/src/app/(shell)/inbox/InboxRouteClient.spec.tsx
+++ b/apps/web/src/app/(shell)/inbox/InboxRouteClient.spec.tsx
@@ -1,0 +1,33 @@
+import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { InboxRouteClient } from './InboxRouteClient'
+
+/**
+ * The wrapper is a passive shell (`RC-39`, exempt from the per-artifact minimum
+ * by `RC-57`), so this asserts only what a wrapper can get wrong: that it
+ * mounts the shared Page and adds nothing of its own.
+ */
+describe('InboxRouteClient', () => {
+  it('mounts the shared Inbox destination Page', () => {
+    render(
+      <StoreProvider store={makeStore(stubbedThunkExtra)}>
+        <InboxRouteClient />
+      </StoreProvider>,
+    )
+
+    expect(screen.getByTestId('inbox-surface')).toBeTruthy()
+  })
+
+  it('adds no chrome of its own — the Page owns the whole surface', () => {
+    const { container } = render(
+      <StoreProvider store={makeStore(stubbedThunkExtra)}>
+        <InboxRouteClient />
+      </StoreProvider>,
+    )
+
+    expect(container.firstElementChild?.getAttribute('data-testid')).toBe(
+      'inbox-surface',
+    )
+  })
+})

--- a/apps/web/src/app/(shell)/inbox/InboxRouteClient.tsx
+++ b/apps/web/src/app/(shell)/inbox/InboxRouteClient.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { InboxDestinationPage } from '@kro/app'
+
+/** Client wrapper (`RC-39`): imports the Page, renders it. Nothing else. */
+export function InboxRouteClient() {
+  return <InboxDestinationPage />
+}

--- a/apps/web/src/app/(shell)/inbox/page.spec.tsx
+++ b/apps/web/src/app/(shell)/inbox/page.spec.tsx
@@ -3,6 +3,11 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import InboxRoute from './page'
 
+/**
+ * The route file is a passive shell (`RC-57`), so this asserts only what a
+ * route can get wrong: that it mounts the real Inbox destination inside the
+ * store rather than the shared placeholder it used to render.
+ */
 describe('/inbox', () => {
   it("mounts the Jot Down destination inside the shell's store", () => {
     render(
@@ -11,6 +16,29 @@ describe('/inbox', () => {
       </StoreProvider>,
     )
 
-    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('Inbox')
+    expect(screen.getByTestId('inbox-surface')).toBeTruthy()
+  })
+
+  it('presents it inline — a destination is navigated away from, not dismissed', () => {
+    render(
+      <StoreProvider store={makeStore(stubbedThunkExtra)}>
+        <InboxRoute />
+      </StoreProvider>,
+    )
+
+    expect(
+      screen.getByTestId('inbox-surface').getAttribute('data-kro-presentation'),
+    ).toBe('inline')
+    expect(screen.queryByRole('button', { name: 'Done' })).toBeNull()
+  })
+
+  it('shows the centered tray when nothing has been captured yet', () => {
+    render(
+      <StoreProvider store={makeStore(stubbedThunkExtra)}>
+        <InboxRoute />
+      </StoreProvider>,
+    )
+
+    expect(screen.getByText('Inbox is empty')).toBeTruthy()
   })
 })

--- a/apps/web/src/app/(shell)/inbox/page.tsx
+++ b/apps/web/src/app/(shell)/inbox/page.tsx
@@ -1,13 +1,13 @@
-import { DestinationPageClient } from '../DestinationPageClient'
+import { InboxRouteClient } from './InboxRouteClient'
 
 /**
  * `/inbox` — the Jot Down destination.
  *
  * A passive Server Component (`RC-38`): it names its destination and renders
  * the client wrapper. No hook, no store read, no markup. The surface itself
- * lives in `packages/app`, so the feature child that builds Inbox replaces
- * a Page there and never touches this file.
+ * lives in `packages/app` — KC-IS-#24 replaced the shared placeholder Page with
+ * the real Inbox, which is the swap `DestinationPage`'s header describes.
  */
 export default function InboxRoute() {
-  return <DestinationPageClient kind="inbox" />
+  return <InboxRouteClient />
 }

--- a/packages/app/src/features/capture/pages/CaptureOverlays.tsx
+++ b/packages/app/src/features/capture/pages/CaptureOverlays.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+/**
+ * The capture feature's mount point — one line in the shell, three surfaces.
+ *
+ * This is **not** a UZF Page: it calls no hook, reads no state and dispatches
+ * nothing. It is the composition that lets `apps/web`'s shell wrapper carry a
+ * single anchor (`<CaptureOverlays />`) while the Pages beneath it stay one
+ * Fragment each — the same shape `MainShellPage` uses when it wraps its own
+ * Fragment in `ToolbarSlotsProvider`.
+ *
+ * What it mounts, and why here:
+ *
+ *   · **`ActiveToastHost`** (chrome kit, KC-IS-#15) — the toast host has no
+ *     mount anywhere in the repo yet, and the Add-for-Today Undo is its first
+ *     consumer. `useActiveToasts()` throws outside a host on purpose, so the
+ *     host has to be above the Pages that enqueue. When a second feature needs
+ *     toasts, lifting this one line into the shell is the follow-up; nothing
+ *     below it changes, because the hook resolves through context.
+ *   · **`CaptureQuickActionPage`** — canon's default quick-action disc.
+ *   · **`CapturePromptPage`** — renders nothing until a draft exists, so any
+ *     surface can open the prompt by dispatching `userDidRequestCapture`.
+ *   · **`InboxOverlayPage`** — renders nothing until the Inbox is open, and
+ *     owns the scheduling Undo window.
+ *
+ * The order is the paint order: the disc sits under both overlays, which
+ * portal to the document body anyway.
+ */
+
+import { CHROME_LAYOUT } from '../../../design/chrome/layout/chromeLayout'
+import { ActiveToastHost } from '../../../design/chrome/toast/ActiveToastHost'
+import { CapturePromptPage } from './CapturePromptPage'
+import { CaptureQuickActionPage } from './CaptureQuickActionPage'
+import { InboxOverlayPage } from './InboxOverlayPage'
+
+/**
+ * How far the toast rises above where the chrome kit would put it.
+ *
+ * Canon places the toast 24pt off the bottom (`toastBottomPadding`) — but it
+ * places it INSIDE a tab, where SwiftUI's safe-area inset already excludes the
+ * tab bar, so 24pt is measured from the top of that bar. The web has no such
+ * inset: the shell's tab bar is an ordinary flex child, so a viewport-anchored
+ * toast at 24px lands underneath it and the message is clipped.
+ *
+ * The lift closes exactly that gap, and it is derived rather than measured:
+ * `fabBottomPadding - toastBottomPadding` puts the toast's bottom level with
+ * the FAB's, which is canon's own stated intent for the pair ("lifted so its
+ * centre lines up with the FAB's"). It is applied on both shells because 60px
+ * of bottom inset is right on either — the sidebar shell simply has no tab bar
+ * to clear.
+ *
+ * That the kit's layer takes no bottom-inset prop, and the shell's tab bar
+ * publishes no height, is the cross-lane gap this works around; it is reported
+ * with this PR against KC-IS-#15's lane.
+ */
+const TOAST_LIFT_ABOVE_TAB_BAR =
+  CHROME_LAYOUT.fabBottomPadding - CHROME_LAYOUT.toastBottomPadding
+
+export function CaptureOverlays() {
+  return (
+    // A zero-height anchor, so it intercepts nothing: the toast layer is
+    // `absolute` within it and overflows upward, which is the only part with
+    // any area at all.
+    <div
+      data-testid="capture-overlays"
+      style={{
+        position: 'fixed',
+        left: 0,
+        right: 0,
+        bottom: `calc(${TOAST_LIFT_ABOVE_TAB_BAR}px + env(safe-area-inset-bottom, 0px))`,
+        height: 0,
+      }}
+    >
+      <ActiveToastHost position="absolute">
+        <CaptureQuickActionPage />
+        <CapturePromptPage />
+        <InboxOverlayPage />
+      </ActiveToastHost>
+    </div>
+  )
+}

--- a/packages/app/src/features/capture/pages/CapturePromptFragment.stories.tsx
+++ b/packages/app/src/features/capture/pages/CapturePromptFragment.stories.tsx
@@ -1,0 +1,149 @@
+/**
+ * The capture prompt, at both widths, in both schemes, in the states its
+ * validation table can produce.
+ *
+ * Every draft comes from `CaptureMocks` — the validation truth table, one row
+ * each — and every disabled Add's reason comes from the same
+ * `captureBlockedReason` the Page reads, so a story cannot show a prompt the
+ * slice could not produce (`RC-31`). `CapturePromptFragment.test.tsx` mirrors
+ * this set one for one (`RC-11`).
+ */
+
+import { ThemeScope } from './__tests__/captureHarness'
+import { captureDraftFixtures, CAPTURE_MOCK_NOW } from '../CaptureMocks'
+import {
+  CaptureDestination,
+  type CaptureDraft,
+  canSubmitCapture,
+  captureBlockedReason,
+} from '../CaptureRules'
+import {
+  CapturePromptFragment,
+  type CapturePromptFragmentProps,
+} from './CapturePromptFragment'
+import type { CapturePresentationKind } from './capturePresentation'
+
+export default {
+  title: 'Capture/Prompt',
+  component: CapturePromptFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+const noop = () => {}
+
+const prompt = (
+  draft: CaptureDraft,
+  presentation: CapturePresentationKind,
+  overrides: Partial<CapturePromptFragmentProps> = {},
+) => (
+  <CapturePromptFragment
+    isOpen
+    draft={draft}
+    isEditingStartTime={false}
+    isEditingEndTime={false}
+    availableDestinations={[
+      CaptureDestination.local,
+      CaptureDestination.kroCloud,
+    ]}
+    canSubmit={canSubmitCapture(draft)}
+    blockedReason={captureBlockedReason(draft)}
+    presentation={presentation}
+    now={CAPTURE_MOCK_NOW}
+    locale="en-US"
+    onEditTitle={noop}
+    onSelectKind={noop}
+    onPickDate={noop}
+    onBeginTimeEdit={noop}
+    onPickTime={noop}
+    onEndTimeEdit={noop}
+    onPickRewards={noop}
+    onPickRecurrence={noop}
+    onSelectDestination={noop}
+    onDiscard={noop}
+    onSubmit={noop}
+    {...overrides}
+  />
+)
+
+/** A fresh Task prompt on a phone: untitled, so Add names what it wants. */
+export const SheetEmptyTask = {
+  render: () => (
+    <ThemeScope theme="light">
+      {prompt(captureDraftFixtures.emptyTask, 'sheet')}
+    </ThemeScope>
+  ),
+}
+
+/** The same prompt with a title typed — Add enabled, no reason shown. */
+export const SheetReadyToSubmit = {
+  render: () => (
+    <ThemeScope theme="light">
+      {prompt(captureDraftFixtures.titledTask, 'sheet')}
+    </ThemeScope>
+  ),
+}
+
+/** An Event with neither time: canon's one stricter kind, blocked on both. */
+export const SheetEventMissingTimes = {
+  render: () => (
+    <ThemeScope theme="light">
+      {prompt(captureDraftFixtures.eventMissingBothTimes, 'sheet')}
+    </ThemeScope>
+  ),
+}
+
+/** The same phone sheet in the dark scheme. */
+export const SheetDark = {
+  render: () => (
+    <ThemeScope theme="dark">
+      {prompt(captureDraftFixtures.emptyTask, 'sheet')}
+    </ThemeScope>
+  ),
+}
+
+/** The desktop glass popover, anchored to the FAB's own corner. */
+export const PopoverEmptyTask = {
+  render: () => (
+    <ThemeScope theme="light">
+      {prompt(captureDraftFixtures.emptyTask, 'popover')}
+    </ThemeScope>
+  ),
+}
+
+/** The popover with an event blocked on its end time only. */
+export const PopoverEventMissingEnd = {
+  render: () => (
+    <ThemeScope theme="light">
+      {prompt(captureDraftFixtures.eventMissingEnd, 'popover')}
+    </ThemeScope>
+  ),
+}
+
+/** The desktop popover in the dark scheme. */
+export const PopoverDark = {
+  render: () => (
+    <ThemeScope theme="dark">
+      {prompt(captureDraftFixtures.titledTask, 'popover')}
+    </ThemeScope>
+  ),
+}
+
+/** The start-time panel expanded — canon's Discard / Clear / Done bar. */
+export const TimePanelOpen = {
+  render: () => (
+    <ThemeScope theme="light">
+      {prompt(captureDraftFixtures.timedTask, 'sheet', {
+        isEditingStartTime: true,
+      })}
+    </ThemeScope>
+  ),
+}
+
+/** A Habit: no date chip at all, and rewards still on offer. */
+export const HabitHasNoDate = {
+  render: () => (
+    <ThemeScope theme="light">
+      {prompt(captureDraftFixtures.titledHabit, 'sheet')}
+    </ThemeScope>
+  ),
+}

--- a/packages/app/src/features/capture/pages/CapturePromptFragment.tsx
+++ b/packages/app/src/features/capture/pages/CapturePromptFragment.tsx
@@ -1,0 +1,857 @@
+'use client'
+
+/**
+ * The capture prompt — canon `Kro/Components/EndeavorInputPrompt.swift`'s
+ * `mainForm`, as one pure Fragment (`RC-15`: it dispatches nothing; every
+ * intent arrives as a callback prop).
+ *
+ * ## The panel, and the two idioms
+ *
+ * Canon presents the same form two ways: `bottomAnchoredSheet` on the phone —
+ * a sheet whose detent IS its content's measured height — and a plain `.sheet`
+ * on the Mac. KC-IS-#24 fixes the web pair as *bottom sheet with a custom
+ * detent / desktop glass popover*, so:
+ *
+ *   · **sheet** is the design system's `SheetContent side="bottom"`, whose
+ *     height is its content up to `85vh`. That IS the custom detent: nothing
+ *     here asks for a fraction of the viewport, so the panel is exactly as tall
+ *     as the form — the property canon's `reportedHeight` measurement exists to
+ *     produce.
+ *   · **popover** is a glass panel anchored to the bottom-trailing corner — the
+ *     corner the quick-action FAB occupies — at `CAPTURE_PROMPT_POPOVER_WIDTH`.
+ *
+ * Both are the same Radix dialog root, which is what the design system's
+ * `Sheet`/`Dialog` split exists for: one focus trap, one scroll lock, one
+ * escape key, two presentations.
+ *
+ * **Dismissal is Discard.** Canon passes `dismissDisabled: true` and closes the
+ * sheet only through Discard or Add, because the draft is dropped whole either
+ * way (`withPromptClosed`). On the web an un-escapable dialog is hostile, so
+ * Escape and the overlay both route to `onDiscard` — the same outcome canon's
+ * two buttons produce, reached through the platform's own affordances.
+ *
+ * ## What is local state here, and why that is not an `RC-4` breach
+ *
+ * Exactly one thing: which inline panel is expanded (`date` / `rewards` /
+ * `repeat` / `destination`). The capture slice's own header states the split —
+ * the time pickers' snapshots are logic and live in the slice, while *"the
+ * 'is the picker showing' booleans stay with #24"*. So the two time panels are
+ * **derived** from the slice (`prompt.startEdit !== null`) and are not held
+ * here at all; only the disclosures canon keeps in `@State` with no logic
+ * behind them are local, and they close on a kind change exactly as canon's
+ * `onChange(of: draft.selectedKind)` does.
+ */
+
+import type { ReactNode } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { Button } from '../../../design/system/primitives/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '../../../design/system/primitives/dialog'
+import { Input } from '../../../design/system/primitives/input'
+import { SheetContent } from '../../../design/system/primitives/sheet'
+import { colorVar, radiusVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import type { CaptureTimeEditOutcome, CaptureTimeField } from '../CaptureFeature'
+import {
+  type CaptureDestination,
+  type CaptureDraft,
+  CaptureKind,
+  type CaptureRecurrence,
+  MAXIMUM_CAPTURE_REWARDS,
+  MINIMUM_CAPTURE_REWARDS,
+  captureDestinationGlyph,
+  captureDestinationLabel,
+  captureKindGlyph,
+  captureKindLabel,
+  captureKindPlaceholder,
+  captureKinds,
+} from '../CaptureRules'
+import { captureIcon, captureIconFor } from './captureIcons'
+import {
+  CAPTURE_PROMPT_POPOVER_WIDTH,
+  type CapturePresentationKind,
+  captureRecurrencePresets,
+  captureRepeatChipLabel,
+  dateInputValue,
+  formatCaptureDate,
+  formatCaptureTime,
+  parseDateInput,
+  parseTimeInput,
+  timeInputValue,
+} from './capturePresentation'
+
+const Star = captureIcon('star.fill')
+const CalendarGlyph = captureIcon('calendar')
+const ClockGlyph = captureIcon('clock')
+const ClockEndGlyph = captureIcon('clock.badge.checkmark')
+const ClearGlyph = captureIcon('xmark.circle.fill')
+const RepeatGlyph = captureIcon('repeat')
+const ChevronDown = captureIcon('chevron.down')
+const Check = captureIcon('checkmark')
+
+/** Canon's stepper step: 5 below 50 points, 10 at or above it. */
+export const captureRewardStep = (points: number): number =>
+  points >= 50 ? 10 : 5
+
+/**
+ * `position: fixed`, inline, because the class cannot win.
+ *
+ * `glass.css`'s `.kro-glass { position: relative }` is **unlayered** CSS, and
+ * unlayered rules beat every `@layer utilities` rule regardless of source
+ * order — so Tailwind's `fixed`, which `SheetContent` and `DialogContent`
+ * already carry, is overridden on any glass panel. The panel then lays out in
+ * normal flow at the end of the portal, which puts an 85vh sheet entirely below
+ * the fold. An inline style is the one declaration that outranks an unlayered
+ * class, so it is what pins the panel here.
+ *
+ * This is a **design-system defect, not a capture one** — it makes every
+ * `Sheet` and `Dialog` in the repo mis-position, and it was invisible until now
+ * because those primitives' own suites deliberately never put a panel on screen
+ * (`design/system/primitives/__tests__/radixEnvironment.tsx`). The real fix is
+ * one line in `glass.css` (`@layer components`, or dropping `position` from the
+ * base rule); it belongs to KC-IS-#6's lane and is reported with this PR. When
+ * it lands, this constant and its two uses delete cleanly.
+ */
+const PINNED_TO_VIEWPORT = { position: 'fixed' } as const
+
+/** Which inline panel is expanded. Only one at a time, exactly as canon. */
+type PromptPanel = 'date' | 'rewards' | 'repeat' | 'destination' | null
+
+export interface CapturePromptFragmentProps {
+  readonly isOpen: boolean
+  readonly draft: CaptureDraft
+  /** `prompt.startEdit !== null` — the slice owns the snapshot, not this view. */
+  readonly isEditingStartTime: boolean
+  readonly isEditingEndTime: boolean
+  readonly availableDestinations: readonly CaptureDestination[]
+  readonly canSubmit: boolean
+  /** The epic's a11y contract: a disabled Add names what blocks it. */
+  readonly blockedReason: string | null
+  readonly presentation: CapturePresentationKind
+  /** Explicit, never a clock read — "Today" must not depend on the wall clock. */
+  readonly now: Date
+  readonly locale?: string
+
+  readonly onEditTitle: (title: string) => void
+  readonly onSelectKind: (kind: CaptureKind) => void
+  readonly onPickDate: (date: Date) => void
+  readonly onBeginTimeEdit: (field: CaptureTimeField) => void
+  readonly onPickTime: (field: CaptureTimeField, time: Date) => void
+  readonly onEndTimeEdit: (
+    field: CaptureTimeField,
+    outcome: CaptureTimeEditOutcome,
+  ) => void
+  readonly onPickRewards: (points: number) => void
+  readonly onPickRecurrence: (recurrence: CaptureRecurrence) => void
+  readonly onSelectDestination: (destination: CaptureDestination) => void
+  readonly onDiscard: () => void
+  readonly onSubmit: () => void
+}
+
+export function CapturePromptFragment(props: CapturePromptFragmentProps) {
+  const { isOpen, draft, presentation, onDiscard } = props
+  const isSheet = presentation === 'sheet'
+
+  const heading = (
+    <>
+      {/*
+        Radix needs a Title and a Description for the dialog's accessible name.
+        Canon's sheet draws neither — the kind chips ARE the title — so both are
+        announced and not shown, carrying canon's own
+        `accessibilityLabel("New \(kind.label)")` verbatim.
+      */}
+      <DialogTitle className="sr-only">
+        {`New ${captureKindLabel(draft.kind)}`}
+      </DialogTitle>
+      <DialogDescription className="sr-only">
+        {captureKindPlaceholder(draft.kind)}
+      </DialogDescription>
+    </>
+  )
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(next) => {
+        if (!next) onDiscard()
+      }}
+    >
+      {isSheet ? (
+        <SheetContent
+          hideClose
+          side="bottom"
+          data-testid="capture-prompt"
+          data-kro-presentation="sheet"
+          className="h-auto gap-0 p-0"
+          style={PINNED_TO_VIEWPORT}
+        >
+          {heading}
+          <PromptForm {...props} />
+        </SheetContent>
+      ) : (
+        <DialogContent
+          hideClose
+          data-testid="capture-prompt"
+          data-kro-presentation="popover"
+          className={cn(
+            'top-auto right-6 bottom-6 left-auto',
+            'translate-x-0 translate-y-0',
+            'flex max-h-[calc(100dvh-3rem)] flex-col gap-0 overflow-y-auto p-0',
+          )}
+          style={{
+            ...PINNED_TO_VIEWPORT,
+            width: `${CAPTURE_PROMPT_POPOVER_WIDTH}px`,
+            maxWidth: 'calc(100vw - 3rem)',
+          }}
+        >
+          {heading}
+          <PromptForm {...props} />
+        </DialogContent>
+      )}
+    </Dialog>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* The form                                                                  */
+/* ------------------------------------------------------------------------ */
+
+function PromptForm({
+  isOpen,
+  draft,
+  isEditingStartTime,
+  isEditingEndTime,
+  availableDestinations,
+  canSubmit,
+  blockedReason,
+  now,
+  locale,
+  onEditTitle,
+  onSelectKind,
+  onPickDate,
+  onBeginTimeEdit,
+  onPickTime,
+  onEndTimeEdit,
+  onPickRewards,
+  onPickRecurrence,
+  onSelectDestination,
+  onDiscard,
+  onSubmit,
+}: CapturePromptFragmentProps) {
+  const [panel, setPanel] = useState<PromptPanel>(null)
+  const titleRef = useRef<HTMLInputElement | null>(null)
+
+  // Canon waits out the sheet's presentation animation and then focuses the
+  // title (`.task(id:)` plus a 350 ms sleep). Radix hands focus to the panel's
+  // first focusable node — the leading kind chip — so the field claims it back
+  // here. `isOpen` is the dependency for canon's own reason: a re-presented
+  // prompt is a fresh draft and has to be typeable immediately.
+  useEffect(() => {
+    if (!isOpen) return
+    titleRef.current?.focus()
+  }, [isOpen])
+
+  const isEvent = draft.kind === CaptureKind.event
+  const isHabit = draft.kind === CaptureKind.habit
+  const earnsRewards = draft.kind === CaptureKind.task || isHabit
+
+  /** Canon closes any open editor when another one expands. */
+  const closeOpenTimeEditors = () => {
+    // `done`, not `discard`: the value the user landed on is kept, which is
+    // what `isShowingTimePicker = false` does on the Swift side.
+    if (isEditingStartTime) onEndTimeEdit('start', 'done')
+    if (isEditingEndTime) onEndTimeEdit('end', 'done')
+  }
+
+  const togglePanel = (next: Exclude<PromptPanel, null>) => {
+    setPanel((current) => (current === next ? null : next))
+    closeOpenTimeEditors()
+  }
+
+  const toggleTimeEdit = (field: CaptureTimeField) => {
+    setPanel(null)
+    const isEditingThis =
+      field === 'start' ? isEditingStartTime : isEditingEndTime
+    if (isEditingThis) {
+      onEndTimeEdit(field, 'done')
+      return
+    }
+    closeOpenTimeEditors()
+    onBeginTimeEdit(field)
+  }
+
+  return (
+    <div className="flex flex-col" data-slot="capture-prompt-form">
+      {/* ── Kind picker ─────────────────────────────────────────────── */}
+      <div
+        className="flex gap-2 overflow-x-auto px-3 pt-4 pb-3"
+        role="group"
+        aria-label="Kind"
+      >
+        {captureKinds.map((kind) => (
+          <KindChip
+            key={kind}
+            kind={kind}
+            isSelected={kind === draft.kind}
+            onSelect={() => {
+              setPanel(null)
+              onSelectKind(kind)
+            }}
+          />
+        ))}
+      </div>
+
+      <Separator />
+
+      {/* ── Title ───────────────────────────────────────────────────── */}
+      <input
+        ref={titleRef}
+        data-testid="capture-title"
+        aria-label="Title"
+        className={cn(
+          'w-full bg-transparent px-4 py-3.5 text-base outline-none',
+          'placeholder:text-kro-fore-secondary',
+        )}
+        style={{ color: colorVar('fore') }}
+        placeholder={captureKindPlaceholder(draft.kind)}
+        value={draft.title}
+        onChange={(event) => onEditTitle(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== 'Enter' || !canSubmit) return
+          event.preventDefault()
+          onSubmit()
+        }}
+      />
+
+      <Separator />
+
+      {/* ── Date / time row ─────────────────────────────────────────── */}
+      <div className="flex flex-col gap-2 py-2.5">
+        <div className="flex gap-2 overflow-x-auto px-3">
+          {earnsRewards ? (
+            <PromptChip
+              glyph={<Star size={12} aria-hidden />}
+              label={String(draft.rewards)}
+              isSet
+              isExpanded={panel === 'rewards'}
+              accessibilityLabel={`Rewards: ${draft.rewards} points`}
+              onSelect={() => togglePanel('rewards')}
+            />
+          ) : null}
+
+          {isHabit ? null : (
+            <PromptChip
+              glyph={<CalendarGlyph size={12} aria-hidden />}
+              label={formatCaptureDate(draft.date, now, locale)}
+              isSet
+              isExpanded={panel === 'date'}
+              accessibilityLabel={`Date: ${formatCaptureDate(draft.date, now, locale)}`}
+              onSelect={() => togglePanel('date')}
+            />
+          )}
+
+          <PromptChip
+            glyph={<ClockGlyph size={12} aria-hidden />}
+            label={
+              draft.hasTime
+                ? formatCaptureTime(draft.time, locale)
+                : isEvent
+                  ? 'Start'
+                  : 'No time'
+            }
+            isSet={draft.hasTime}
+            isExpanded={isEditingStartTime}
+            accessibilityLabel={isEvent ? 'Start time' : 'Time'}
+            onSelect={() => toggleTimeEdit('start')}
+          />
+
+          {isEvent ? (
+            <>
+              <PromptChip
+                glyph={<ClockEndGlyph size={12} aria-hidden />}
+                label={
+                  draft.hasEndTime
+                    ? formatCaptureTime(draft.endTime, locale)
+                    : 'End'
+                }
+                isSet={draft.hasEndTime}
+                isExpanded={isEditingEndTime}
+                accessibilityLabel="End time"
+                onSelect={() => toggleTimeEdit('end')}
+              />
+              {draft.hasEndTime ? (
+                <ClearButton
+                  label="Clear end time"
+                  onSelect={() => onEndTimeEdit('end', 'clear')}
+                />
+              ) : null}
+            </>
+          ) : draft.hasTime ? (
+            <ClearButton
+              label="Clear time"
+              onSelect={() => onEndTimeEdit('start', 'clear')}
+            />
+          ) : null}
+
+          <PromptChip
+            glyph={<RepeatGlyph size={12} aria-hidden />}
+            label={captureRepeatChipLabel(draft.recurrence)}
+            isSet={draft.recurrence.kind !== 'never'}
+            isExpanded={panel === 'repeat'}
+            accessibilityLabel={
+              draft.recurrence.kind === 'never'
+                ? 'Set repeat schedule'
+                : `Repeat: ${captureRepeatChipLabel(draft.recurrence)}`
+            }
+            onSelect={() => togglePanel('repeat')}
+          />
+        </div>
+
+        {panel === 'date' && !isHabit ? (
+          <div className="px-3">
+            <Input
+              type="date"
+              aria-label="Due date"
+              data-testid="capture-date-input"
+              // Canon's `in: Calendar.current.startOfDay(for: .now)...` — a
+              // capture is never scheduled into the past.
+              min={dateInputValue(now)}
+              value={dateInputValue(draft.date)}
+              onChange={(event) => {
+                const parsed = parseDateInput(event.target.value)
+                if (parsed !== null) onPickDate(parsed)
+              }}
+            />
+          </div>
+        ) : null}
+
+        {isEditingStartTime ? (
+          <TimePanel
+            field="start"
+            label={isEvent ? 'Start time' : 'Time'}
+            value={draft.time}
+            day={draft.date}
+            onPick={onPickTime}
+            onEnd={onEndTimeEdit}
+          />
+        ) : null}
+
+        {isEditingEndTime && isEvent ? (
+          <TimePanel
+            field="end"
+            label="End time"
+            value={draft.endTime}
+            day={draft.date}
+            onPick={onPickTime}
+            onEnd={onEndTimeEdit}
+          />
+        ) : null}
+
+        {panel === 'rewards' && earnsRewards ? (
+          <RewardsEditor points={draft.rewards} onPick={onPickRewards} />
+        ) : null}
+
+        {panel === 'repeat' ? (
+          <div
+            className="flex flex-wrap gap-2 px-3 py-1"
+            role="group"
+            aria-label="Repeat"
+            data-testid="capture-repeat-panel"
+          >
+            {captureRecurrencePresets(draft.date).map((preset) => (
+              <PromptChip
+                key={preset.id}
+                label={preset.label}
+                isSet={preset.recurrence.kind === draft.recurrence.kind}
+                isExpanded={preset.recurrence.kind === draft.recurrence.kind}
+                accessibilityLabel={preset.label}
+                onSelect={() => {
+                  onPickRecurrence(preset.recurrence)
+                  setPanel(null)
+                }}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <Separator />
+
+      {/* ── Bottom bar ──────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-2 px-3 py-3">
+        <div className="flex items-start justify-between gap-2">
+          <DestinationPicker
+            selected={draft.destination}
+            available={availableDestinations}
+            isExpanded={panel === 'destination'}
+            onToggle={() => togglePanel('destination')}
+            onSelect={(destination) => {
+              onSelectDestination(destination)
+              setPanel(null)
+            }}
+          />
+
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              variant="secondary"
+              size="pill"
+              className="w-24 px-0"
+              aria-label={`Discard new ${captureKindLabel(draft.kind).toLowerCase()}`}
+              onClick={onDiscard}
+            >
+              Discard
+            </Button>
+            <Button
+              variant="primary"
+              size="pill"
+              className="w-24 px-0"
+              data-testid="capture-add"
+              disabled={!canSubmit}
+              // A disabled control leaves the action surface of the a11y tree,
+              // so the reason is attached to it explicitly. This is the epic's
+              // "disabled submit controls name what blocks them" rule; canon
+              // (a bare `.disabled(!canSubmit)`) has no equivalent.
+              aria-describedby={
+                blockedReason === null ? undefined : 'capture-blocked-reason'
+              }
+              onClick={onSubmit}
+            >
+              Add
+            </Button>
+          </div>
+        </div>
+
+        {/*
+          Always mounted, so a screen reader announces the reason CHANGING
+          (untitled -> event missing a start) rather than only its arrival.
+        */}
+        <p
+          id="capture-blocked-reason"
+          data-testid="capture-blocked-reason"
+          aria-live="polite"
+          className={cn('m-0 text-sm', blockedReason === null && 'sr-only')}
+          style={{ color: colorVar('foreSecondary') }}
+        >
+          {blockedReason ?? ''}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* Parts                                                                     */
+/* ------------------------------------------------------------------------ */
+
+function Separator() {
+  return (
+    <div
+      aria-hidden
+      className="h-px w-full shrink-0"
+      style={{ backgroundColor: colorVar('hairline') }}
+    />
+  )
+}
+
+function KindChip({
+  kind,
+  isSelected,
+  onSelect,
+}: {
+  readonly kind: CaptureKind
+  readonly isSelected: boolean
+  readonly onSelect: () => void
+}) {
+  const Glyph = captureIconFor(captureKindGlyph(kind))
+  return (
+    <button
+      type="button"
+      // A toggle-button group rather than a radiogroup: radios owe the user
+      // arrow-key roving focus, and claiming the role without implementing it
+      // is worse than not claiming it. `aria-pressed` is canon's
+      // `.accessibilityAddTraits(.isSelected)` on the web.
+      aria-pressed={isSelected}
+      aria-label={captureKindLabel(kind)}
+      onClick={onSelect}
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1.5 rounded-kro-pill px-3',
+        'font-semibold text-sm',
+        'kro-motion-quick transition-[background-color,color]',
+        'outline-none focus-visible:shadow-[var(--kro-ring)]',
+      )}
+      style={{
+        minHeight: 'var(--kro-size-min-touch-target)',
+        backgroundColor: isSelected ? colorVar('accent') : 'transparent',
+        color: isSelected ? colorVar('onAccent') : colorVar('foreSecondary'),
+      }}
+    >
+      <Glyph size={13} aria-hidden />
+      {captureKindLabel(kind)}
+    </button>
+  )
+}
+
+function PromptChip({
+  glyph,
+  label,
+  isSet,
+  isExpanded,
+  accessibilityLabel,
+  onSelect,
+}: {
+  readonly glyph?: ReactNode
+  readonly label: string
+  readonly isSet: boolean
+  readonly isExpanded: boolean
+  readonly accessibilityLabel: string
+  readonly onSelect: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={accessibilityLabel}
+      aria-expanded={isExpanded}
+      onClick={onSelect}
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1.5 rounded-kro-pill px-2.5',
+        'font-medium text-sm',
+        'outline-none focus-visible:shadow-[var(--kro-ring)]',
+      )}
+      style={{
+        minHeight: 'var(--kro-size-min-touch-target)',
+        backgroundColor: isExpanded
+          ? `color-mix(in srgb, ${colorVar('accent')} 15%, transparent)`
+          : colorVar('backInner'),
+        color: isSet ? colorVar('fore') : colorVar('foreSecondary'),
+      }}
+    >
+      {glyph}
+      {label}
+    </button>
+  )
+}
+
+function ClearButton({
+  label,
+  onSelect,
+}: {
+  readonly label: string
+  readonly onSelect: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onSelect}
+      className="inline-flex shrink-0 items-center justify-center rounded-kro-pill outline-none focus-visible:shadow-[var(--kro-ring)]"
+      style={{
+        minWidth: 'var(--kro-size-min-touch-target)',
+        minHeight: 'var(--kro-size-min-touch-target)',
+        color: colorVar('foreSecondary'),
+      }}
+    >
+      <ClearGlyph size={16} aria-hidden />
+    </button>
+  )
+}
+
+/** Canon's inline `timePickerPanel` — the value, then Discard / Clear / Done. */
+function TimePanel({
+  field,
+  label,
+  value,
+  day,
+  onPick,
+  onEnd,
+}: {
+  readonly field: CaptureTimeField
+  readonly label: string
+  readonly value: Date
+  readonly day: Date
+  readonly onPick: (field: CaptureTimeField, time: Date) => void
+  readonly onEnd: (
+    field: CaptureTimeField,
+    outcome: CaptureTimeEditOutcome,
+  ) => void
+}) {
+  return (
+    <div
+      className="flex flex-col gap-2 px-3"
+      data-testid={`capture-time-panel-${field}`}
+    >
+      <Input
+        type="time"
+        aria-label={label}
+        value={timeInputValue(value)}
+        onChange={(event) => {
+          const parsed = parseTimeInput(event.target.value, day)
+          if (parsed !== null) onPick(field, parsed)
+        }}
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => onEnd(field, 'discard')}
+        >
+          Discard
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => onEnd(field, 'clear')}
+        >
+          Clear
+        </Button>
+        <span className="flex-1" />
+        <Button variant="primary" size="sm" onClick={() => onEnd(field, 'done')}>
+          <Check size={12} aria-hidden />
+          Done
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/** Canon's inline `rewardsEditor` — the 1…999 stepper, 5/10 by magnitude. */
+function RewardsEditor({
+  points,
+  onPick,
+}: {
+  readonly points: number
+  readonly onPick: (points: number) => void
+}) {
+  return (
+    <div
+      className="flex items-center gap-4 px-3 py-1"
+      data-testid="capture-rewards-editor"
+    >
+      <span className="text-sm" style={{ color: colorVar('foreSecondary') }}>
+        Reward points
+      </span>
+      <span className="flex-1" />
+      <div
+        className="flex items-center"
+        style={{
+          borderRadius: radiusVar('field'),
+          backgroundColor: colorVar('backInner'),
+        }}
+      >
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Decrease reward points"
+          disabled={points <= MINIMUM_CAPTURE_REWARDS}
+          onClick={() => onPick(points - captureRewardStep(points))}
+        >
+          −
+        </Button>
+        <span
+          className="min-w-9 text-center font-semibold text-base"
+          style={{ color: colorVar('fore') }}
+        >
+          {points}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Increase reward points"
+          disabled={points >= MAXIMUM_CAPTURE_REWARDS}
+          onClick={() => onPick(points + captureRewardStep(points))}
+        >
+          +
+        </Button>
+      </div>
+      <Star size={14} aria-hidden style={{ color: colorVar('rewardYellow') }} />
+    </div>
+  )
+}
+
+/**
+ * Canon's `destinationMenu`, as an inline disclosure rather than a popper.
+ *
+ * A Radix `DropdownMenu` is built on `@radix-ui/react-popper`, which this repo
+ * cannot mount in a test: the measurement recorded in
+ * `design/system/primitives/__tests__/radixEnvironment.tsx` is 5–12 SECONDS per
+ * mount under jsdom, enough to fail `make test` outright. An inline disclosure
+ * is also the idiom every other expanding control in this form already uses, so
+ * the panel gains no second grammar.
+ */
+function DestinationPicker({
+  selected,
+  available,
+  isExpanded,
+  onToggle,
+  onSelect,
+}: {
+  readonly selected: CaptureDestination
+  readonly available: readonly CaptureDestination[]
+  readonly isExpanded: boolean
+  readonly onToggle: () => void
+  readonly onSelect: (destination: CaptureDestination) => void
+}) {
+  const SelectedGlyph = captureIconFor(captureDestinationGlyph(selected))
+
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <button
+        type="button"
+        aria-label={`Hosting destination: ${captureDestinationLabel(selected)}`}
+        aria-expanded={isExpanded}
+        onClick={onToggle}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-kro-pill px-2.5',
+          'font-medium text-sm outline-none focus-visible:shadow-[var(--kro-ring)]',
+        )}
+        style={{
+          minHeight: 'var(--kro-size-min-touch-target)',
+          color: colorVar('fore'),
+        }}
+      >
+        <SelectedGlyph size={14} aria-hidden />
+        {captureDestinationLabel(selected)}
+        <ChevronDown size={10} aria-hidden />
+      </button>
+
+      {isExpanded ? (
+        <div
+          role="group"
+          aria-label="Hosting destination"
+          data-testid="capture-destination-options"
+          className="flex flex-col gap-1"
+        >
+          {available.map((destination) => {
+            const Glyph = captureIconFor(captureDestinationGlyph(destination))
+            return (
+              <button
+                key={destination}
+                type="button"
+                aria-pressed={destination === selected}
+                onClick={() => onSelect(destination)}
+                className={cn(
+                  'inline-flex w-full items-center gap-1.5 rounded-kro-small px-2.5 text-sm',
+                  'outline-none focus-visible:shadow-[var(--kro-ring)]',
+                )}
+                style={{
+                  minHeight: 'var(--kro-size-min-touch-target)',
+                  color: colorVar('fore'),
+                  backgroundColor:
+                    destination === selected
+                      ? colorVar('backInner')
+                      : 'transparent',
+                }}
+              >
+                <Glyph size={14} aria-hidden />
+                {captureDestinationLabel(destination)}
+              </button>
+            )
+          })}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/app/src/features/capture/pages/CapturePromptPage.stories.tsx
+++ b/packages/app/src/features/capture/pages/CapturePromptPage.stories.tsx
@@ -1,0 +1,87 @@
+/**
+ * The prompt Page, driven by a real store.
+ *
+ * Every story opens the prompt the way the app does — by dispatching
+ * `userDidRequestCapture` — so what is on screen is a state the reducer
+ * actually produced. `CapturePromptPage.test.tsx` mirrors this set (`RC-11`).
+ */
+
+import { userDidRequestCapture } from '../CaptureFeature'
+import { CAPTURE_MOCK_NOW } from '../CaptureMocks'
+import { CaptureKind } from '../CaptureRules'
+import { CapturePromptPage } from './CapturePromptPage'
+import {
+  CaptureStoreStage,
+  ThemeScope,
+  desktopSurface,
+  handheldSurface,
+  makeCaptureStore,
+} from './__tests__/captureHarness'
+import type { DoSurface } from '../../main/DoSurfaceLayout'
+
+export default {
+  title: 'Capture/Prompt page',
+  component: CapturePromptPage,
+  parameters: { layout: 'fullscreen' },
+}
+
+const opened = (kind: CaptureKind, surface: DoSurface) => {
+  const store = makeCaptureStore({ endeavors: [], surface })
+  store.dispatch(userDidRequestCapture({ kind, now: CAPTURE_MOCK_NOW }))
+  return store
+}
+
+/** A phone: the bottom sheet, sized to the form. */
+export const SheetOnPhone = {
+  render: () => (
+    <ThemeScope theme="light">
+      <CaptureStoreStage store={opened(CaptureKind.task, handheldSurface)}>
+        <CapturePromptPage />
+      </CaptureStoreStage>
+    </ThemeScope>
+  ),
+}
+
+/** A desktop: the glass popover in the FAB's own corner. */
+export const PopoverOnDesktop = {
+  render: () => (
+    <ThemeScope theme="light">
+      <CaptureStoreStage store={opened(CaptureKind.task, desktopSurface)}>
+        <CapturePromptPage />
+      </CaptureStoreStage>
+    </ThemeScope>
+  ),
+}
+
+/** An Event: the one kind canon gates on both a start and an end. */
+export const EventBlockedOnTimes = {
+  render: () => (
+    <ThemeScope theme="light">
+      <CaptureStoreStage store={opened(CaptureKind.event, handheldSurface)}>
+        <CapturePromptPage />
+      </CaptureStoreStage>
+    </ThemeScope>
+  ),
+}
+
+/** The desktop popover in the dark scheme. */
+export const PopoverDark = {
+  render: () => (
+    <ThemeScope theme="dark">
+      <CaptureStoreStage store={opened(CaptureKind.habit, desktopSurface)}>
+        <CapturePromptPage />
+      </CaptureStoreStage>
+    </ThemeScope>
+  ),
+}
+
+/** Nothing asked for: the Page renders nothing at all. */
+export const ClosedRendersNothing = {
+  render: () => (
+    <ThemeScope theme="light">
+      <CaptureStoreStage store={makeCaptureStore({ endeavors: [] })}>
+        <CapturePromptPage />
+      </CaptureStoreStage>
+    </ThemeScope>
+  ),
+}

--- a/packages/app/src/features/capture/pages/CapturePromptPage.tsx
+++ b/packages/app/src/features/capture/pages/CapturePromptPage.tsx
@@ -15,7 +15,7 @@
  * lets the Plan timeline's press-to-create (KC-IS-#19) reuse it unchanged.
  */
 
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../library/hooks'
 import { selectLayout } from '../../main/MainSelectors'
 import type { CaptureTimeEditOutcome, CaptureTimeField } from '../CaptureFeature'
@@ -62,8 +62,41 @@ export function CapturePromptPage() {
   const startEdit = useAppSelector((state) => state.capture.prompt?.startEdit)
   const endEdit = useAppSelector((state) => state.capture.prompt?.endEdit)
 
+  /**
+   * The instant the date chip is read against.
+   *
+   * The slice already parks one — `clockAnchor`, re-stamped by every event that
+   * carries a `now`, including `userDidRequestCapture` — so the view reads that
+   * rather than the wall clock. A `new Date()` in the render body would be a
+   * different instant on every keystroke, which is both a clock read in a
+   * render (the thing this feature's whole logic tier is built to avoid) and a
+   * fresh object that defeats every memo below it.
+   *
+   * The `useRef` covers the one window where the anchor is still `null` — the
+   * first paint of a store nothing has been asked of yet. Same shape, and same
+   * reasoning, as `useInboxSurface`.
+   */
+  const mountedAt = useRef(new Date())
+  const anchoredAt = useAppSelector((state) => state.capture.clockAnchor)
+  const now = anchoredAt ?? mountedAt.current
+
+  /**
+   * One capture per press.
+   *
+   * The write is asynchronous and `submitCaptureThunk` deliberately has no
+   * `.pending` arm — the slice keeps the prompt exactly as the user left it so
+   * a failed capture can be retried without re-typing — so Add stays enabled
+   * while the first write is in flight and a second press would mint a second
+   * id and persist a duplicate row. A ref rather than state because this is not
+   * feature state (`RC-4`): it is one press's own lifetime, it must not paint,
+   * and it is cleared when the write settles either way so a retry after a
+   * failure still works.
+   */
+  const isSubmitting = useRef(false)
+
   const onSubmit = useCallback(() => {
-    if (draft === null) return
+    if (draft === null || isSubmitting.current) return
+    isSubmitting.current = true
     void dispatch(
       submitCaptureThunk({
         draft,
@@ -73,7 +106,9 @@ export function CapturePromptPage() {
         id: crypto.randomUUID(),
         now: new Date(),
       }),
-    )
+    ).finally(() => {
+      isSubmitting.current = false
+    })
   }, [dispatch, draft])
 
   if (draft === null) return null
@@ -88,11 +123,7 @@ export function CapturePromptPage() {
       canSubmit={canSubmit}
       blockedReason={blockedReason}
       presentation={capturePromptPresentation(layout)}
-      // The instant "Today" is measured against. Read at render because the
-      // prompt is short-lived and always freshly opened; the draft's own
-      // committed instants come from the slice, which stamped them with the
-      // `now` the opening event carried.
-      now={new Date()}
+      now={now}
       onEditTitle={(title: string) => dispatch(userDidEditTitle({ title }))}
       onSelectKind={(kind: CaptureKind) => dispatch(userDidSelectKind({ kind }))}
       onPickDate={(date: Date) => dispatch(userDidPickDate({ date }))}

--- a/packages/app/src/features/capture/pages/CapturePromptPage.tsx
+++ b/packages/app/src/features/capture/pages/CapturePromptPage.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+/**
+ * The capture prompt's stateful container (`RC-37`).
+ *
+ * Selects, dispatches, renders one Fragment and owns no markup of its own.
+ * Every value it forwards comes from a named Selector; the two "is this picker
+ * open" flags are derived from the slice's own snapshots
+ * (`prompt.startEdit` / `prompt.endEdit`) rather than held here, because the
+ * snapshot IS the evidence an edit is in flight — see `withTimeEditBegun`.
+ *
+ * The prompt is mounted globally by `CaptureOverlays` and renders nothing while
+ * `capture.prompt` is `null`, so any surface can open it by dispatching
+ * `userDidRequestCapture` without owning a sheet of its own — which is what
+ * lets the Plan timeline's press-to-create (KC-IS-#19) reuse it unchanged.
+ */
+
+import { useCallback } from 'react'
+import { useAppDispatch, useAppSelector } from '../../../library/hooks'
+import { selectLayout } from '../../main/MainSelectors'
+import type { CaptureTimeEditOutcome, CaptureTimeField } from '../CaptureFeature'
+import {
+  userDidBeginTimeEdit,
+  userDidDiscardCapture,
+  userDidEditTitle,
+  userDidEndTimeEdit,
+  userDidPickDate,
+  userDidPickRecurrence,
+  userDidPickRewards,
+  userDidPickTime,
+  userDidSelectDestination,
+  userDidSelectKind,
+} from '../CaptureFeature'
+import { submitCaptureThunk } from '../CaptureProducer'
+import type {
+  CaptureDestination,
+  CaptureKind,
+  CaptureRecurrence,
+} from '../CaptureRules'
+import {
+  selectAvailableCaptureDestinations,
+  selectCanSubmitCapture,
+  selectCaptureBlockedReason,
+  selectCaptureDraft,
+} from '../CaptureSelectors'
+import { CapturePromptFragment } from './CapturePromptFragment'
+import { capturePromptPresentation } from './capturePresentation'
+
+export function CapturePromptPage() {
+  const dispatch = useAppDispatch()
+
+  const draft = useAppSelector(selectCaptureDraft)
+  const canSubmit = useAppSelector(selectCanSubmitCapture)
+  const blockedReason = useAppSelector(selectCaptureBlockedReason)
+  const availableDestinations = useAppSelector(
+    selectAvailableCaptureDestinations,
+  )
+  const layout = useAppSelector(selectLayout)
+
+  // O(1) field reads (`RC-5`): the snapshot objects themselves, never a boolean
+  // assembled inside the callback. The null check is done here, in the Page.
+  const startEdit = useAppSelector((state) => state.capture.prompt?.startEdit)
+  const endEdit = useAppSelector((state) => state.capture.prompt?.endEdit)
+
+  const onSubmit = useCallback(() => {
+    if (draft === null) return
+    void dispatch(
+      submitCaptureThunk({
+        draft,
+        // Identity is the composition root's to supply, never the Producer's —
+        // the rule `CaptureProducer`'s header states, and the one
+        // `MainShellPage` already follows for a new project.
+        id: crypto.randomUUID(),
+        now: new Date(),
+      }),
+    )
+  }, [dispatch, draft])
+
+  if (draft === null) return null
+
+  return (
+    <CapturePromptFragment
+      isOpen
+      draft={draft}
+      isEditingStartTime={startEdit != null}
+      isEditingEndTime={endEdit != null}
+      availableDestinations={availableDestinations}
+      canSubmit={canSubmit}
+      blockedReason={blockedReason}
+      presentation={capturePromptPresentation(layout)}
+      // The instant "Today" is measured against. Read at render because the
+      // prompt is short-lived and always freshly opened; the draft's own
+      // committed instants come from the slice, which stamped them with the
+      // `now` the opening event carried.
+      now={new Date()}
+      onEditTitle={(title: string) => dispatch(userDidEditTitle({ title }))}
+      onSelectKind={(kind: CaptureKind) => dispatch(userDidSelectKind({ kind }))}
+      onPickDate={(date: Date) => dispatch(userDidPickDate({ date }))}
+      onBeginTimeEdit={(field: CaptureTimeField) =>
+        dispatch(userDidBeginTimeEdit({ field }))
+      }
+      onPickTime={(field: CaptureTimeField, time: Date) =>
+        dispatch(userDidPickTime({ field, time }))
+      }
+      onEndTimeEdit={(field: CaptureTimeField, outcome: CaptureTimeEditOutcome) =>
+        dispatch(userDidEndTimeEdit({ field, outcome }))
+      }
+      onPickRewards={(points: number) => dispatch(userDidPickRewards({ points }))}
+      onPickRecurrence={(recurrence: CaptureRecurrence) =>
+        dispatch(userDidPickRecurrence({ recurrence }))
+      }
+      onSelectDestination={(destination: CaptureDestination) =>
+        dispatch(userDidSelectDestination({ destination }))
+      }
+      onDiscard={() => dispatch(userDidDiscardCapture())}
+      onSubmit={onSubmit}
+    />
+  )
+}

--- a/packages/app/src/features/capture/pages/CaptureQuickActionFragment.stories.tsx
+++ b/packages/app/src/features/capture/pages/CaptureQuickActionFragment.stories.tsx
@@ -1,0 +1,65 @@
+/**
+ * The default quick-action disc, and the destinations it stands down for.
+ *
+ * `CaptureQuickActionFragment.test.tsx` mirrors this set (`RC-11`).
+ */
+
+import { DestinationKind } from '../../main/SidebarDestination'
+import {
+  CaptureQuickActionFragment,
+  captureQuickActionShows,
+} from './CaptureQuickActionFragment'
+import { ThemeScope } from './__tests__/captureHarness'
+
+export default {
+  title: 'Capture/Quick action',
+  component: CaptureQuickActionFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+const noop = () => {}
+
+/** On a destination whose own child owns no FAB — canon's `default:` branch. */
+export const Visible = {
+  render: () => (
+    <ThemeScope theme="light">
+      <CaptureQuickActionFragment
+        isVisible={captureQuickActionShows({ kind: DestinationKind.allTasks })}
+        onPress={noop}
+      />
+    </ThemeScope>
+  ),
+}
+
+/** The same disc in the dark scheme. */
+export const Dark = {
+  render: () => (
+    <ThemeScope theme="dark">
+      <CaptureQuickActionFragment isVisible onPress={noop} />
+    </ThemeScope>
+  ),
+}
+
+/** Plan owns its own unfurling menu (KC-IS-#19), so this one stands down. */
+export const HiddenOnPlan = {
+  render: () => (
+    <ThemeScope theme="light">
+      <CaptureQuickActionFragment
+        isVisible={captureQuickActionShows({ kind: DestinationKind.plan })}
+        onPress={noop}
+      />
+    </ThemeScope>
+  ),
+}
+
+/** Search hides it outright — canon's `isQuickActionAvailable`. */
+export const HiddenOnSearch = {
+  render: () => (
+    <ThemeScope theme="light">
+      <CaptureQuickActionFragment
+        isVisible={captureQuickActionShows({ kind: DestinationKind.search })}
+        onPress={noop}
+      />
+    </ThemeScope>
+  ),
+}

--- a/packages/app/src/features/capture/pages/CaptureQuickActionFragment.tsx
+++ b/packages/app/src/features/capture/pages/CaptureQuickActionFragment.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+/**
+ * The quick-action FAB's **default** branch — canon
+ * `MainScreen.quickActionFAB`'s `default:` case, a 62pt glass disc drawing
+ * `plus` in the bottom-trailing corner (`RC-15`: pure, intent by callback).
+ *
+ * ## Which destinations it appears on
+ *
+ * Canon switches on the selected tab: Plan gets an unfurling kind menu, Do gets
+ * an action menu, Earn gets Add Reward, and *everything else* gets this one.
+ * Those three per-tab configurations belong to their own children (KC-IS-#17,
+ * KC-IS-#19, KC-IS-#28) — this child ships the default and exports the
+ * open-prompt intent for them to reuse, which is what `captureQuickActionShows`
+ * encodes. Canon's `isQuickActionAvailable` also hides the button on Search;
+ * that row is ported too.
+ *
+ * ## What it does, and where that parts company with canon's code
+ *
+ * Canon's `default:` branch calls `selectInbox()`, and says why in its own
+ * comment: *"Routes a quick-input / quick-action tap to the Inbox **until each
+ * option has its own dedicated creation flow**. Keeps the menus functional
+ * today and makes the future wiring an obvious one-line swap per case."* The
+ * dedicated creation flow is exactly what this issue ships, so the web takes
+ * the swap canon signposted: `plus` opens the capture prompt on Task — canon's
+ * own `plus`/"Quick Add" pairing from the Do menu
+ * (`.init(label: "Quick Add", glyph: "plus") { showPrompt(kind: .task) }`).
+ * The Inbox keeps its own front door: the shell's tray toolbar button and the
+ * sidebar's "Jot Down" row both reach the `/inbox` destination. Recorded as a
+ * divergence in the delivery PR.
+ *
+ * ## Where it is drawn
+ *
+ * Canon puts the FAB in the two phone bodies only; `padBody` and `wideBody`
+ * have none, because the Mac reaches the prompt through Do's empty-state
+ * Create and Plan's press-to-create. Neither of those exists on the web yet, so
+ * confining the disc to the tab-bar shell would leave the desktop with no
+ * capture entry point at all — it is drawn on both shells until #17/#19 land
+ * theirs, at which point narrowing it is one line. Also recorded in the PR.
+ */
+
+import { LiquidGlassFAB } from '../../../design/chrome/fab/LiquidGlassFAB'
+import { CHROME_LAYOUT } from '../../../design/chrome/layout/chromeLayout'
+import {
+  DestinationKind,
+  type SidebarDestination,
+} from '../../main/SidebarDestination'
+
+/**
+ * Whether the default quick action is drawn for `destination`.
+ *
+ * Canon's `default:` branch minus canon's `isQuickActionAvailable`: Plan, Do
+ * and Earn own their own FAB, and Search hides it outright.
+ */
+export const captureQuickActionShows = (
+  destination: SidebarDestination,
+): boolean => {
+  switch (destination.kind) {
+    case DestinationKind.plan:
+    case DestinationKind.myDay:
+    case DestinationKind.earn:
+    case DestinationKind.search:
+      return false
+    default:
+      return true
+  }
+}
+
+export interface CaptureQuickActionFragmentProps {
+  readonly isVisible: boolean
+  readonly onPress: () => void
+}
+
+export function CaptureQuickActionFragment({
+  isVisible,
+  onPress,
+}: CaptureQuickActionFragmentProps) {
+  if (!isVisible) return null
+
+  return (
+    <div
+      data-testid="capture-quick-action"
+      className="fixed z-40"
+      // Canon's `fabTrailingPadding` / `fabBottomPadding`, read from the chrome
+      // kit rather than retyped — the kit exists so the pill and the toast can
+      // compute their own offsets from the same two numbers.
+      style={{
+        right: `${CHROME_LAYOUT.fabTrailingPadding}px`,
+        bottom: `calc(${CHROME_LAYOUT.fabBottomPadding}px + env(safe-area-inset-bottom, 0px))`,
+      }}
+    >
+      <LiquidGlassFAB
+        glyph="plus"
+        accessibilityLabel="Quick add"
+        onClick={onPress}
+      />
+    </div>
+  )
+}

--- a/packages/app/src/features/capture/pages/CaptureQuickActionPage.stories.tsx
+++ b/packages/app/src/features/capture/pages/CaptureQuickActionPage.stories.tsx
@@ -1,0 +1,48 @@
+/**
+ * The default quick action, driven by a real store: what it draws follows the
+ * destination the shell has selected.
+ *
+ * `CaptureQuickActionPage.test.tsx` mirrors this set (`RC-11`).
+ */
+
+import { DestinationKind, type SidebarDestination } from '../../main/SidebarDestination'
+import { CaptureQuickActionPage } from './CaptureQuickActionPage'
+import {
+  CaptureStoreStage,
+  ThemeScope,
+  makeCaptureStore,
+} from './__tests__/captureHarness'
+
+export default {
+  title: 'Capture/Quick action page',
+  component: CaptureQuickActionPage,
+  parameters: { layout: 'fullscreen' },
+}
+
+const at = (destination: SidebarDestination, theme: 'light' | 'dark') => (
+  <ThemeScope theme={theme}>
+    <CaptureStoreStage store={makeCaptureStore({ endeavors: [], destination })}>
+      <CaptureQuickActionPage />
+    </CaptureStoreStage>
+  </ThemeScope>
+)
+
+/** All Tasks: nothing else owns a FAB there, so the default disc draws. */
+export const OnAllTasks = {
+  render: () => at({ kind: DestinationKind.allTasks }, 'light'),
+}
+
+/** The same disc in the dark scheme. */
+export const Dark = {
+  render: () => at({ kind: DestinationKind.allTasks }, 'dark'),
+}
+
+/** Plan: KC-IS-#19 owns the unfurling kind menu there, so this stands down. */
+export const OnPlanStandsDown = {
+  render: () => at({ kind: DestinationKind.plan }, 'light'),
+}
+
+/** Search: canon's `isQuickActionAvailable` hides it outright. */
+export const OnSearchHidden = {
+  render: () => at({ kind: DestinationKind.search }, 'light'),
+}

--- a/packages/app/src/features/capture/pages/CaptureQuickActionPage.tsx
+++ b/packages/app/src/features/capture/pages/CaptureQuickActionPage.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+/**
+ * The default quick action's stateful container (`RC-37`).
+ *
+ * Reads which destination is selected — through the shell's own root-level
+ * Selector, never by importing the shell's state shape (`RC-20`) — and
+ * dispatches the one intent the disc carries.
+ */
+
+import { useCallback } from 'react'
+import { useAppDispatch, useAppSelector } from '../../../library/hooks'
+import { selectSelectedDestination } from '../../main/MainSelectors'
+import { userDidRequestCapture } from '../CaptureFeature'
+import { CaptureKind } from '../CaptureRules'
+import {
+  CaptureQuickActionFragment,
+  captureQuickActionShows,
+} from './CaptureQuickActionFragment'
+
+export function CaptureQuickActionPage() {
+  const dispatch = useAppDispatch()
+  const selected = useAppSelector(selectSelectedDestination)
+
+  const onPress = useCallback(() => {
+    // Canon's `.init(label: "Quick Add", glyph: "plus") { showPrompt(kind: .task) }`
+    // — the pairing this disc inherits. `initialStart` is omitted, so the draft
+    // opens unscheduled and merely offers the quarter hour nearest `now`; the
+    // Plan timeline's press-to-create is the caller that passes one.
+    dispatch(
+      userDidRequestCapture({ kind: CaptureKind.task, now: new Date() }),
+    )
+  }, [dispatch])
+
+  return (
+    <CaptureQuickActionFragment
+      isVisible={captureQuickActionShows(selected)}
+      onPress={onPress}
+    />
+  )
+}

--- a/packages/app/src/features/capture/pages/InboxDestinationPage.stories.tsx
+++ b/packages/app/src/features/capture/pages/InboxDestinationPage.stories.tsx
@@ -1,0 +1,62 @@
+/**
+ * The `/inbox` destination Page — the sidebar's Jot Down row, filling the
+ * shell's content area.
+ *
+ * `InboxDestinationPage.test.tsx` mirrors this set (`RC-11`).
+ */
+
+import type { DoSurface } from '../../main/DoSurfaceLayout'
+import { captureFixtureRecords } from '../CaptureMocks'
+import { InboxDestinationPage } from './InboxDestinationPage'
+import {
+  CaptureStoreStage,
+  ThemeScope,
+  desktopSurface,
+  handheldSurface,
+  makeCaptureStore,
+} from './__tests__/captureHarness'
+
+export default {
+  title: 'Capture/Inbox destination page',
+  component: InboxDestinationPage,
+  parameters: { layout: 'fullscreen' },
+}
+
+const page = (
+  surface: DoSurface,
+  theme: 'light' | 'dark',
+  seeded = true,
+) => (
+  <ThemeScope theme={theme}>
+    <div style={{ height: 620 }}>
+      <CaptureStoreStage
+        store={makeCaptureStore({
+          endeavors: seeded ? captureFixtureRecords() : [],
+          surface,
+        })}
+      >
+        <InboxDestinationPage />
+      </CaptureStoreStage>
+    </div>
+  </ThemeScope>
+)
+
+/** The desktop page: compact rows, hover operations, no dismiss control. */
+export const DesktopSeeded = {
+  render: () => page(desktopSurface, 'light'),
+}
+
+/** The phone page: comfortable rows and swipe operations. */
+export const PhoneSeeded = {
+  render: () => page(handheldSurface, 'light'),
+}
+
+/** Nothing captured yet: the pinned header over a centred tray. */
+export const EmptyTray = {
+  render: () => page(desktopSurface, 'light', false),
+}
+
+/** The desktop page in the dark scheme. */
+export const DesktopDark = {
+  render: () => page(desktopSurface, 'dark'),
+}

--- a/packages/app/src/features/capture/pages/InboxDestinationPage.tsx
+++ b/packages/app/src/features/capture/pages/InboxDestinationPage.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+/**
+ * The `/inbox` destination — the sidebar's "Jot Down" row, as a full page
+ * (`RC-37`).
+ *
+ * Canon's macOS sidebar routes `.inbox` to a destination rather than to a
+ * popover; the popover is the *toolbar* affordance. The web keeps both, and
+ * this is the destination half: the same `InboxFragment`, presented inline in
+ * the shell's content area with no dialog and no dismiss control, because a
+ * page is navigated away from rather than dismissed.
+ *
+ * ## Why it yields to the overlay
+ *
+ * The shell turns a capture's inbox route into a navigation to this path
+ * (`selectPendingShellRoute` -> `deliverCaptureRouteThunk`), while the capture
+ * slice independently opens `inbox.isOpen`. Rendering both would put the same
+ * surface on screen twice, so the page stands down while the overlay is up —
+ * the overlay is the presentation canon uses for a capture that has just
+ * landed, and it carries the Just Created row. Dismissing it (Done, Escape,
+ * the overlay) clears `isOpen` and this page takes over, which is exactly right
+ * because the user is standing on Jot Down by then.
+ *
+ * The route mount is re-dispatched here rather than inherited from
+ * `DestinationPage`: that shared Page renders the placeholder, and a feature
+ * child replaces a destination's body by owning its route's Page. The
+ * selection dispatch is the part that must survive the swap — it is what makes
+ * a pasted link, a back step and a forward step all arrive as a fresh mount and
+ * move the sidebar's highlight (`RC-17`, `RC-63`).
+ */
+
+import { useEffect } from 'react'
+import { useAppDispatch } from '../../../library/hooks'
+import { onDestinationRouteMounted } from '../../main/MainFeature'
+import { DestinationKind } from '../../main/SidebarDestination'
+import { loadCaptureContextThunk } from '../CaptureProducer'
+import { InboxFragment } from './InboxFragment'
+import { useInboxSurface } from './useInboxSurface'
+
+export function InboxDestinationPage() {
+  const dispatch = useAppDispatch()
+  const inbox = useInboxSurface()
+
+  useEffect(() => {
+    dispatch(
+      onDestinationRouteMounted({
+        destination: { kind: DestinationKind.inbox },
+      }),
+    )
+    const effect = dispatch(loadCaptureContextThunk({ now: new Date() }))
+    return () => effect.abort()
+  }, [dispatch])
+
+  if (inbox.isOpen) return null
+
+  return <InboxFragment {...inbox} isOpen presentation="inline" />
+}

--- a/packages/app/src/features/capture/pages/InboxFragment.stories.tsx
+++ b/packages/app/src/features/capture/pages/InboxFragment.stories.tsx
@@ -1,0 +1,161 @@
+/**
+ * The Inbox in all three presentations, both row layouts, both schemes, and the
+ * three states canon's own previews cover: mixed, pending-only, empty.
+ *
+ * Every row is built from `captureEndeavorFixtures` through the same
+ * `endeavorCardModelFrom` seam the Page uses, and the row operations come from
+ * the shipped `EndeavorsVistas.inbox` — so a story cannot show a capability the
+ * vista does not declare (`RC-31`). `InboxFragment.test.tsx` mirrors this set
+ * (`RC-11`).
+ */
+
+import { EndeavorsVistas } from '@kro/core'
+import { endeavorCardModelFrom } from '../../../design/endeavor/endeavorCardModel'
+import { CAPTURE_MOCK_NOW, captureEndeavorFixtures } from '../CaptureMocks'
+import { nextQuarterHourSlot } from '../CaptureRules'
+import { InboxFragment, type InboxFragmentProps } from './InboxFragment'
+import { ThemeScope } from './__tests__/captureHarness'
+
+export default {
+  title: 'Capture/Inbox',
+  component: InboxFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+const noop = () => {}
+
+const card = (endeavor: Parameters<typeof endeavorCardModelFrom>[0]) =>
+  endeavorCardModelFrom(endeavor, CAPTURE_MOCK_NOW)
+
+const justCreated = card(captureEndeavorFixtures.freshTask)
+const pending = [
+  card(captureEndeavorFixtures.unscheduledReminder),
+  card(captureEndeavorFixtures.unscheduledHabit),
+  card(captureEndeavorFixtures.neglectedTask),
+]
+
+const inbox = (overrides: Partial<InboxFragmentProps> = {}) => (
+  <InboxFragment
+    isOpen
+    presentation="sheet"
+    justCreated={justCreated}
+    pendingTriage={pending}
+    totalCount={1 + pending.length}
+    isEmpty={false}
+    capabilities={EndeavorsVistas.inbox.capabilities}
+    rowLayout="comfortable"
+    addForToday={null}
+    now={CAPTURE_MOCK_NOW}
+    locale="en-US"
+    input="touch"
+    onDismiss={noop}
+    onTapTriage={noop}
+    onRequestAddForToday={noop}
+    onAdjustAddForTodayTime={noop}
+    onCancelAddForToday={noop}
+    onConfirmAddForToday={noop}
+    onOperation={noop}
+    {...overrides}
+  />
+)
+
+/** Canon's "Just Created + Pending Triage" preview, on a phone sheet. */
+export const SheetBothSections = {
+  render: () => <ThemeScope theme="light">{inbox()}</ThemeScope>,
+}
+
+/** Canon's "Pending Triage only" — the slot fires once per capture, then drains. */
+export const SheetPendingOnly = {
+  render: () => (
+    <ThemeScope theme="light">
+      {inbox({ justCreated: null, totalCount: pending.length })}
+    </ThemeScope>
+  ),
+}
+
+/** The pinned header over a centred tray — acceptance criterion 3. */
+export const SheetEmptyTray = {
+  render: () => (
+    <ThemeScope theme="light">
+      {inbox({
+        justCreated: null,
+        pendingTriage: [],
+        totalCount: 0,
+        isEmpty: true,
+      })}
+    </ThemeScope>
+  ),
+}
+
+/** The phone sheet in the dark scheme. */
+export const SheetDark = {
+  render: () => <ThemeScope theme="dark">{inbox()}</ThemeScope>,
+}
+
+/** Canon's macOS popover: 560 x 620, compact rows, hover operations. */
+export const PopoverBothSections = {
+  render: () => (
+    <ThemeScope theme="light">
+      {inbox({
+        presentation: 'popover',
+        rowLayout: 'compactDesktop',
+        input: 'pointer',
+      })}
+    </ThemeScope>
+  ),
+}
+
+/** The desktop popover with nothing to triage. */
+export const PopoverEmptyTray = {
+  render: () => (
+    <ThemeScope theme="light">
+      {inbox({
+        presentation: 'popover',
+        rowLayout: 'compactDesktop',
+        input: 'pointer',
+        justCreated: null,
+        pendingTriage: [],
+        totalCount: 0,
+        isEmpty: true,
+      })}
+    </ThemeScope>
+  ),
+}
+
+/** The desktop popover in the dark scheme. */
+export const PopoverDark = {
+  render: () => (
+    <ThemeScope theme="dark">
+      {inbox({
+        presentation: 'popover',
+        rowLayout: 'compactDesktop',
+        input: 'pointer',
+      })}
+    </ThemeScope>
+  ),
+}
+
+/** The Add-for-Today confirm, pre-filled with the next quarter hour. */
+export const AddForTodayOpen = {
+  render: () => (
+    <ThemeScope theme="light">
+      {inbox({
+        addForToday: {
+          endeavorId: justCreated.id,
+          pickedTime: nextQuarterHourSlot(CAPTURE_MOCK_NOW),
+        },
+      })}
+    </ThemeScope>
+  ),
+}
+
+/** The `/inbox` destination: no dialog, no dismiss — a page is navigated away from. */
+export const DestinationPageInline = {
+  render: () => (
+    <ThemeScope theme="light">
+      <div style={{ height: 620 }}>
+        {inbox({ presentation: 'inline', rowLayout: 'compactDesktop', input: 'pointer' })}
+      </div>
+    </ThemeScope>
+  ),
+}

--- a/packages/app/src/features/capture/pages/InboxFragment.tsx
+++ b/packages/app/src/features/capture/pages/InboxFragment.tsx
@@ -1,0 +1,587 @@
+'use client'
+
+/**
+ * The Inbox — canon `KroUI/Inbox/InboxView.swift`, as one pure Fragment
+ * (`RC-15`: it dispatches nothing; every intent arrives as a callback prop).
+ *
+ * ## One Fragment, three presentations
+ *
+ * Canon renders the same `InboxView` into three hosts: the phone's sheet, the
+ * Mac's 560 x 620 toolbar popover, and — through the sidebar's "Jot Down" row —
+ * a full destination. The body never changes; only the chrome around it does.
+ * So this Fragment takes a `presentation` and supplies the chrome itself:
+ *
+ *   · `sheet`     the handheld bottom sheet.
+ *   · `popover`   the desktop panel, framed by `PRESENTATION_SIZE.inbox`
+ *                 (560 x 620) — the shell's own ported constant, never a
+ *                 fifth copy of the numbers.
+ *   · `inline`    the `/inbox` destination page, filling the shell's content
+ *                 area. No dialog, no overlay, no dismiss control: a
+ *                 destination is not dismissed, it is navigated away from.
+ *
+ * ## The pinned header
+ *
+ * Canon's `VStack(spacing: 0) { header; List }` plus the empty state's
+ * `frame(maxHeight: .infinity)` is the acceptance criterion in one line: *the
+ * header stays pinned at the top and the tray illustration is centred in the
+ * remaining space*, so the sheet does not visually collapse around it. Here
+ * that is a flex column — a `shrink-0` header over a `flex-1` body — and the
+ * empty state's own `flex-1 justify-center` does the centring.
+ *
+ * ## Add for Today is expanded inline, not popped over
+ *
+ * Canon anchors a `SchedulePopover` to the row's button. A Radix popover is
+ * built on `@radix-ui/react-popper`, which this repo cannot mount in a test:
+ * the measurement in `design/system/primitives/__tests__/radixEnvironment.tsx`
+ * records 5–12 SECONDS per mount under jsdom, enough to fail `make test`
+ * outright — and the add-for-today -> undo interaction test is a requirement of
+ * KC-IS-#24, so the confirm surface has to be drivable. It expands under its
+ * row instead, which is also the idiom the capture prompt already uses for
+ * every one of its own pickers. Same content, same one-tap confirm, same
+ * next-quarter-hour prefill.
+ */
+
+import type { EndeavorCapabilities, EndeavorOperation } from '@kro/core'
+import type { ReactNode } from 'react'
+import { CompactPresentationHeader } from '../../../design/endeavor/CompactPresentationHeader'
+import { InboxTrayEmptyState } from '../../../design/endeavor/EmptyDayStateView'
+import { EndeavorRow } from '../../../design/endeavor/EndeavorRow'
+import type { EndeavorCardModel } from '../../../design/endeavor/endeavorCardModel'
+import {
+  type InputCapability,
+  useInputCapability,
+} from '../../../design/endeavor/useInputCapability'
+import { Button } from '../../../design/system/primitives/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '../../../design/system/primitives/dialog'
+import { Input } from '../../../design/system/primitives/input'
+import { SheetContent } from '../../../design/system/primitives/sheet'
+import { colorVar, radiusVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import { PRESENTATION_SIZE } from '../../main/MainPresentation'
+import type { CaptureAddForTodayState } from '../CaptureFeature'
+import { captureIcon, captureIconFor } from './captureIcons'
+import {
+  type InboxRowLayout,
+  inboxCountCaption,
+  inboxRowConfigFor,
+  parseTimeInput,
+  timeInputValue,
+} from './capturePresentation'
+
+const Sparkles = captureIcon('sparkles')
+const TrayFull = captureIcon('tray.full')
+const TriageGlyph = captureIconFor('rectangle.split.2x2.fill')
+const AddForTodayGlyph = captureIconFor('calendar.badge.plus')
+
+/** How the Inbox is hosted. `inline` is the `/inbox` destination page. */
+export type InboxPresentation = 'sheet' | 'popover' | 'inline'
+
+/**
+ * `position: fixed`, inline, for the reason spelled out in
+ * `CapturePromptFragment`: `glass.css`'s unlayered `.kro-glass` sets
+ * `position: relative`, which outranks Tailwind's layered `fixed` utility on
+ * every glass panel in the repo. Reported against KC-IS-#6's lane; when the
+ * one-line fix lands there, this deletes.
+ */
+const PINNED_TO_VIEWPORT = { position: 'fixed' } as const
+
+/**
+ * The width the row's own pointer chrome occupies at its trailing edge.
+ *
+ * `EndeavorActionSurface` overlays two things on the right of every row it
+ * wraps: the hover-revealed action strip (`right-2`, one 28px button per
+ * binding, 4px apart — 8 + 28 + 4 + 28 = 68 for the Inbox vista's two) and the
+ * context-menu trigger (28px at `top-1 right-1`). Both become clickable on
+ * hover, and both sit exactly where canon puts the Inbox's two explicit
+ * buttons — so without a reserved gutter the kit's chrome covers Triage and Add
+ * for Today and a pointer can never reach them.
+ *
+ * Reserved only on pointer, because on touch neither overlay is drawn.
+ * The number is measured from the kit rather than exported by it; that the kit
+ * does not reserve its own gutter when a row carries `trailing` is reported
+ * against KC-IS-#14's lane with this PR.
+ */
+const POINTER_ACTION_GUTTER_PX = 72
+
+export interface InboxFragmentProps {
+  /** Ignored by `inline`, which is always on screen. */
+  readonly isOpen: boolean
+  readonly presentation: InboxPresentation
+  /** Canon's `justCreatedCardSelector` — one row, or none. */
+  readonly justCreated: EndeavorCardModel | null
+  /** Canon's `pendingTriageSelector`, newest first. */
+  readonly pendingTriage: readonly EndeavorCardModel[]
+  readonly totalCount: number
+  readonly isEmpty: boolean
+  /** The Inbox vista's declared row operations — swipe on touch, hover on pointer. */
+  readonly capabilities: EndeavorCapabilities
+  readonly rowLayout: InboxRowLayout
+  /** The open Add-for-Today confirm, or `null`. */
+  readonly addForToday: CaptureAddForTodayState | null
+  readonly now: Date
+  readonly locale?: string
+  /** Forces the row input grammar. Stories and tests only; production detects it. */
+  readonly input?: InputCapability
+
+  readonly onDismiss: () => void
+  readonly onTapTriage: (endeavorId: string) => void
+  readonly onRequestAddForToday: (endeavorId: string) => void
+  readonly onAdjustAddForTodayTime: (time: Date) => void
+  readonly onCancelAddForToday: () => void
+  readonly onConfirmAddForToday: () => void
+  readonly onOperation: (
+    operation: EndeavorOperation,
+    endeavorId: string,
+  ) => void
+}
+
+export function InboxFragment(props: InboxFragmentProps) {
+  const { isOpen, presentation, onDismiss } = props
+
+  if (presentation === 'inline') {
+    return (
+      <section
+        data-testid="inbox-surface"
+        data-kro-presentation="inline"
+        aria-label="Inbox"
+        className="flex h-full min-h-0 w-full flex-col"
+      >
+        <InboxBody {...props} />
+      </section>
+    )
+  }
+
+  const heading = (
+    <>
+      <DialogTitle className="sr-only">Inbox</DialogTitle>
+      <DialogDescription className="sr-only">
+        {inboxCountCaption(props.totalCount) ?? 'Nothing to triage.'}
+      </DialogDescription>
+    </>
+  )
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(next) => {
+        if (!next) onDismiss()
+      }}
+    >
+      {presentation === 'sheet' ? (
+        <SheetContent
+          hideClose
+          side="bottom"
+          data-testid="inbox-surface"
+          data-kro-presentation="sheet"
+          className="flex h-[85vh] flex-col gap-0 p-0"
+          style={PINNED_TO_VIEWPORT}
+        >
+          {heading}
+          <InboxBody {...props} />
+        </SheetContent>
+      ) : (
+        <DialogContent
+          hideClose
+          data-testid="inbox-surface"
+          data-kro-presentation="popover"
+          className="flex max-w-none flex-col gap-0 p-0"
+          // Canon's `InboxScreen(...).frame(width: 560, height: 620)` on
+          // `macInboxButton`'s popover, read from the shell's ported table so
+          // the two can never disagree.
+          style={{
+            ...PINNED_TO_VIEWPORT,
+            width: `${PRESENTATION_SIZE.inbox.width}px`,
+            height: `${PRESENTATION_SIZE.inbox.height}px`,
+            maxWidth: 'calc(100vw - 3rem)',
+            maxHeight: 'calc(100dvh - 3rem)',
+          }}
+        >
+          {heading}
+          <InboxBody {...props} />
+        </DialogContent>
+      )}
+    </Dialog>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* Body                                                                      */
+/* ------------------------------------------------------------------------ */
+
+function InboxBody({
+  presentation,
+  justCreated,
+  pendingTriage,
+  totalCount,
+  isEmpty,
+  capabilities,
+  rowLayout,
+  addForToday,
+  now,
+  locale,
+  input,
+  onDismiss,
+  onTapTriage,
+  onRequestAddForToday,
+  onAdjustAddForTodayTime,
+  onCancelAddForToday,
+  onConfirmAddForToday,
+  onOperation,
+}: InboxFragmentProps) {
+  const rowProps = {
+    capabilities,
+    rowLayout,
+    addForToday,
+    now,
+    locale,
+    input,
+    onTapTriage,
+    onRequestAddForToday,
+    onAdjustAddForTodayTime,
+    onCancelAddForToday,
+    onConfirmAddForToday,
+    onOperation,
+  }
+
+  return (
+    <>
+      <InboxHeader
+        presentation={presentation}
+        rowLayout={rowLayout}
+        totalCount={totalCount}
+        onDismiss={onDismiss}
+      />
+
+      {isEmpty ? (
+        <div className="flex min-h-0 flex-1 flex-col">
+          <InboxTrayEmptyState />
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto py-2">
+          {justCreated === null ? null : (
+            <InboxSection
+              title="Just Created"
+              glyph={<Sparkles size={14} aria-hidden />}
+              cards={[justCreated]}
+              {...rowProps}
+            />
+          )}
+          {pendingTriage.length === 0 ? null : (
+            <InboxSection
+              title="Pending Triage"
+              glyph={<TrayFull size={14} aria-hidden />}
+              cards={pendingTriage}
+              {...rowProps}
+            />
+          )}
+        </div>
+      )}
+    </>
+  )
+}
+
+/**
+ * Canon's `header`: the compact presentation header on a pointer-first surface,
+ * the title + Done row otherwise.
+ *
+ * The destination presentation drops the dismiss control in both shapes — the
+ * shell's own chrome carries the heading there, and a page has nothing to
+ * dismiss.
+ */
+function InboxHeader({
+  presentation,
+  rowLayout,
+  totalCount,
+  onDismiss,
+}: {
+  readonly presentation: InboxPresentation
+  readonly rowLayout: InboxRowLayout
+  readonly totalCount: number
+  readonly onDismiss: () => void
+}) {
+  const caption = inboxCountCaption(totalCount)
+  const isDestination = presentation === 'inline'
+
+  if (rowLayout === 'compactDesktop') {
+    return (
+      <div className="shrink-0">
+        <CompactPresentationHeader
+          title="Inbox"
+          subtitle={caption}
+          leadingAction={
+            isDestination ? undefined : { kind: 'dismiss', onPress: onDismiss }
+          }
+        />
+      </div>
+    )
+  }
+
+  return (
+    <header className="flex shrink-0 items-center gap-3 px-5 pt-4 pb-4">
+      <div className="flex min-w-0 flex-col gap-1">
+        <p
+          className="m-0 font-bold text-xl"
+          style={{ color: colorVar('fore') }}
+        >
+          Inbox
+        </p>
+        {caption === undefined ? null : (
+          <p
+            className="m-0 text-sm"
+            style={{ color: colorVar('foreSecondary') }}
+          >
+            {caption}
+          </p>
+        )}
+      </div>
+      <span className="flex-1" />
+      {isDestination ? null : (
+        <Button variant="ghost" onClick={onDismiss}>
+          Done
+        </Button>
+      )}
+    </header>
+  )
+}
+
+type SectionProps = {
+  readonly title: string
+  readonly glyph: ReactNode
+  readonly cards: readonly EndeavorCardModel[]
+} & Pick<
+  InboxFragmentProps,
+  | 'capabilities'
+  | 'rowLayout'
+  | 'addForToday'
+  | 'now'
+  | 'locale'
+  | 'input'
+  | 'onTapTriage'
+  | 'onRequestAddForToday'
+  | 'onAdjustAddForTodayTime'
+  | 'onCancelAddForToday'
+  | 'onConfirmAddForToday'
+  | 'onOperation'
+>
+
+function InboxSection({ title, glyph, cards, ...row }: SectionProps) {
+  const compact = row.rowLayout === 'compactDesktop'
+  return (
+    <section
+      aria-label={title}
+      data-testid={`inbox-section-${title.toLowerCase().replace(/\s+/g, '-')}`}
+      className={cn('flex flex-col gap-2', compact ? 'px-2.5' : 'px-4')}
+    >
+      <header className="flex items-center gap-2 pt-2">
+        <span style={{ color: colorVar('foreSecondary') }}>{glyph}</span>
+        <h3
+          className="m-0 font-semibold text-sm"
+          style={{ color: colorVar('foreSecondary') }}
+        >
+          {title}
+        </h3>
+        <span className="flex-1" />
+        <span
+          className="rounded-kro-pill px-2 py-0.5 font-bold text-xs"
+          style={{
+            color: colorVar('foreSecondary'),
+            backgroundColor: `color-mix(in srgb, ${colorVar('fore')} 8%, transparent)`,
+          }}
+        >
+          {cards.length}
+        </span>
+      </header>
+
+      <ul className={cn('m-0 flex list-none flex-col p-0', compact ? 'gap-1' : 'gap-2')}>
+        {cards.map((card) => (
+          <li key={card.id}>
+            <InboxRow card={card} {...row} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* Row                                                                       */
+/* ------------------------------------------------------------------------ */
+
+function InboxRow({
+  card,
+  capabilities,
+  rowLayout,
+  addForToday,
+  now,
+  locale,
+  input,
+  onTapTriage,
+  onRequestAddForToday,
+  onAdjustAddForTodayTime,
+  onCancelAddForToday,
+  onConfirmAddForToday,
+  onOperation,
+}: { readonly card: EndeavorCardModel } & Omit<SectionProps, 'title' | 'glyph' | 'cards'>) {
+  const detected = useInputCapability()
+  const resolvedInput = input ?? detected
+  const compact = rowLayout === 'compactDesktop'
+  const isScheduling = addForToday?.endeavorId === card.id
+
+  return (
+    <div className="flex flex-col gap-2">
+      <EndeavorRow
+        endeavorId={card.id}
+        symbol={card.symbol}
+        title={card.title}
+        badges={
+          // Canon's `InboxRowWrapper`: urgency only when it is worth reading,
+          // then the reward. Time info is off in both Inbox presets.
+          card.urgency === 'low'
+            ? [{ kind: 'reward', amount: card.reward }]
+            : [
+                { kind: 'urgency', urgency: card.urgency },
+                { kind: 'reward', amount: card.reward },
+              ]
+        }
+        config={inboxRowConfigFor(rowLayout)}
+        now={now}
+        locale={locale}
+        capabilities={capabilities}
+        onOperation={onOperation}
+        input={input}
+        trailing={
+          <div
+            className={cn(
+              'relative z-2 flex shrink-0',
+              compact ? 'items-center gap-1.5' : 'w-[130px] flex-col gap-1.5',
+            )}
+            style={{
+              marginRight:
+                resolvedInput === 'pointer' ? POINTER_ACTION_GUTTER_PX : 0,
+            }}
+            // A swipe never starts on an action button. Without this the row's
+            // own `onPointerDown` calls `setPointerCapture`, and a captured
+            // pointer retargets the subsequent `click` to the capturing element
+            // — so in a real browser the tap lands on the row and canon's two
+            // in-row buttons never fire at all. jsdom implements no pointer
+            // capture, which is why only a browser could find this. Reported
+            // against KC-IS-#14's lane with this PR.
+            onPointerDown={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              aria-label={`Triage ${card.title}`}
+              onClick={() => onTapTriage(card.id)}
+              className={cn(
+                'inline-flex items-center justify-center gap-1 rounded-kro-pill px-2.5',
+                'font-semibold text-white text-xs',
+                'outline-none focus-visible:shadow-[var(--kro-ring)]',
+                compact ? 'h-7' : 'w-full py-1.5',
+              )}
+              style={{ backgroundColor: colorVar('badgeBlue') }}
+            >
+              <TriageGlyph size={11} aria-hidden />
+              Triage
+            </button>
+
+            <button
+              type="button"
+              aria-label={`Add ${card.title} for today`}
+              aria-expanded={isScheduling}
+              onClick={() => onRequestAddForToday(card.id)}
+              className={cn(
+                'inline-flex items-center justify-center gap-1 rounded-kro-pill',
+                'font-semibold text-xs',
+                'outline-none focus-visible:shadow-[var(--kro-ring)]',
+                compact ? 'size-7' : 'w-full px-2.5 py-1.5',
+              )}
+              style={{
+                color: colorVar('badgeGreen'),
+                backgroundColor: `color-mix(in srgb, ${colorVar('badgeGreen')} 15%, transparent)`,
+              }}
+            >
+              {compact ? (
+                <AddForTodayGlyph size={13} aria-hidden />
+              ) : (
+                'Add for Today'
+              )}
+            </button>
+          </div>
+        }
+      />
+
+      {isScheduling && addForToday !== null ? (
+        <AddForTodayConfirm
+          pickedTime={addForToday.pickedTime}
+          locale={locale}
+          onAdjust={onAdjustAddForTodayTime}
+          onCancel={onCancelAddForToday}
+          onConfirm={onConfirmAddForToday}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * Canon's `SchedulePopover`, expanded under its row.
+ *
+ * The time is restricted to today, exactly as canon's `dateInterval` is
+ * (`startOfDay ... 23:59`): the input carries only a time-of-day, and the day
+ * comes from the prefilled instant the slice computed, so there is no way to
+ * name a slot outside today at all.
+ */
+function AddForTodayConfirm({
+  pickedTime,
+  locale,
+  onAdjust,
+  onCancel,
+  onConfirm,
+}: {
+  readonly pickedTime: Date
+  readonly locale?: string
+  readonly onAdjust: (time: Date) => void
+  readonly onCancel: () => void
+  readonly onConfirm: () => void
+}) {
+  return (
+    <div
+      data-testid="add-for-today-confirm"
+      role="group"
+      aria-label="Add for Today"
+      className="flex flex-col gap-3 p-3.5"
+      style={{
+        borderRadius: radiusVar('surface'),
+        backgroundColor: colorVar('backInner'),
+      }}
+    >
+      <p className="m-0 font-semibold text-base" style={{ color: colorVar('fore') }}>
+        Add for Today
+      </p>
+      <Input
+        type="time"
+        aria-label="Time"
+        data-testid="add-for-today-time"
+        lang={locale}
+        value={timeInputValue(pickedTime)}
+        onChange={(event) => {
+          const parsed = parseTimeInput(event.target.value, pickedTime)
+          if (parsed !== null) onAdjust(parsed)
+        }}
+      />
+      <div className="flex items-center justify-between gap-3">
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="primary" onClick={onConfirm}>
+          Schedule
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/features/capture/pages/InboxOverlayPage.stories.tsx
+++ b/packages/app/src/features/capture/pages/InboxOverlayPage.stories.tsx
@@ -1,0 +1,64 @@
+/**
+ * The Inbox overlay Page, driven by a real store: the pool arrives through
+ * `loadCaptureContextThunk` on mount, exactly as it does in the browser.
+ *
+ * `InboxOverlayPage.test.tsx` mirrors this set (`RC-11`).
+ */
+
+import { ActiveToastHost } from '../../../design/chrome/toast/ActiveToastHost'
+import type { DoSurface } from '../../main/DoSurfaceLayout'
+import { userDidTapOpenInbox } from '../CaptureFeature'
+import { captureFixtureRecords } from '../CaptureMocks'
+import { InboxOverlayPage } from './InboxOverlayPage'
+import {
+  CaptureStoreStage,
+  ThemeScope,
+  desktopSurface,
+  handheldSurface,
+  makeCaptureStore,
+} from './__tests__/captureHarness'
+
+export default {
+  title: 'Capture/Inbox overlay page',
+  component: InboxOverlayPage,
+  parameters: { layout: 'fullscreen' },
+}
+
+const opened = (surface: DoSurface, seeded = true) => {
+  const store = makeCaptureStore({
+    endeavors: seeded ? captureFixtureRecords() : [],
+    surface,
+  })
+  store.dispatch(userDidTapOpenInbox())
+  return store
+}
+
+const overlay = (store: ReturnType<typeof opened>, theme: 'light' | 'dark') => (
+  <ThemeScope theme={theme}>
+    <CaptureStoreStage store={store}>
+      <ActiveToastHost>
+        <InboxOverlayPage />
+      </ActiveToastHost>
+    </CaptureStoreStage>
+  </ThemeScope>
+)
+
+/** The phone sheet, with rows loaded from the seeded store. */
+export const SheetOnPhone = {
+  render: () => overlay(opened(handheldSurface), 'light'),
+}
+
+/** The desktop popover at canon's 560 x 620, with the compact row. */
+export const PopoverOnDesktop = {
+  render: () => overlay(opened(desktopSurface), 'light'),
+}
+
+/** Nothing to triage: the pinned header over a centred tray. */
+export const EmptyTray = {
+  render: () => overlay(opened(desktopSurface, false), 'light'),
+}
+
+/** The desktop popover in the dark scheme. */
+export const PopoverDark = {
+  render: () => overlay(opened(desktopSurface), 'dark'),
+}

--- a/packages/app/src/features/capture/pages/InboxOverlayPage.tsx
+++ b/packages/app/src/features/capture/pages/InboxOverlayPage.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+/**
+ * The Inbox overlay's stateful container (`RC-37`) — the sheet on a handheld,
+ * the 560 x 620 popover on a desktop-shaped surface.
+ *
+ * Mounted globally by `CaptureOverlays`, so a capture routed to the Inbox
+ * (`withRouteDelivered`) presents it over whatever the user was looking at,
+ * which is canon's behaviour: *"everything else opens the Inbox and never
+ * auto-navigates"*.
+ *
+ * ## It also owns the Undo window
+ *
+ * Add for Today is confirmed from an Inbox row, so this Page is where the
+ * scheduling's ~8 s Undo lives. Two things happen when the window arms:
+ *
+ *   1. the toast goes up through the chrome kit's host — canon's
+ *      `ActionToastModel(message:…, icon: "calendar.badge.plus", iconColor:
+ *      .green, iconSize: 16, actionTitle: "Undo", duration: 8)`, field for
+ *      field; and
+ *   2. a single timer dispatches `onUndoWindowTicked` at the deadline the slice
+ *      already computed.
+ *
+ * The timer is a *view* concern in exactly the sense `MainShellPage`'s routing
+ * delay is: the **decision** (when the window closes) is state, computed by
+ * `withUndoWindowChecked` against an injected instant, and this only tells the
+ * slice that the instant has arrived. Nothing here decides anything, which is
+ * why "undo at 7.999 s works, at 8.001 s does not" stays a plain unit test one
+ * tier down.
+ */
+
+import { useEffect } from 'react'
+import { useActiveToasts } from '../../../design/chrome/toast/ActiveToastHost'
+import { useAppDispatch, useAppSelector } from '../../../library/hooks'
+import { selectSurface } from '../../main/MainSelectors'
+import { PresentationSurface, presentationFor } from '../../main/MainPresentation'
+import { onUndoWindowTicked } from '../CaptureFeature'
+import {
+  loadCaptureContextThunk,
+  undoScheduleForTodayThunk,
+} from '../CaptureProducer'
+import {
+  selectSchedulingUndo,
+  selectUndoSnapshot,
+} from '../CaptureSelectors'
+import { InboxFragment } from './InboxFragment'
+import { schedulingToastMessage } from './capturePresentation'
+import { useInboxSurface } from './useInboxSurface'
+
+export function InboxOverlayPage() {
+  const dispatch = useAppDispatch()
+  const inbox = useInboxSurface()
+  const surface = useAppSelector(selectSurface)
+  const undo = useAppSelector(selectSchedulingUndo)
+  const snapshot = useAppSelector(selectUndoSnapshot)
+
+  const { enqueue, dismiss } = useActiveToasts()
+
+  // The pool every Inbox read sits on. Mounted once with the shell, so the
+  // rows are already there the moment a capture routes into the sheet.
+  useEffect(() => {
+    const effect = dispatch(loadCaptureContextThunk({ now: new Date() }))
+    return () => effect.abort()
+  }, [dispatch])
+
+  const undoTitle = undo?.title ?? null
+  const undoScheduledAtMs = undo?.scheduledAt.getTime() ?? null
+  const undoExpiresAtMs = undo?.expiresAt.getTime() ?? null
+
+  useEffect(() => {
+    if (
+      snapshot === null ||
+      undoTitle === null ||
+      undoScheduledAtMs === null ||
+      undoExpiresAtMs === null
+    ) {
+      return
+    }
+
+    const id = enqueue({
+      message: schedulingToastMessage(undoTitle, new Date(undoScheduledAtMs)),
+      // Canon draws `calendar.badge.plus`. `ActiveToastInput.icon` is typed to
+      // the design system's own `SfSymbolName`, which does not carry that row
+      // yet — the endeavor kit's extension map does, and the toast host cannot
+      // see it. `calendar` is the nearest symbol both files agree on; folding
+      // `calendar.badge.plus` into `design/system/icons/icons.ts` (one line,
+      // that lane's) restores canon's glyph with no change here.
+      icon: 'calendar',
+      iconColor: 'green',
+      iconSize: 16,
+      // The host clamps into its documented 3–12 s reading window; 8 is canon's
+      // `duration: 8` and sits inside it, so the two agree without a cast.
+      duration: (undoExpiresAtMs - Date.now()) / 1000,
+      primaryAction: {
+        title: 'Undo',
+        onSelect: () => {
+          void dispatch(
+            undoScheduleForTodayThunk({ snapshot, now: new Date() }),
+          )
+          dismiss(id)
+        },
+      },
+    })
+
+    const timer = setTimeout(
+      () => dispatch(onUndoWindowTicked({ now: new Date() })),
+      Math.max(0, undoExpiresAtMs - Date.now()),
+    )
+
+    return () => {
+      clearTimeout(timer)
+      dismiss(id)
+    }
+  }, [
+    dispatch,
+    enqueue,
+    dismiss,
+    snapshot,
+    undoTitle,
+    undoScheduledAtMs,
+    undoExpiresAtMs,
+  ])
+
+  return (
+    <InboxFragment
+      {...inbox}
+      presentation={
+        presentationFor(PresentationSurface.inbox, surface).kind === 'popover'
+          ? 'popover'
+          : 'sheet'
+      }
+    />
+  )
+}

--- a/packages/app/src/features/capture/pages/InboxOverlayPage.tsx
+++ b/packages/app/src/features/capture/pages/InboxOverlayPage.tsx
@@ -39,6 +39,7 @@ import {
   loadCaptureContextThunk,
   undoScheduleForTodayThunk,
 } from '../CaptureProducer'
+import { ADD_FOR_TODAY_UNDO_WINDOW_MS } from '../CaptureRules'
 import {
   selectSchedulingUndo,
   selectUndoSnapshot,
@@ -88,9 +89,13 @@ export function InboxOverlayPage() {
       icon: 'calendar',
       iconColor: 'green',
       iconSize: 16,
-      // The host clamps into its documented 3–12 s reading window; 8 is canon's
-      // `duration: 8` and sits inside it, so the two agree without a cast.
-      duration: (undoExpiresAtMs - Date.now()) / 1000,
+      // Canon's `duration: 8`, read from the constant the slice sizes its own
+      // window with — never `expiresAt - Date.now()`. That subtraction takes a
+      // second clock reading, so it drifts from the deadline the slice already
+      // fixed and goes NEGATIVE if the effect is re-run after the window has
+      // closed. The host clamps into its documented 3–12 s reading window
+      // either way, so a negative would silently become 3.
+      duration: ADD_FOR_TODAY_UNDO_WINDOW_MS / 1000,
       primaryAction: {
         title: 'Undo',
         onSelect: () => {

--- a/packages/app/src/features/capture/pages/__tests__/CaptureOverlays.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/CaptureOverlays.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * The two flows KC-IS-#24 names as interaction tests, driven through the real
+ * composition: capture -> route, and add-for-today -> undo.
+ *
+ * Nothing is stubbed except the boundary the architecture already stubs — the
+ * `LocalStore`, injected through `ThunkExtra`. The prompt is typed into, Add is
+ * clicked, the real Producer writes, the real Shifters classify, and the
+ * assertions read the store the browser would read.
+ */
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { installRadixEnvironment } from '../../../../design/system/primitives/__tests__/radixEnvironment'
+import { onCaptureRouteDelivered, userDidTapOpenInbox } from '../../CaptureFeature'
+import { captureFixtureRecords } from '../../CaptureMocks'
+import { CAPTURE_INBOX_DELAY_MS } from '../../CaptureRules'
+import { CaptureOverlays } from '../CaptureOverlays'
+import {
+  type CaptureStore,
+  CaptureStoreStage,
+  desktopSurface,
+  handheldSurface,
+  installCaptureEnvironment,
+  makeCaptureStore,
+} from './captureHarness'
+
+let teardownRadix: () => void
+let teardownCapture: () => void
+
+beforeEach(() => {
+  teardownRadix = installRadixEnvironment()
+  teardownCapture = installCaptureEnvironment()
+})
+
+afterEach(() => {
+  cleanup()
+  teardownRadix()
+  teardownCapture()
+})
+
+const mount = (store: CaptureStore) =>
+  render(
+    <CaptureStoreStage store={store}>
+      <CaptureOverlays />
+    </CaptureStoreStage>,
+  )
+
+/** Walks the user through the disc, the title field and Add. */
+const captureTitled = async (title: string, kind = 'Task') => {
+  await userEvent.click(screen.getByRole('button', { name: 'Quick add' }))
+  if (kind !== 'Task') {
+    await userEvent.click(screen.getByRole('button', { name: kind }))
+  }
+  await userEvent.type(screen.getByTestId('capture-title'), title)
+  await userEvent.click(screen.getByTestId('capture-add'))
+}
+
+describe('capture -> route (acceptance criterion 3, first half)', () => {
+  it('routes a captured Task to the Inbox and opens it with its Just Created row', async () => {
+    const store = makeCaptureStore({ endeavors: [], surface: handheldSurface })
+    mount(store)
+
+    await captureTitled('Book the flights')
+
+    await waitFor(() => {
+      expect(store.getState().capture.navigation?.route.kind).toBe('inbox')
+    })
+    // The wait is the behaviour, so the shell's delivery is simulated at the
+    // deadline the slice itself computed rather than by sleeping.
+    const decidedAt = store.getState().capture.navigation?.decidedAt as Date
+    store.dispatch(
+      onCaptureRouteDelivered({
+        now: new Date(decidedAt.getTime() + CAPTURE_INBOX_DELAY_MS),
+      }),
+    )
+
+    const created = await screen.findByTestId('inbox-section-just-created')
+    expect(within(created).getByText('Book the flights')).toBeTruthy()
+    expect(store.getState().capture.prompt).toBeNull()
+  })
+
+  it('routes a captured Event to Plan instead, and never opens the Inbox for it', async () => {
+    const store = makeCaptureStore({ endeavors: [], surface: handheldSurface })
+    mount(store)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Quick add' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Event' }))
+    await userEvent.type(screen.getByTestId('capture-title'), 'Design review')
+    // Canon's stricter kind: an event needs both a start and an end before Add
+    // is even enabled, so the two chips are opened and confirmed here.
+    await userEvent.click(screen.getByRole('button', { name: 'Start time' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Done' }))
+    await userEvent.click(screen.getByRole('button', { name: 'End time' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Done' }))
+    await userEvent.click(screen.getByTestId('capture-add'))
+
+    await waitFor(() => {
+      expect(store.getState().capture.navigation?.route.kind).toBe('plan')
+    })
+    expect(store.getState().capture.inbox.isOpen).toBe(false)
+    expect(screen.queryByTestId('inbox-surface')).toBeNull()
+  })
+
+  it('refuses to submit an Event that is missing a time, and says which one', async () => {
+    const store = makeCaptureStore({ endeavors: [], surface: handheldSurface })
+    mount(store)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Quick add' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Event' }))
+    await userEvent.type(screen.getByTestId('capture-title'), 'Design review')
+
+    expect(
+      screen.getByTestId<HTMLButtonElement>('capture-add').disabled,
+    ).toBe(true)
+    expect(screen.getByTestId('capture-blocked-reason').textContent).toBe(
+      'Pick a start time and an end time to add this event.',
+    )
+    expect(store.getState().capture.endeavors).toHaveLength(0)
+  })
+
+  it('drops the draft whole on Discard, exactly as canon does', async () => {
+    const store = makeCaptureStore({ endeavors: [], surface: handheldSurface })
+    mount(store)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Quick add' }))
+    await userEvent.type(screen.getByTestId('capture-title'), 'Never mind')
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Discard new task' }),
+    )
+
+    expect(store.getState().capture.prompt).toBeNull()
+    expect(store.getState().capture.endeavors).toHaveLength(0)
+    expect(screen.queryByTestId('capture-prompt')).toBeNull()
+  })
+})
+
+describe('add for today -> undo (acceptance criterion 3, second half)', () => {
+  const openInboxWithRows = async (store: CaptureStore) => {
+    mount(store)
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+    store.dispatch(userDidTapOpenInbox())
+    return screen.findByTestId('inbox-surface')
+  }
+
+  it('pre-fills the next quarter-hour slot, schedules, and raises an Undo toast', async () => {
+    const store = makeCaptureStore({
+      endeavors: captureFixtureRecords(),
+      surface: desktopSurface,
+    })
+    await openInboxWithRows(store)
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add Draft the announcement for today' }),
+    )
+    const picked = store.getState().capture.addForToday?.pickedTime as Date
+    expect(picked.getMinutes() % 15).toBe(0)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Schedule' }))
+
+    await waitFor(() => {
+      expect(store.getState().capture.undo.kind).toBe('armed')
+    })
+    // Canon's copy, quotes included, with the slot named in the user's locale.
+    // The host prints it twice on purpose — once drawn, once into its live
+    // region — so the assertion is on the set, not on a single node.
+    expect(
+      (await screen.findAllByText(/"Draft the announcement" scheduled for /))
+        .length,
+    ).toBeGreaterThan(0)
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeTruthy()
+    // Canon dismisses the sheet and routes to Plan in the same step.
+    expect(store.getState().capture.inbox.isOpen).toBe(false)
+    expect(store.getState().capture.navigation?.route.kind).toBe('plan')
+  })
+
+  it('puts the row back exactly as it was when Undo is taken', async () => {
+    const store = makeCaptureStore({
+      endeavors: captureFixtureRecords(),
+      surface: desktopSurface,
+    })
+    await openInboxWithRows(store)
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add Draft the announcement for today' }),
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Schedule' }))
+    await waitFor(() => {
+      expect(store.getState().capture.undo.kind).toBe('armed')
+    })
+
+    const scheduled = store
+      .getState()
+      .capture.endeavors.find((endeavor) => endeavor.id === 'fresh-task')
+    expect(scheduled?.due).not.toBeNull()
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Undo' }))
+
+    await waitFor(() => {
+      expect(store.getState().capture.undo.kind).toBe('undone')
+    })
+    const restored = store
+      .getState()
+      .capture.endeavors.find((endeavor) => endeavor.id === 'fresh-task')
+    expect(restored?.due).toBeNull()
+    // The audit entry the scheduling appended goes with it, or the row would
+    // claim it had been deferred to a slot it was never on.
+    expect(restored?.defers).toHaveLength(0)
+  })
+
+  it('does nothing on a second Undo, because the window is already spent', async () => {
+    const store = makeCaptureStore({
+      endeavors: captureFixtureRecords(),
+      surface: desktopSurface,
+    })
+    await openInboxWithRows(store)
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add Draft the announcement for today' }),
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Schedule' }))
+    await waitFor(() => {
+      expect(store.getState().capture.undo.kind).toBe('armed')
+    })
+    await userEvent.click(await screen.findByRole('button', { name: 'Undo' }))
+    await waitFor(() => {
+      expect(store.getState().capture.undo.kind).toBe('undone')
+    })
+
+    // The toast goes with the window, so there is nothing left to press.
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Undo' })).toBeNull()
+    })
+    expect(store.getState().capture.undo.kind).toBe('undone')
+  })
+
+  it('cancels without touching the row', async () => {
+    const store = makeCaptureStore({
+      endeavors: captureFixtureRecords(),
+      surface: desktopSurface,
+    })
+    await openInboxWithRows(store)
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add Draft the announcement for today' }),
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(store.getState().capture.addForToday).toBeNull()
+    expect(store.getState().capture.undo.kind).toBe('idle')
+    expect(
+      store.getState().capture.endeavors.find((e) => e.id === 'fresh-task')?.due,
+    ).toBeNull()
+  })
+})

--- a/packages/app/src/features/capture/pages/__tests__/CapturePromptFragment.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/CapturePromptFragment.test.tsx
@@ -1,0 +1,297 @@
+/**
+ * The capture prompt's render tests, mirroring `CapturePromptFragment.stories`
+ * (`RC-11`).
+ *
+ * The pair that matters most is acceptance criterion 1: the disabled Add
+ * **names** what is blocking it, and the name changes as the draft does. Canon
+ * only computes a boolean, so this is the one place the epic's a11y contract is
+ * observable.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installRadixEnvironment } from '../../../../design/system/primitives/__tests__/radixEnvironment'
+import { CAPTURE_MOCK_NOW, captureDraftFixtures } from '../../CaptureMocks'
+import {
+  CaptureDestination,
+  type CaptureDraft,
+  canSubmitCapture,
+  captureBlockedReason,
+} from '../../CaptureRules'
+import {
+  CapturePromptFragment,
+  type CapturePromptFragmentProps,
+} from '../CapturePromptFragment'
+import { CAPTURE_PROMPT_POPOVER_WIDTH } from '../capturePresentation'
+import { installCaptureEnvironment } from './captureHarness'
+
+let teardownRadix: () => void
+let teardownCapture: () => void
+
+beforeEach(() => {
+  teardownRadix = installRadixEnvironment()
+  teardownCapture = installCaptureEnvironment()
+})
+
+afterEach(() => {
+  cleanup()
+  teardownRadix()
+  teardownCapture()
+})
+
+const noop = () => {}
+
+const renderPrompt = (
+  draft: CaptureDraft,
+  overrides: Partial<CapturePromptFragmentProps> = {},
+) =>
+  render(
+    <CapturePromptFragment
+      isOpen
+      draft={draft}
+      isEditingStartTime={false}
+      isEditingEndTime={false}
+      availableDestinations={[
+        CaptureDestination.local,
+        CaptureDestination.kroCloud,
+      ]}
+      canSubmit={canSubmitCapture(draft)}
+      blockedReason={captureBlockedReason(draft)}
+      presentation="sheet"
+      now={CAPTURE_MOCK_NOW}
+      locale="en-US"
+      onEditTitle={noop}
+      onSelectKind={noop}
+      onPickDate={noop}
+      onBeginTimeEdit={noop}
+      onPickTime={noop}
+      onEndTimeEdit={noop}
+      onPickRewards={noop}
+      onPickRecurrence={noop}
+      onSelectDestination={noop}
+      onDiscard={noop}
+      onSubmit={noop}
+      {...overrides}
+    />,
+  )
+
+describe('the disabled Add names what blocks it (acceptance criterion 1)', () => {
+  it('asks for a title on a fresh Task prompt', () => {
+    renderPrompt(captureDraftFixtures.emptyTask)
+
+    expect(
+      screen.getByTestId<HTMLButtonElement>('capture-add').disabled,
+    ).toBe(true)
+    expect(screen.getByTestId('capture-blocked-reason').textContent).toBe(
+      'Enter a title to add this task.',
+    )
+  })
+
+  it('asks an Event for both times once it has a title', () => {
+    renderPrompt(captureDraftFixtures.eventMissingBothTimes)
+
+    expect(screen.getByTestId('capture-blocked-reason').textContent).toBe(
+      'Pick a start time and an end time to add this event.',
+    )
+  })
+
+  it('asks only for the end once the Event has a start', () => {
+    renderPrompt(captureDraftFixtures.eventMissingEnd)
+
+    expect(screen.getByTestId('capture-blocked-reason').textContent).toBe(
+      'Pick an end time to add this event.',
+    )
+  })
+
+  it('still reports the missing title first on an untitled but fully timed Event', () => {
+    renderPrompt(captureDraftFixtures.untitledCompleteEvent)
+
+    expect(screen.getByTestId('capture-blocked-reason').textContent).toBe(
+      'Enter a title to add this event.',
+    )
+  })
+
+  it('enables Add and says nothing once the draft is valid', () => {
+    renderPrompt(captureDraftFixtures.titledTask)
+
+    expect(
+      screen.getByTestId<HTMLButtonElement>('capture-add').disabled,
+    ).toBe(false)
+    expect(screen.getByTestId('capture-blocked-reason').textContent).toBe('')
+  })
+
+  it('points the disabled Add at the reason, which a disabled control needs to be readable', () => {
+    renderPrompt(captureDraftFixtures.emptyTask)
+
+    expect(
+      screen.getByTestId('capture-add').getAttribute('aria-describedby'),
+    ).toBe('capture-blocked-reason')
+  })
+})
+
+describe('the chip strip follows the kind', () => {
+  it('offers canon\'s four kinds with the drafted one pressed', () => {
+    renderPrompt(captureDraftFixtures.emptyTask)
+
+    for (const label of ['Task', 'Event', 'Reminder', 'Habit']) {
+      expect(screen.getByRole('button', { name: label })).toBeTruthy()
+    }
+    expect(
+      screen.getByRole('button', { name: 'Task' }).getAttribute('aria-pressed'),
+    ).toBe('true')
+  })
+
+  it('drops the date chip for a Habit, which canon says is timeless', () => {
+    renderPrompt(captureDraftFixtures.titledHabit)
+
+    expect(screen.queryByRole('button', { name: /^Date:/ })).toBeNull()
+  })
+
+  it('shows an Event\'s end chip and hides it for every other kind', () => {
+    const { unmount } = renderPrompt(captureDraftFixtures.eventMissingEnd)
+    expect(screen.getByRole('button', { name: 'End time' })).toBeTruthy()
+    unmount()
+
+    renderPrompt(captureDraftFixtures.titledTask)
+    expect(screen.queryByRole('button', { name: 'End time' })).toBeNull()
+  })
+
+  it('offers rewards on a Task and never on a Reminder, which earns nothing', () => {
+    const { unmount } = renderPrompt(captureDraftFixtures.titledTask)
+    expect(screen.getByRole('button', { name: /^Rewards:/ })).toBeTruthy()
+    unmount()
+
+    renderPrompt(captureDraftFixtures.titledReminder)
+    expect(screen.queryByRole('button', { name: /^Rewards:/ })).toBeNull()
+  })
+
+  it('reads the date as "Today" for the day the draft is on', () => {
+    renderPrompt(captureDraftFixtures.titledTask)
+
+    expect(screen.getByRole('button', { name: 'Date: Today' })).toBeTruthy()
+  })
+})
+
+describe('the two presentations', () => {
+  it('sheets the panel from the bottom edge on a phone', () => {
+    renderPrompt(captureDraftFixtures.emptyTask)
+
+    expect(
+      screen.getByTestId('capture-prompt').getAttribute('data-kro-presentation'),
+    ).toBe('sheet')
+  })
+
+  it('pops it over the content at the named width on a desktop', () => {
+    renderPrompt(captureDraftFixtures.emptyTask, { presentation: 'popover' })
+
+    const panel = screen.getByTestId('capture-prompt')
+    expect(panel.getAttribute('data-kro-presentation')).toBe('popover')
+    expect(panel.style.width).toBe(`${CAPTURE_PROMPT_POPOVER_WIDTH}px`)
+  })
+
+  it('renders nothing at all while it is closed', () => {
+    renderPrompt(captureDraftFixtures.emptyTask, { isOpen: false })
+
+    expect(screen.queryByTestId('capture-prompt')).toBeNull()
+  })
+})
+
+describe('intent leaves through callbacks only (RC-15)', () => {
+  it('focuses the title field on open, as canon does after its sheet settles', () => {
+    renderPrompt(captureDraftFixtures.emptyTask)
+
+    expect(document.activeElement).toBe(screen.getByTestId('capture-title'))
+  })
+
+  it('raises every keystroke rather than holding the title locally', async () => {
+    const onEditTitle = vi.fn()
+    renderPrompt(captureDraftFixtures.emptyTask, { onEditTitle })
+
+    await userEvent.type(screen.getByTestId('capture-title'), 'Hi')
+
+    expect(onEditTitle).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats Escape as Discard — the same outcome canon\'s button produces', async () => {
+    const onDiscard = vi.fn()
+    renderPrompt(captureDraftFixtures.emptyTask, { onDiscard })
+
+    await userEvent.keyboard('{Escape}')
+
+    expect(onDiscard).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens the time editor through the slice rather than a local flag', async () => {
+    const onBeginTimeEdit = vi.fn()
+    renderPrompt(captureDraftFixtures.titledTask, { onBeginTimeEdit })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Time' }))
+
+    expect(onBeginTimeEdit).toHaveBeenCalledWith('start')
+  })
+
+  it('offers Discard, Clear and Done while an edit is in flight', async () => {
+    const onEndTimeEdit = vi.fn()
+    renderPrompt(captureDraftFixtures.timedTask, {
+      isEditingStartTime: true,
+      onEndTimeEdit,
+    })
+
+    expect(screen.getByTestId('capture-time-panel-start')).toBeTruthy()
+    await userEvent.click(screen.getByRole('button', { name: 'Discard' }))
+
+    expect(onEndTimeEdit).toHaveBeenCalledWith('start', 'discard')
+  })
+
+  it('picks a hosting destination from the inline list', async () => {
+    const onSelectDestination = vi.fn()
+    renderPrompt(captureDraftFixtures.titledTask, { onSelectDestination })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Hosting destination: On Device' }),
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Kro Cloud' }))
+
+    expect(onSelectDestination).toHaveBeenCalledWith(CaptureDestination.kroCloud)
+  })
+
+  it('submits on Enter only when the draft is valid', async () => {
+    const onSubmit = vi.fn()
+    const { unmount } = renderPrompt(captureDraftFixtures.emptyTask, { onSubmit })
+    await userEvent.type(screen.getByTestId('capture-title'), '{Enter}')
+    expect(onSubmit).not.toHaveBeenCalled()
+    unmount()
+
+    renderPrompt(captureDraftFixtures.titledTask, { onSubmit })
+    await userEvent.type(screen.getByTestId('capture-title'), '{Enter}')
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('steps rewards by canon\'s 5, and clamps the floor at 1', async () => {
+    const onPickRewards = vi.fn()
+    renderPrompt(captureDraftFixtures.titledTask, { onPickRewards })
+
+    await userEvent.click(screen.getByRole('button', { name: /^Rewards:/ }))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Increase reward points' }),
+    )
+
+    expect(onPickRewards).toHaveBeenCalledWith(15)
+  })
+
+  it('offers canon\'s five repeat shapes anchored to the drafted day', async () => {
+    const onPickRecurrence = vi.fn()
+    renderPrompt(captureDraftFixtures.titledTask, { onPickRecurrence })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Set repeat schedule' }),
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Weekly' }))
+
+    expect(onPickRecurrence).toHaveBeenCalledWith({
+      kind: 'weekly',
+      interval: 1,
+      weekdays: ['tuesday'],
+    })
+  })
+})

--- a/packages/app/src/features/capture/pages/__tests__/CapturePromptPage.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/CapturePromptPage.test.tsx
@@ -170,4 +170,60 @@ describe('every edit goes through the slice, never through local state', () => {
       'Water the plants',
     )
   })
+
+  it('captures once for one intent, however fast Add is pressed twice', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+    open(store)
+    await screen.findByTestId('capture-title')
+    await userEvent.type(screen.getByTestId('capture-title'), 'Book the flights')
+
+    // Two presses inside one frame — the shape a double-click takes, and the
+    // one an awaited `userEvent.click` can never produce because it lets the
+    // write settle in between. Add stays enabled on purpose (a failed capture
+    // must be retryable without re-typing), so the guard is what stops the
+    // second press minting a second id.
+    const add = screen.getByTestId<HTMLButtonElement>('capture-add')
+    add.click()
+    add.click()
+
+    await waitFor(() => {
+      expect(store.getState().capture.endeavors).toHaveLength(1)
+    })
+    // …and the prompt is gone, so there is nothing left to press either.
+    expect(store.getState().capture.prompt).toBeNull()
+  })
+})
+
+describe('the clock it reads "Today" against', () => {
+  it('comes from the slice\'s anchor, not from the wall clock', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+
+    // The prompt is opened with an instant a day behind the wall clock, which
+    // is what `clockAnchor` then holds and what the draft's own date is built
+    // from. A Page reading `new Date()` in render would compare the draft's
+    // yesterday against today and print a medium date; reading the anchor makes
+    // the two agree and the chip reads "Today".
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    store.dispatch(
+      userDidRequestCapture({ kind: CaptureKind.task, now: yesterday }),
+    )
+
+    expect(
+      await screen.findByRole('button', { name: 'Date: Today' }),
+    ).toBeTruthy()
+  })
+
+  it('still answers before anything has stamped an anchor', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+    open(store)
+
+    // `userDidRequestCapture` stamps the anchor itself, so this is the ordinary
+    // path; what it proves is that the fallback never leaves the chip blank.
+    expect(
+      await screen.findByRole('button', { name: 'Date: Today' }),
+    ).toBeTruthy()
+  })
 })

--- a/packages/app/src/features/capture/pages/__tests__/CapturePromptPage.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/CapturePromptPage.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * The prompt Page's render tests, mirroring `CapturePromptPage.stories`
+ * (`RC-11`).
+ *
+ * A Page's job is selection and dispatch, so these read the store rather than
+ * the markup wherever the markup is the Fragment's business.
+ */
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { installRadixEnvironment } from '../../../../design/system/primitives/__tests__/radixEnvironment'
+import { userDidRequestCapture } from '../../CaptureFeature'
+import { CAPTURE_MOCK_NOW } from '../../CaptureMocks'
+import { CaptureKind } from '../../CaptureRules'
+import { CAPTURE_PROMPT_POPOVER_WIDTH } from '../capturePresentation'
+import { CapturePromptPage } from '../CapturePromptPage'
+import {
+  type CaptureStore,
+  CaptureStoreStage,
+  desktopSurface,
+  handheldSurface,
+  installCaptureEnvironment,
+  makeCaptureStore,
+} from './captureHarness'
+
+let teardownRadix: () => void
+let teardownCapture: () => void
+
+beforeEach(() => {
+  teardownRadix = installRadixEnvironment()
+  teardownCapture = installCaptureEnvironment()
+})
+
+afterEach(() => {
+  cleanup()
+  teardownRadix()
+  teardownCapture()
+})
+
+const mount = (store: CaptureStore) =>
+  render(
+    <CaptureStoreStage store={store}>
+      <CapturePromptPage />
+    </CaptureStoreStage>,
+  )
+
+const open = (store: CaptureStore, kind: CaptureKind = CaptureKind.task) =>
+  store.dispatch(userDidRequestCapture({ kind, now: CAPTURE_MOCK_NOW }))
+
+describe('the Page renders nothing until a draft exists', () => {
+  it('is absent on a store no one has asked to capture on', () => {
+    mount(makeCaptureStore({ endeavors: [] }))
+
+    expect(screen.queryByTestId('capture-prompt')).toBeNull()
+  })
+
+  it('appears the moment the intent lands, from anywhere in the app', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+
+    open(store)
+
+    expect(await screen.findByTestId('capture-prompt')).toBeTruthy()
+  })
+
+  it('disappears again on Discard', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+    open(store)
+    await screen.findByTestId('capture-prompt')
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Discard new task' }),
+    )
+
+    expect(screen.queryByTestId('capture-prompt')).toBeNull()
+  })
+})
+
+describe('it presents itself from the ported decision table', () => {
+  it('sheets on a phone', async () => {
+    const store = makeCaptureStore({ endeavors: [], surface: handheldSurface })
+    mount(store)
+    open(store)
+
+    expect(
+      (await screen.findByTestId('capture-prompt')).getAttribute(
+        'data-kro-presentation',
+      ),
+    ).toBe('sheet')
+  })
+
+  it('pops over on a desktop, at the named width', async () => {
+    const store = makeCaptureStore({ endeavors: [], surface: desktopSurface })
+    mount(store)
+    open(store)
+
+    const panel = await screen.findByTestId('capture-prompt')
+    expect(panel.getAttribute('data-kro-presentation')).toBe('popover')
+    expect(panel.style.width).toBe(`${CAPTURE_PROMPT_POPOVER_WIDTH}px`)
+  })
+
+  it('opens on the kind it was asked for, with that kind\'s placeholder', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+    open(store, CaptureKind.reminder)
+
+    const title = await screen.findByTestId<HTMLInputElement>('capture-title')
+    expect(title.placeholder).toBe('What do you need to remember?')
+  })
+})
+
+describe('every edit goes through the slice, never through local state', () => {
+  it('writes the typed title into the draft', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+    open(store)
+    await screen.findByTestId('capture-title')
+
+    await userEvent.type(screen.getByTestId('capture-title'), 'Book the flights')
+
+    expect(store.getState().capture.prompt?.draft.title).toBe(
+      'Book the flights',
+    )
+  })
+
+  it('switches kind and drops both half-open picker snapshots with it', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+    open(store)
+    await screen.findByTestId('capture-prompt')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Time' }))
+    expect(store.getState().capture.prompt?.startEdit).not.toBeNull()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Event' }))
+
+    expect(store.getState().capture.prompt?.draft.kind).toBe(CaptureKind.event)
+    expect(store.getState().capture.prompt?.startEdit).toBeNull()
+  })
+
+  it('remembers the picked hosting destination on the draft, not on the app yet', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+    open(store)
+    await screen.findByTestId('capture-prompt')
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Hosting destination: On Device' }),
+    )
+
+    // `statusQuo` has `supabaseHosting` off, so On Device is the only offer —
+    // which is itself the assertion that the list comes from the slice.
+    expect(store.getState().capture.availableDestinations).toEqual(['local'])
+  })
+
+  it('writes the capture through the real Producer when Add is taken', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+    open(store)
+    await screen.findByTestId('capture-title')
+
+    await userEvent.type(screen.getByTestId('capture-title'), 'Water the plants')
+    await userEvent.click(screen.getByTestId('capture-add'))
+
+    await waitFor(() => {
+      expect(store.getState().capture.endeavors).toHaveLength(1)
+    })
+    expect(store.getState().capture.endeavors[0]?.title).toBe(
+      'Water the plants',
+    )
+  })
+})

--- a/packages/app/src/features/capture/pages/__tests__/CaptureQuickActionFragment.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/CaptureQuickActionFragment.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * The default quick action's render tests, mirroring its stories (`RC-11`).
+ *
+ * The rule under test is canon's own `switch store.selectedElement?.type` plus
+ * `isQuickActionAvailable`: three tabs own their own FAB, Search hides it, and
+ * everything else gets this disc.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CHROME_LAYOUT } from '../../../../design/chrome/layout/chromeLayout'
+import {
+  ALL_SIMPLE_DESTINATIONS,
+  DestinationKind,
+} from '../../../main/SidebarDestination'
+import {
+  CaptureQuickActionFragment,
+  captureQuickActionShows,
+} from '../CaptureQuickActionFragment'
+
+afterEach(cleanup)
+
+describe('captureQuickActionShows — canon\'s default: branch', () => {
+  it('stands down on the three tabs that own their own FAB', () => {
+    expect(captureQuickActionShows({ kind: DestinationKind.plan })).toBe(false)
+    expect(captureQuickActionShows({ kind: DestinationKind.myDay })).toBe(false)
+    expect(captureQuickActionShows({ kind: DestinationKind.earn })).toBe(false)
+  })
+
+  it('hides on Search, which canon\'s isQuickActionAvailable excludes outright', () => {
+    expect(captureQuickActionShows({ kind: DestinationKind.search })).toBe(false)
+  })
+
+  it('shows on every other destination, including a project list', () => {
+    expect(captureQuickActionShows({ kind: DestinationKind.allTasks })).toBe(true)
+    expect(captureQuickActionShows({ kind: DestinationKind.inbox })).toBe(true)
+    expect(
+      captureQuickActionShows({
+        kind: DestinationKind.list,
+        listId: 'work',
+        listTitle: 'Work',
+      }),
+    ).toBe(true)
+  })
+
+  it('answers for every destination the shell can select, with no gaps', () => {
+    const answered = ALL_SIMPLE_DESTINATIONS.filter(
+      (destination) => typeof captureQuickActionShows(destination) === 'boolean',
+    )
+    expect(answered.length).toBe(ALL_SIMPLE_DESTINATIONS.length)
+  })
+})
+
+describe('the disc itself', () => {
+  it('draws a named plus, never a bare glyph', () => {
+    render(<CaptureQuickActionFragment isVisible onPress={() => {}} />)
+
+    expect(screen.getByRole('button', { name: 'Quick add' })).toBeTruthy()
+  })
+
+  it('sits at canon\'s own trailing and bottom insets', () => {
+    render(<CaptureQuickActionFragment isVisible onPress={() => {}} />)
+
+    const anchor = screen.getByTestId('capture-quick-action')
+    expect(anchor.style.right).toBe(`${CHROME_LAYOUT.fabTrailingPadding}px`)
+    expect(anchor.style.bottom).toContain(`${CHROME_LAYOUT.fabBottomPadding}px`)
+  })
+
+  it('renders nothing at all where the destination owns its own FAB', () => {
+    render(<CaptureQuickActionFragment isVisible={false} onPress={() => {}} />)
+
+    expect(screen.queryByTestId('capture-quick-action')).toBeNull()
+  })
+
+  it('raises the intent rather than acting on it (RC-15)', async () => {
+    const onPress = vi.fn()
+    render(<CaptureQuickActionFragment isVisible onPress={onPress} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Quick add' }))
+
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/src/features/capture/pages/__tests__/CaptureQuickActionPage.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/CaptureQuickActionPage.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * The quick-action Page's render tests, mirroring
+ * `CaptureQuickActionPage.stories` (`RC-11`).
+ *
+ * It reads one thing — which destination the shell has selected — and
+ * dispatches one intent.
+ */
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { onDestinationRouteMounted } from '../../../main/MainFeature'
+import { DestinationKind } from '../../../main/SidebarDestination'
+import { CaptureKind } from '../../CaptureRules'
+import { CaptureQuickActionPage } from '../CaptureQuickActionPage'
+import {
+  type CaptureStore,
+  CaptureStoreStage,
+  installCaptureEnvironment,
+  makeCaptureStore,
+} from './captureHarness'
+
+let teardownCapture: () => void
+
+beforeEach(() => {
+  teardownCapture = installCaptureEnvironment()
+})
+
+afterEach(() => {
+  cleanup()
+  teardownCapture()
+})
+
+const mount = (store: CaptureStore) =>
+  render(
+    <CaptureStoreStage store={store}>
+      <CaptureQuickActionPage />
+    </CaptureStoreStage>,
+  )
+
+describe('it follows the selected destination', () => {
+  it('draws the disc where no other child owns a FAB', () => {
+    mount(
+      makeCaptureStore({
+        endeavors: [],
+        destination: { kind: DestinationKind.allTasks },
+      }),
+    )
+
+    expect(screen.getByRole('button', { name: 'Quick add' })).toBeTruthy()
+  })
+
+  it('stands down on Plan, whose own menu is KC-IS-#19\'s', () => {
+    mount(
+      makeCaptureStore({
+        endeavors: [],
+        destination: { kind: DestinationKind.plan },
+      }),
+    )
+
+    expect(screen.queryByRole('button', { name: 'Quick add' })).toBeNull()
+  })
+
+  it('follows a later selection rather than the one it mounted on', async () => {
+    const store = makeCaptureStore({
+      endeavors: [],
+      destination: { kind: DestinationKind.allTasks },
+    })
+    mount(store)
+    expect(screen.getByRole('button', { name: 'Quick add' })).toBeTruthy()
+
+    store.dispatch(
+      onDestinationRouteMounted({
+        destination: { kind: DestinationKind.plan },
+      }),
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Quick add' })).toBeNull()
+    })
+  })
+})
+
+describe('the intent it carries', () => {
+  it('opens the capture prompt on Task — canon\'s plus / "Quick Add" pairing', async () => {
+    const store = makeCaptureStore({
+      endeavors: [],
+      destination: { kind: DestinationKind.allTasks },
+    })
+    mount(store)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Quick add' }))
+
+    expect(store.getState().capture.prompt?.draft.kind).toBe(CaptureKind.task)
+  })
+
+  it('opens the draft unscheduled — only the Plan timeline seeds a start', async () => {
+    const store = makeCaptureStore({
+      endeavors: [],
+      destination: { kind: DestinationKind.allTasks },
+    })
+    mount(store)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Quick add' }))
+
+    expect(store.getState().capture.prompt?.draft.hasTime).toBe(false)
+    expect(store.getState().capture.prompt?.draft.hasEndTime).toBe(false)
+  })
+
+  it('seeds the draft with the remembered hosting destination', async () => {
+    const store = makeCaptureStore({
+      endeavors: [],
+      destination: { kind: DestinationKind.allTasks },
+    })
+    mount(store)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Quick add' }))
+
+    expect(store.getState().capture.prompt?.draft.destination).toBe(
+      store.getState().capture.lastUsedDestination,
+    )
+  })
+})

--- a/packages/app/src/features/capture/pages/__tests__/InboxDestinationPage.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/InboxDestinationPage.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * The `/inbox` destination Page's render tests, mirroring
+ * `InboxDestinationPage.stories` (`RC-11`).
+ *
+ * Three things only this Page can get wrong: the route mount that moves the
+ * sidebar's highlight, the inline presentation, and standing down while the
+ * overlay is up so the same surface is never on screen twice.
+ */
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { installRadixEnvironment } from '../../../../design/system/primitives/__tests__/radixEnvironment'
+import { DestinationKind } from '../../../main/SidebarDestination'
+import { userDidTapOpenInbox } from '../../CaptureFeature'
+import { captureFixtureRecords } from '../../CaptureMocks'
+import { InboxDestinationPage } from '../InboxDestinationPage'
+import {
+  type CaptureStore,
+  CaptureStoreStage,
+  desktopSurface,
+  handheldSurface,
+  installCaptureEnvironment,
+  makeCaptureStore,
+} from './captureHarness'
+
+let teardownRadix: () => void
+let teardownCapture: () => void
+
+beforeEach(() => {
+  teardownRadix = installRadixEnvironment()
+  teardownCapture = installCaptureEnvironment()
+})
+
+afterEach(() => {
+  cleanup()
+  teardownRadix()
+  teardownCapture()
+})
+
+const mount = (store: CaptureStore) =>
+  render(
+    <CaptureStoreStage store={store}>
+      <InboxDestinationPage />
+    </CaptureStoreStage>,
+  )
+
+describe('the route mount', () => {
+  it('selects Jot Down, so a pasted link moves the sidebar highlight', () => {
+    const store = makeCaptureStore({
+      endeavors: [],
+      destination: { kind: DestinationKind.myDay },
+    })
+    mount(store)
+
+    expect(store.getState().main.selected.kind).toBe(DestinationKind.inbox)
+  })
+
+  it('loads the pool itself, so the page is correct even standing alone', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+  })
+})
+
+describe('the inline presentation', () => {
+  it('draws the surface with no dialog and no dismiss control', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+
+    const surface = await screen.findByTestId('inbox-surface')
+    expect(surface.getAttribute('data-kro-presentation')).toBe('inline')
+    expect(screen.queryByRole('button', { name: 'Done' })).toBeNull()
+  })
+
+  it('lists the rows canon\'s Pending Triage selector keeps', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+
+    const triage = await screen.findByTestId('inbox-section-pending-triage')
+    expect(within(triage).getByText('Draft the announcement')).toBeTruthy()
+    expect(within(triage).getByText('Imported from somewhere')).toBeTruthy()
+  })
+
+  it('centres the tray under a pinned header when nothing is waiting', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+
+    expect(await screen.findByText('Inbox is empty')).toBeTruthy()
+    expect(screen.queryByTestId('inbox-section-pending-triage')).toBeNull()
+  })
+
+  it('draws the compact row on a desktop and the comfortable one on a phone', async () => {
+    const desktop = makeCaptureStore({
+      endeavors: captureFixtureRecords(),
+      surface: desktopSurface,
+    })
+    const { unmount } = mount(desktop)
+    const compactRow = (await screen.findAllByTestId(
+      'inbox-section-pending-triage',
+    ))[0]
+    expect(
+      compactRow?.querySelector('[data-config="compactDesktopInbox"]'),
+    ).not.toBeNull()
+    unmount()
+
+    const phone = makeCaptureStore({
+      endeavors: captureFixtureRecords(),
+      surface: handheldSurface,
+    })
+    mount(phone)
+    const comfortableRow = await screen.findByTestId(
+      'inbox-section-pending-triage',
+    )
+    expect(comfortableRow.querySelector('[data-config="inbox"]')).not.toBeNull()
+  })
+})
+
+describe('it stands down while the overlay is up', () => {
+  it('renders nothing rather than a second copy of the same surface', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+    await screen.findByTestId('inbox-surface')
+
+    store.dispatch(userDidTapOpenInbox())
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('inbox-surface')).toBeNull()
+    })
+  })
+})

--- a/packages/app/src/features/capture/pages/__tests__/InboxFragment.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/InboxFragment.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * The Inbox's render tests, mirroring `InboxFragment.stories` (`RC-11`).
+ *
+ * Acceptance criteria 2 and 3 are read here: the sheet-on-mobile /
+ * popover-on-desktop split with canon's frame and its two sections, and the
+ * pinned header over a centred tray when there is nothing to triage.
+ */
+import { EndeavorOperation, EndeavorsVistas } from '@kro/core'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { endeavorCardModelFrom } from '../../../../design/endeavor/endeavorCardModel'
+import { installRadixEnvironment } from '../../../../design/system/primitives/__tests__/radixEnvironment'
+import { PRESENTATION_SIZE } from '../../../main/MainPresentation'
+import { CAPTURE_MOCK_NOW, captureEndeavorFixtures } from '../../CaptureMocks'
+import { nextQuarterHourSlot } from '../../CaptureRules'
+import { InboxFragment, type InboxFragmentProps } from '../InboxFragment'
+import { installCaptureEnvironment } from './captureHarness'
+
+let teardownRadix: () => void
+let teardownCapture: () => void
+
+beforeEach(() => {
+  teardownRadix = installRadixEnvironment()
+  teardownCapture = installCaptureEnvironment()
+})
+
+afterEach(() => {
+  cleanup()
+  teardownRadix()
+  teardownCapture()
+})
+
+const noop = () => {}
+
+const justCreated = endeavorCardModelFrom(
+  captureEndeavorFixtures.freshTask,
+  CAPTURE_MOCK_NOW,
+)
+const pending = [
+  endeavorCardModelFrom(
+    captureEndeavorFixtures.unscheduledReminder,
+    CAPTURE_MOCK_NOW,
+  ),
+  endeavorCardModelFrom(
+    captureEndeavorFixtures.unscheduledHabit,
+    CAPTURE_MOCK_NOW,
+  ),
+]
+
+const renderInbox = (overrides: Partial<InboxFragmentProps> = {}) =>
+  render(
+    <InboxFragment
+      isOpen
+      presentation="sheet"
+      justCreated={justCreated}
+      pendingTriage={pending}
+      totalCount={1 + pending.length}
+      isEmpty={false}
+      capabilities={EndeavorsVistas.inbox.capabilities}
+      rowLayout="comfortable"
+      addForToday={null}
+      now={CAPTURE_MOCK_NOW}
+      locale="en-US"
+      input="touch"
+      onDismiss={noop}
+      onTapTriage={noop}
+      onRequestAddForToday={noop}
+      onAdjustAddForTodayTime={noop}
+      onCancelAddForToday={noop}
+      onConfirmAddForToday={noop}
+      onOperation={noop}
+      {...overrides}
+    />,
+  )
+
+describe('sheet on mobile, popover on desktop (acceptance criterion 2)', () => {
+  it('sheets it from the bottom edge on a phone', () => {
+    renderInbox()
+
+    expect(
+      screen.getByTestId('inbox-surface').getAttribute('data-kro-presentation'),
+    ).toBe('sheet')
+  })
+
+  it('pops it over the content at canon\'s 560 x 620 on a desktop', () => {
+    renderInbox({ presentation: 'popover', rowLayout: 'compactDesktop' })
+
+    const panel = screen.getByTestId('inbox-surface')
+    expect(panel.getAttribute('data-kro-presentation')).toBe('popover')
+    expect(panel.style.width).toBe(`${PRESENTATION_SIZE.inbox.width}px`)
+    expect(panel.style.height).toBe(`${PRESENTATION_SIZE.inbox.height}px`)
+  })
+
+  it('renders inline for the Jot Down destination, with nothing to dismiss', () => {
+    renderInbox({ presentation: 'inline' })
+
+    expect(
+      screen.getByTestId('inbox-surface').getAttribute('data-kro-presentation'),
+    ).toBe('inline')
+    expect(screen.queryByRole('button', { name: 'Done' })).toBeNull()
+  })
+
+  it('renders nothing at all while the overlay is closed', () => {
+    renderInbox({ isOpen: false })
+
+    expect(screen.queryByTestId('inbox-surface')).toBeNull()
+  })
+})
+
+describe('the two sections', () => {
+  it('puts the freshly captured row in Just Created and the rest in Pending Triage', () => {
+    renderInbox()
+
+    const created = screen.getByTestId('inbox-section-just-created')
+    expect(within(created).getByText('Draft the announcement')).toBeTruthy()
+
+    const triage = screen.getByTestId('inbox-section-pending-triage')
+    expect(within(triage).getByText('Bring the parcel in')).toBeTruthy()
+    expect(within(triage).getByText('Stretch for five minutes')).toBeTruthy()
+  })
+
+  it('drops the Just Created section entirely once the slot has drained', () => {
+    renderInbox({ justCreated: null, totalCount: pending.length })
+
+    expect(screen.queryByTestId('inbox-section-just-created')).toBeNull()
+    expect(screen.getByTestId('inbox-section-pending-triage')).toBeTruthy()
+  })
+
+  it('counts the rows in the header, as canon\'s subtitle does', () => {
+    renderInbox({ presentation: 'inline' })
+
+    // The overlay presentations also announce the count through the dialog's
+    // hidden description, so the inline one is where a single visible node is
+    // the assertion rather than an ambiguity.
+    expect(screen.getByText('3 endeavors')).toBeTruthy()
+  })
+
+  it('gives every row canon\'s two explicit buttons, which are not swipe bindings', () => {
+    renderInbox()
+
+    expect(
+      screen.getByRole('button', { name: 'Triage Draft the announcement' }),
+    ).toBeTruthy()
+    expect(
+      screen.getByRole('button', { name: 'Add Draft the announcement for today' }),
+    ).toBeTruthy()
+  })
+})
+
+describe('the empty tray (acceptance criterion 3)', () => {
+  it('pins the header and centres the tray illustration', () => {
+    renderInbox({
+      presentation: 'inline',
+      justCreated: null,
+      pendingTriage: [],
+      totalCount: 0,
+      isEmpty: true,
+    })
+
+    const surface = screen.getByTestId('inbox-surface')
+    const header = within(surface).getByText('Inbox')
+    const tray = within(surface).getByText('Inbox is empty')
+
+    // Pinned above, centred below: the header precedes the illustration in the
+    // document, which is canon's `VStack { header; emptyState }`.
+    expect(header.compareDocumentPosition(tray)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
+    expect(
+      within(surface).getByText('Recently added endeavors will appear here'),
+    ).toBeTruthy()
+  })
+
+  it('says nothing about a count when there is nothing to count', () => {
+    renderInbox({
+      justCreated: null,
+      pendingTriage: [],
+      totalCount: 0,
+      isEmpty: true,
+    })
+
+    expect(screen.queryByText(/endeavors$/)).toBeNull()
+  })
+
+  it('shows no sections at all rather than two empty ones', () => {
+    renderInbox({
+      justCreated: null,
+      pendingTriage: [],
+      totalCount: 0,
+      isEmpty: true,
+    })
+
+    expect(screen.queryByTestId('inbox-section-just-created')).toBeNull()
+    expect(screen.queryByTestId('inbox-section-pending-triage')).toBeNull()
+  })
+})
+
+describe('Add for Today', () => {
+  it('stays shut until its row asks for it', () => {
+    renderInbox()
+
+    expect(screen.queryByTestId('add-for-today-confirm')).toBeNull()
+  })
+
+  it('raises the request rather than opening itself — the slice owns the prefill', async () => {
+    const onRequestAddForToday = vi.fn()
+    renderInbox({ onRequestAddForToday })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add Draft the announcement for today' }),
+    )
+
+    expect(onRequestAddForToday).toHaveBeenCalledWith(justCreated.id)
+  })
+
+  it('opens pre-filled with the next quarter hour, so one tap confirms', () => {
+    renderInbox({
+      addForToday: {
+        endeavorId: justCreated.id,
+        pickedTime: nextQuarterHourSlot(CAPTURE_MOCK_NOW),
+      },
+    })
+
+    expect(screen.getByTestId('add-for-today-confirm')).toBeTruthy()
+    // 10:07 rounds UP to 10:15, never to the 10:00 the prompt's own seed uses.
+    expect(
+      screen.getByTestId<HTMLInputElement>('add-for-today-time').value,
+    ).toBe('10:15')
+  })
+
+  it('opens on exactly the row that asked, never on its neighbour', () => {
+    renderInbox({
+      addForToday: {
+        endeavorId: justCreated.id,
+        pickedTime: nextQuarterHourSlot(CAPTURE_MOCK_NOW),
+      },
+    })
+
+    const created = screen.getByTestId('inbox-section-just-created')
+    expect(within(created).getByTestId('add-for-today-confirm')).toBeTruthy()
+    const triage = screen.getByTestId('inbox-section-pending-triage')
+    expect(within(triage).queryByTestId('add-for-today-confirm')).toBeNull()
+  })
+
+  it('confirms and cancels through callbacks, never by mutating anything itself', async () => {
+    const onConfirmAddForToday = vi.fn()
+    const onCancelAddForToday = vi.fn()
+    renderInbox({
+      addForToday: {
+        endeavorId: justCreated.id,
+        pickedTime: nextQuarterHourSlot(CAPTURE_MOCK_NOW),
+      },
+      onConfirmAddForToday,
+      onCancelAddForToday,
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Schedule' }))
+    expect(onConfirmAddForToday).toHaveBeenCalledTimes(1)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancelAddForToday).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('the row operations come from the vista, not from this file', () => {
+  it('reveals the trailing swipe bindings on touch, and nothing on the leading edge', () => {
+    renderInbox()
+
+    // `EndeavorsVistas.inbox` declares markComplete and delete on the trailing
+    // swipe and nothing on the leading one; the surface renders exactly those,
+    // labelled with the vista's own strings.
+    const created = screen.getByTestId('inbox-section-just-created')
+    const trailing = created.querySelector('[data-slot="endeavor-swipe-trailing"]')
+    expect(trailing).not.toBeNull()
+    expect(
+      [...(trailing?.querySelectorAll('button') ?? [])].map((button) =>
+        button.getAttribute('aria-label'),
+      ),
+    ).toEqual(['Complete', 'Delete'])
+    expect(
+      created.querySelector('[data-slot="endeavor-swipe-leading"]'),
+    ).toBeNull()
+  })
+
+  it('raises an operation with the row it belongs to', async () => {
+    const onOperation = vi.fn()
+    renderInbox({ onOperation })
+
+    const created = screen.getByTestId('inbox-section-just-created')
+    // The revealed panel is `aria-hidden` until the swipe uncovers it, so it is
+    // reached by slot rather than by role — the gesture itself belongs to the
+    // kit's own suite, and what matters here is which row the intent carries.
+    const complete = created.querySelector<HTMLButtonElement>(
+      '[data-slot="endeavor-swipe-trailing"] button[aria-label="Complete"]',
+    )
+    complete?.click()
+
+    expect(onOperation).toHaveBeenCalledWith(
+      EndeavorOperation.markComplete,
+      justCreated.id,
+    )
+  })
+
+  it('raises the Triage intent and stops there — the carousel is #26\'s', async () => {
+    const onTapTriage = vi.fn()
+    renderInbox({ onTapTriage })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Triage Draft the announcement' }),
+    )
+
+    expect(onTapTriage).toHaveBeenCalledWith(justCreated.id)
+  })
+})

--- a/packages/app/src/features/capture/pages/__tests__/InboxOverlayPage.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/InboxOverlayPage.test.tsx
@@ -13,6 +13,7 @@ import { installRadixEnvironment } from '../../../../design/system/primitives/__
 import { PRESENTATION_SIZE } from '../../../main/MainPresentation'
 import { userDidTapOpenInbox } from '../../CaptureFeature'
 import { captureFixtureRecords } from '../../CaptureMocks'
+import { ADD_FOR_TODAY_UNDO_WINDOW_MS } from '../../CaptureRules'
 import { InboxOverlayPage } from '../InboxOverlayPage'
 import {
   type CaptureStore,
@@ -161,6 +162,36 @@ describe('the Undo window', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Schedule' }))
 
     expect(await screen.findByRole('button', { name: 'Undo' })).toBeTruthy()
+  })
+
+  it('hands the host canon\'s fixed eight seconds, never a computed remainder', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+    store.dispatch(userDidTapOpenInbox())
+    await screen.findByTestId('inbox-surface')
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add Draft the announcement for today' }),
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Schedule' }))
+    await screen.findByRole('button', { name: 'Undo' })
+
+    // The toast's own auto-dismiss is the host's, and the host clamps its
+    // input into 3-12s. What this asserts is the INPUT: the window the slice
+    // armed is exactly canon's 8s, and the Page hands the host that same
+    // constant rather than `expiresAt - Date.now()` — a second clock reading
+    // that drifts from the deadline and goes negative once it has passed,
+    // which the clamp would then silently turn into three.
+    const undo = store.getState().capture.undo
+    if (undo.kind !== 'armed') throw new Error('the window did not arm')
+    expect(undo.expiresAt.getTime() - undo.armedAt.getTime()).toBe(
+      ADD_FOR_TODAY_UNDO_WINDOW_MS,
+    )
+    expect(ADD_FOR_TODAY_UNDO_WINDOW_MS / 1000).toBeGreaterThanOrEqual(3)
+    expect(ADD_FOR_TODAY_UNDO_WINDOW_MS / 1000).toBeLessThanOrEqual(12)
   })
 
   it('arms the window for canon\'s eight seconds, measured from the confirmation', async () => {

--- a/packages/app/src/features/capture/pages/__tests__/InboxOverlayPage.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/InboxOverlayPage.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * The Inbox overlay Page's render tests, mirroring `InboxOverlayPage.stories`
+ * (`RC-11`).
+ *
+ * Its two jobs are the pool (loaded on mount through the real Producer) and the
+ * Undo window (the toast, and the tick that closes it).
+ */
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ActiveToastHost } from '../../../../design/chrome/toast/ActiveToastHost'
+import { installRadixEnvironment } from '../../../../design/system/primitives/__tests__/radixEnvironment'
+import { PRESENTATION_SIZE } from '../../../main/MainPresentation'
+import { userDidTapOpenInbox } from '../../CaptureFeature'
+import { captureFixtureRecords } from '../../CaptureMocks'
+import { InboxOverlayPage } from '../InboxOverlayPage'
+import {
+  type CaptureStore,
+  CaptureStoreStage,
+  desktopSurface,
+  handheldSurface,
+  installCaptureEnvironment,
+  makeCaptureStore,
+} from './captureHarness'
+
+let teardownRadix: () => void
+let teardownCapture: () => void
+
+beforeEach(() => {
+  teardownRadix = installRadixEnvironment()
+  teardownCapture = installCaptureEnvironment()
+})
+
+afterEach(() => {
+  cleanup()
+  teardownRadix()
+  teardownCapture()
+})
+
+const mount = (store: CaptureStore) =>
+  render(
+    <CaptureStoreStage store={store}>
+      <ActiveToastHost>
+        <InboxOverlayPage />
+      </ActiveToastHost>
+    </CaptureStoreStage>,
+  )
+
+describe('the pool arrives through the real Producer', () => {
+  it('loads on mount, so the rows are there the moment the sheet opens', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+    expect(store.getState().capture.endeavors.length).toBeGreaterThan(0)
+  })
+
+  it('shows only the unscheduled, non-event, unfinished rows canon\'s selector keeps', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+
+    store.dispatch(userDidTapOpenInbox())
+    const triage = await screen.findByTestId('inbox-section-pending-triage')
+
+    expect(within(triage).getByText('Draft the announcement')).toBeTruthy()
+    // Scheduled, completed and calendar-event fixtures never reach the Inbox.
+    expect(within(triage).queryByText('Call the bank')).toBeNull()
+    expect(within(triage).queryByText('Water the plants')).toBeNull()
+    expect(within(triage).queryByText('Design review')).toBeNull()
+  })
+
+  it('stays shut until something opens it', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+
+    expect(screen.queryByTestId('inbox-surface')).toBeNull()
+  })
+})
+
+describe('it presents itself from the shell\'s own ported frame', () => {
+  it('sheets on a phone', async () => {
+    const store = makeCaptureStore({
+      endeavors: captureFixtureRecords(),
+      surface: handheldSurface,
+    })
+    mount(store)
+    store.dispatch(userDidTapOpenInbox())
+
+    expect(
+      (await screen.findByTestId('inbox-surface')).getAttribute(
+        'data-kro-presentation',
+      ),
+    ).toBe('sheet')
+  })
+
+  it('pops over at canon\'s 560 x 620 on a desktop', async () => {
+    const store = makeCaptureStore({
+      endeavors: captureFixtureRecords(),
+      surface: desktopSurface,
+    })
+    mount(store)
+    store.dispatch(userDidTapOpenInbox())
+
+    const panel = await screen.findByTestId('inbox-surface')
+    expect(panel.style.width).toBe(`${PRESENTATION_SIZE.inbox.width}px`)
+    expect(panel.style.height).toBe(`${PRESENTATION_SIZE.inbox.height}px`)
+  })
+
+  it('drains the Just Created slot when Done is taken, as canon does on dismiss', async () => {
+    // The comfortable header is the one that carries "Done"; the pointer-first
+    // one carries the compact header's Close instead, which is canon's split.
+    const store = makeCaptureStore({
+      endeavors: captureFixtureRecords(),
+      surface: handheldSurface,
+    })
+    mount(store)
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+    store.dispatch(userDidTapOpenInbox())
+    await screen.findByTestId('inbox-surface')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(store.getState().capture.inbox.isOpen).toBe(false)
+    expect(store.getState().capture.inbox.justCreatedEndeavorId).toBeNull()
+  })
+})
+
+describe('the Undo window', () => {
+  it('raises no toast while nothing has been scheduled', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+
+    expect(screen.queryByRole('button', { name: 'Undo' })).toBeNull()
+  })
+
+  it('raises canon\'s toast, with Undo, the moment a scheduling lands', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+    store.dispatch(userDidTapOpenInbox())
+    await screen.findByTestId('inbox-surface')
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add Draft the announcement for today' }),
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Schedule' }))
+
+    expect(await screen.findByRole('button', { name: 'Undo' })).toBeTruthy()
+  })
+
+  it('arms the window for canon\'s eight seconds, measured from the confirmation', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+    store.dispatch(userDidTapOpenInbox())
+    await screen.findByTestId('inbox-surface')
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add Draft the announcement for today' }),
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Schedule' }))
+
+    await waitFor(() => {
+      expect(store.getState().capture.undo.kind).toBe('armed')
+    })
+    const undo = store.getState().capture.undo
+    if (undo.kind !== 'armed') throw new Error('the window did not arm')
+    expect(undo.expiresAt.getTime() - undo.armedAt.getTime()).toBe(8_000)
+  })
+})

--- a/packages/app/src/features/capture/pages/__tests__/captureHarness.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/captureHarness.tsx
@@ -1,0 +1,182 @@
+/**
+ * The scaffolding every capture story and suite sits on.
+ *
+ * Under `__tests__/` rather than beside the surfaces for the same reason
+ * `design/system/primitives/__tests__/radixEnvironment.tsx` is: it is test
+ * scaffolding, not shipped code — and, unlike shipped code, it is allowed to
+ * reach a Service module directly (`check-uzf-boundaries.mjs` exempts test and
+ * story files, `RC-6`). A seeded `LocalStore` is the only honest way to give a
+ * Page a pool: every Inbox Page loads through `loadCaptureContextThunk` on
+ * mount, so a store seeded here produces its rows through the real Producer,
+ * the real Shifter and the real reconcile pass rather than a hand-built slice.
+ *
+ * Nothing here constructs a `CaptureState`, and nothing constructs a thunk's
+ * lifecycle action by hand: the states come from `CaptureMocks`, and the pool
+ * arrives the way it arrives in the browser.
+ */
+
+import type { EndeavorRecord } from '@kro/core'
+import { type ReactNode, useEffect } from 'react'
+import { StoreProvider } from '../../../../library/StoreProvider'
+import { type ThunkExtra, makeStore, stubbedThunkExtra } from '../../../../library/store'
+import { makeInMemoryLocalStore } from '../../../../services/localStore/InMemoryLocalStore'
+import {
+  onDestinationRouteMounted,
+  onShellMounted,
+} from '../../../main/MainFeature'
+import { desktopSurface, handheldSurface } from '../../../main/MainMocks'
+import {
+  DestinationKind,
+  type SidebarDestination,
+} from '../../../main/SidebarDestination'
+import type { DoSurface } from '../../../main/DoSurfaceLayout'
+import { CAPTURE_MOCK_NOW, captureFixtureRecords } from '../../CaptureMocks'
+
+export { desktopSurface, handheldSurface }
+export { CAPTURE_MOCK_NOW }
+
+/**
+ * jsdom implements neither `matchMedia` nor `crypto.randomUUID` reliably, and
+ * both are on the path of every surface here — the first through
+ * `useInputCapability` (the row's swipe/hover split), the second through the
+ * prompt's own Add. Installed per suite, torn down after, so no file leaks a
+ * stub into the next.
+ */
+export function installCaptureEnvironment(options?: {
+  readonly pointer?: 'coarse' | 'fine'
+}): () => void {
+  const pointer = options?.pointer ?? 'fine'
+  const originalMatchMedia = window.matchMedia
+  const originalUuid = globalThis.crypto?.randomUUID
+
+  window.matchMedia = ((query: string) =>
+    ({
+      matches:
+        query.includes('pointer: fine') || query.includes('any-pointer: fine')
+          ? pointer === 'fine'
+          : query.includes('min-width'),
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => true,
+      onchange: null,
+    }) as unknown as MediaQueryList) as typeof window.matchMedia
+
+  let counter = 0
+  if (globalThis.crypto !== undefined) {
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+      configurable: true,
+      writable: true,
+      value: () => `capture-${(counter += 1)}` as `${string}-${string}`,
+    })
+  }
+
+  return () => {
+    window.matchMedia = originalMatchMedia
+    if (globalThis.crypto !== undefined && originalUuid !== undefined) {
+      Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        configurable: true,
+        writable: true,
+        value: originalUuid,
+      })
+    }
+  }
+}
+
+export interface CaptureStoreOptions {
+  /** Stored rows the pool is built from. Defaults to the whole fixture set. */
+  readonly endeavors?: readonly EndeavorRecord[]
+  /** Which row of the ported decision table the shell resolves to. */
+  readonly surface?: DoSurface
+  /**
+   * Where the user is standing. Defaults to All Tasks, which is the shape of
+   * destination canon's `default:` quick-action branch covers — the shell's own
+   * initial selection is My Day, and My Day owns its own FAB (KC-IS-#17), so a
+   * suite that wants the default disc has to say where it is.
+   */
+  readonly destination?: SidebarDestination
+  /** Anything else a suite wants to swap — a recording navigation service, say. */
+  readonly extra?: Partial<ThunkExtra>
+}
+
+/**
+ * A store wired to an in-memory `LocalStore` holding `endeavors`, with the
+ * shell already measured at `surface` and standing on `destination`.
+ */
+export function makeCaptureStore(options: CaptureStoreOptions = {}) {
+  const store = makeStore({
+    ...stubbedThunkExtra,
+    localStore: makeInMemoryLocalStore({
+      endeavors: [...(options.endeavors ?? captureFixtureRecords())],
+    }),
+    ...options.extra,
+  })
+  store.dispatch(
+    onShellMounted({
+      surface: options.surface ?? desktopSurface,
+      isDevelopment: false,
+    }),
+  )
+  store.dispatch(
+    onDestinationRouteMounted({
+      destination: options.destination ?? { kind: DestinationKind.allTasks },
+    }),
+  )
+  return store
+}
+
+export type CaptureStore = ReturnType<typeof makeCaptureStore>
+
+/**
+ * A scheme, applied where a portal can see it.
+ *
+ * `storyStage.tsx`'s `Stage` puts `data-theme` on a `div`, which is enough for
+ * a component rendered inline. Both surfaces here are Radix dialogs, and a
+ * dialog portals to `document.body` — outside any story container — so the
+ * attribute has to go on the document element or the panel renders in the light
+ * palette no matter what the story asked for. Restored on unmount so one story
+ * cannot leave the next one dark.
+ */
+export function ThemeScope({
+  theme,
+  children,
+}: {
+  readonly theme: 'light' | 'dark'
+  readonly children: ReactNode
+}) {
+  useEffect(() => {
+    const root = document.documentElement
+    const previous = root.getAttribute('data-theme')
+    root.setAttribute('data-theme', theme)
+    return () => {
+      if (previous === null) root.removeAttribute('data-theme')
+      else root.setAttribute('data-theme', previous)
+    }
+  }, [theme])
+
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        minHeight: 420,
+        background: 'var(--kro-color-back)',
+        fontFamily: 'system-ui, sans-serif',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+/** The provider wrapper every Page story and Page test renders inside. */
+export function CaptureStoreStage({
+  store,
+  children,
+}: {
+  readonly store: CaptureStore
+  readonly children: ReactNode
+}) {
+  return <StoreProvider store={store}>{children}</StoreProvider>
+}

--- a/packages/app/src/features/capture/pages/__tests__/captureIcons.test.ts
+++ b/packages/app/src/features/capture/pages/__tests__/captureIcons.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The capture surfaces' icon seam.
+ *
+ * The two properties that make a third map safe rather than a fork: the key
+ * sets are disjoint, so no row here can shadow a more general answer; and every
+ * glyph the logic tier names resolves to a real drawing rather than the help
+ * fallback, so an unmapped symbol fails here instead of showing a user a
+ * question mark.
+ */
+import { describe, expect, it } from 'vitest'
+import { ENDEAVOR_SF_SYMBOL_TO_LUCIDE } from '../../../../design/endeavor/endeavorIcons'
+import { SF_SYMBOL_TO_LUCIDE } from '../../../../design/system/icons/icons'
+import {
+  captureDestinationGlyph,
+  captureKindGlyph,
+  captureKinds,
+  captureDestinations,
+  inboxRowButtons,
+} from '../../CaptureRules'
+import {
+  CAPTURE_SF_SYMBOL_TO_LUCIDE,
+  captureIcon,
+  captureIconFor,
+  isCaptureMappedSymbol,
+} from '../captureIcons'
+
+describe('the three maps stay disjoint', () => {
+  it('shadows no row of the design system\'s map', () => {
+    const collisions = Object.keys(CAPTURE_SF_SYMBOL_TO_LUCIDE).filter(
+      (name) => name in SF_SYMBOL_TO_LUCIDE,
+    )
+    expect(collisions).toEqual([])
+  })
+
+  it('shadows no row of the endeavor kit\'s extension map', () => {
+    const collisions = Object.keys(CAPTURE_SF_SYMBOL_TO_LUCIDE).filter(
+      (name) => name in ENDEAVOR_SF_SYMBOL_TO_LUCIDE,
+    )
+    expect(collisions).toEqual([])
+  })
+
+  it('lets the more general map win for a symbol it already answers', () => {
+    expect(captureIcon('calendar')).toBe(SF_SYMBOL_TO_LUCIDE.calendar)
+    expect(captureIcon('tray')).toBe(ENDEAVOR_SF_SYMBOL_TO_LUCIDE.tray)
+  })
+})
+
+describe('every glyph the logic tier names resolves to a real drawing', () => {
+  it('draws all four kind chips', () => {
+    for (const kind of captureKinds) {
+      expect(isCaptureMappedSymbol(captureKindGlyph(kind))).toBe(true)
+    }
+  })
+
+  it('draws every hosting destination, including the two the web never offers', () => {
+    for (const destination of captureDestinations) {
+      expect(isCaptureMappedSymbol(captureDestinationGlyph(destination))).toBe(
+        true,
+      )
+    }
+  })
+
+  it('draws both in-row buttons — Triage and Add for Today', () => {
+    for (const button of inboxRowButtons) {
+      expect(isCaptureMappedSymbol(button.icon)).toBe(true)
+    }
+  })
+})
+
+describe('captureIconFor — the resolver that can fail', () => {
+  it('answers a mapped symbol with its own component', () => {
+    expect(captureIconFor('rectangle.split.2x2.fill')).toBe(
+      CAPTURE_SF_SYMBOL_TO_LUCIDE['rectangle.split.2x2.fill'],
+    )
+  })
+
+  it('falls back visibly rather than returning undefined, which React would crash on', () => {
+    const fallback = captureIconFor('not.a.symbol')
+    expect(typeof fallback).toBe('object')
+    expect(fallback).not.toBeUndefined()
+  })
+
+  it('reports an unmapped symbol as unmapped', () => {
+    expect(isCaptureMappedSymbol('not.a.symbol')).toBe(false)
+  })
+})

--- a/packages/app/src/features/capture/pages/__tests__/capturePresentation.test.ts
+++ b/packages/app/src/features/capture/pages/__tests__/capturePresentation.test.ts
@@ -174,8 +174,8 @@ describe('inboxCountCaption — canon\'s "N endeavors" subtitle', () => {
     expect(inboxCountCaption(0)).toBeUndefined()
   })
 
-  it('still names a single row rather than hiding it', () => {
-    expect(inboxCountCaption(1)).toBe('1 endeavors')
+  it('singularizes one row — canon\'s own string reads "1 endeavors"', () => {
+    expect(inboxCountCaption(1)).toBe('1 endeavor')
   })
 })
 

--- a/packages/app/src/features/capture/pages/__tests__/capturePresentation.test.ts
+++ b/packages/app/src/features/capture/pages/__tests__/capturePresentation.test.ts
@@ -1,0 +1,248 @@
+/**
+ * The capture surfaces' pure presentation rules.
+ *
+ * Every case is named for the situation it protects, and every clock-relative
+ * one passes its own instant — the fixtures' `CAPTURE_MOCK_NOW` — so none of
+ * these can pass or fail because of the day the suite happened to run.
+ */
+import { Month, WeekDay } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { doSurfaceLayout } from '../../../main/DoSurfaceLayout'
+import {
+  desktopSurface,
+  handheldSurface,
+  tabletSurface,
+} from '../../../main/MainMocks'
+import { CAPTURE_MOCK_NOW, captureMockAt } from '../../CaptureMocks'
+import { NO_RECURRENCE } from '../../CaptureRules'
+import {
+  capturePromptPresentation,
+  captureRecurrencePresets,
+  captureRepeatChipLabel,
+  dateInputValue,
+  formatCaptureDate,
+  formatCaptureTime,
+  inboxCountCaption,
+  inboxRowConfigFor,
+  inboxRowLayoutFor,
+  parseDateInput,
+  parseTimeInput,
+  schedulingToastMessage,
+  timeInputValue,
+  weekDayFromDate,
+} from '../capturePresentation'
+
+describe('capturePromptPresentation — the idiom split', () => {
+  it('pops the prompt over the content on a Mac-shaped window', () => {
+    expect(capturePromptPresentation(doSurfaceLayout(desktopSurface))).toBe(
+      'popover',
+    )
+  })
+
+  it('sheets it from the bottom edge on a phone, where a popover costs more than it gives', () => {
+    expect(capturePromptPresentation(doSurfaceLayout(handheldSurface))).toBe(
+      'sheet',
+    )
+  })
+
+  it('pops it over a landscape tablet too — the cell is width, not pointer', () => {
+    expect(capturePromptPresentation(doSurfaceLayout(tabletSurface))).toBe(
+      'popover',
+    )
+  })
+})
+
+describe('inboxRowLayoutFor — canon\'s InboxView.Layout', () => {
+  it('draws the compact row on a pointer-first window, per canon\'s own note', () => {
+    expect(inboxRowLayoutFor(doSurfaceLayout(desktopSurface))).toBe(
+      'compactDesktop',
+    )
+  })
+
+  it('keeps the comfortable row on a phone', () => {
+    expect(inboxRowLayoutFor(doSurfaceLayout(handheldSurface))).toBe(
+      'comfortable',
+    )
+  })
+
+  it('keeps it comfortable on a landscape tablet, which is wide but still a finger', () => {
+    expect(inboxRowLayoutFor(doSurfaceLayout(tabletSurface))).toBe('comfortable')
+  })
+
+  it('maps each layout onto the EndeavorRow preset canon names', () => {
+    expect(inboxRowConfigFor('compactDesktop')).toBe('compactDesktopInbox')
+    expect(inboxRowConfigFor('comfortable')).toBe('inbox')
+  })
+})
+
+describe('dateInputValue / parseDateInput', () => {
+  it('writes the local calendar day, not the UTC one — a user east of London at 00:30', () => {
+    expect(dateInputValue(new Date(2026, 2, 17, 0, 30))).toBe('2026-03-17')
+  })
+
+  it('round-trips a picked day back to local midnight', () => {
+    const parsed = parseDateInput('2026-03-17')
+    expect(parsed?.getFullYear()).toBe(2026)
+    expect(parsed?.getMonth()).toBe(2)
+    expect(parsed?.getDate()).toBe(17)
+    expect(parsed?.getHours()).toBe(0)
+  })
+
+  it('refuses the half-typed value the input allows mid-keystroke', () => {
+    expect(parseDateInput('2026-03-')).toBeNull()
+    expect(parseDateInput('')).toBeNull()
+  })
+})
+
+describe('timeInputValue / parseTimeInput', () => {
+  it('pads a single-digit hour so the input accepts it', () => {
+    expect(timeInputValue(captureMockAt(17, 9, 5))).toBe('09:05')
+  })
+
+  it('projects the picked time onto the day the draft is already on', () => {
+    const parsed = parseTimeInput('14:45', captureMockAt(20, 8, 0))
+    expect(parsed?.getDate()).toBe(20)
+    expect(parsed?.getHours()).toBe(14)
+    expect(parsed?.getMinutes()).toBe(45)
+    expect(parsed?.getSeconds()).toBe(0)
+  })
+
+  it('refuses a malformed or out-of-range time rather than inventing one', () => {
+    expect(parseTimeInput('', CAPTURE_MOCK_NOW)).toBeNull()
+    expect(parseTimeInput('9:5', CAPTURE_MOCK_NOW)).toBeNull()
+    expect(parseTimeInput('24:00', CAPTURE_MOCK_NOW)).toBeNull()
+  })
+})
+
+describe('formatCaptureDate — canon\'s formattedDate', () => {
+  it('reads "Today" for the day the user is capturing on', () => {
+    expect(formatCaptureDate(captureMockAt(17, 0), CAPTURE_MOCK_NOW, 'en-US')).toBe(
+      'Today',
+    )
+  })
+
+  it('reads "Tomorrow" for the next day', () => {
+    expect(formatCaptureDate(captureMockAt(18, 0), CAPTURE_MOCK_NOW, 'en-US')).toBe(
+      'Tomorrow',
+    )
+  })
+
+  it('falls back to a medium date once it is further out', () => {
+    expect(
+      formatCaptureDate(captureMockAt(25, 0), CAPTURE_MOCK_NOW, 'en-US'),
+    ).toBe('Mar 25, 2026')
+  })
+
+  it('does not read "Tomorrow" for the same weekday a week later', () => {
+    expect(
+      formatCaptureDate(captureMockAt(24, 0), CAPTURE_MOCK_NOW, 'en-US'),
+    ).not.toBe('Tomorrow')
+  })
+})
+
+describe('schedulingToastMessage — canon\'s ActionToastModel copy', () => {
+  it('quotes the title and names the slot, as canon\'s format string does', () => {
+    expect(
+      schedulingToastMessage('Draft the announcement', captureMockAt(17, 14, 30), 'en-US'),
+    ).toBe('"Draft the announcement" scheduled for 2:30 PM')
+  })
+
+  it('strips a leading emoji — the toast already carries its own glyph', () => {
+    expect(
+      schedulingToastMessage('📞 Call the bank', captureMockAt(17, 9, 0), 'en-US'),
+    ).toBe('"Call the bank" scheduled for 9:00 AM')
+  })
+
+  it('keeps a mid-title emoji, which is part of the name the user typed', () => {
+    expect(
+      schedulingToastMessage('Ship the 🚀 launch', captureMockAt(17, 9, 0), 'en-US'),
+    ).toBe('"Ship the 🚀 launch" scheduled for 9:00 AM')
+  })
+
+  it('formats midnight and noon unambiguously', () => {
+    expect(formatCaptureTime(captureMockAt(17, 0, 0), 'en-US')).toBe('12:00 AM')
+    expect(formatCaptureTime(captureMockAt(17, 12, 0), 'en-US')).toBe('12:00 PM')
+  })
+})
+
+describe('inboxCountCaption — canon\'s "N endeavors" subtitle', () => {
+  it('names the count when there is anything to triage', () => {
+    expect(inboxCountCaption(3)).toBe('3 endeavors')
+  })
+
+  it('says nothing at all when the tray is empty, so the header does not shout zero', () => {
+    expect(inboxCountCaption(0)).toBeUndefined()
+  })
+
+  it('still names a single row rather than hiding it', () => {
+    expect(inboxCountCaption(1)).toBe('1 endeavors')
+  })
+})
+
+describe('weekDayFromDate — canon\'s Monday-first allCases', () => {
+  it('maps a Tuesday, which is what the fixtures capture on', () => {
+    expect(weekDayFromDate(CAPTURE_MOCK_NOW)).toBe(WeekDay.tuesday)
+  })
+
+  it('maps a Sunday, the case a 0-indexed getDay() gets wrong', () => {
+    expect(weekDayFromDate(captureMockAt(22, 12))).toBe(WeekDay.sunday)
+  })
+
+  it('maps a Monday, the first case', () => {
+    expect(weekDayFromDate(captureMockAt(16, 12))).toBe(WeekDay.monday)
+  })
+})
+
+describe('captureRecurrencePresets — anchored to the drafted day', () => {
+  it('offers canon\'s five shapes, Never first', () => {
+    const presets = captureRecurrencePresets(CAPTURE_MOCK_NOW)
+    expect(presets.map((preset) => preset.recurrence.kind)).toEqual([
+      'never',
+      'daily',
+      'weekly',
+      'monthly',
+      'yearly',
+    ])
+  })
+
+  it('repeats weekly on the weekday the draft is already on', () => {
+    const weekly = captureRecurrencePresets(CAPTURE_MOCK_NOW)[2]
+    expect(weekly?.recurrence).toEqual({
+      kind: 'weekly',
+      interval: 1,
+      weekdays: [WeekDay.tuesday],
+    })
+  })
+
+  it('repeats yearly on that month and day, with March as Month.march (not JS\'s 2)', () => {
+    const yearly = captureRecurrencePresets(CAPTURE_MOCK_NOW)[4]
+    expect(yearly?.recurrence).toEqual({
+      kind: 'yearly',
+      interval: 1,
+      month: Month.march,
+      day: 17,
+    })
+  })
+
+  it('labels each preset with canon\'s own EndeavorRecurrence.label', () => {
+    expect(
+      captureRecurrencePresets(CAPTURE_MOCK_NOW).map((preset) => preset.label),
+    ).toEqual(['Never', 'Daily', 'Weekly', 'Monthly', 'Yearly'])
+  })
+})
+
+describe('captureRepeatChipLabel', () => {
+  it('reads "No Repeat" on the chip while nothing repeats — canon\'s own string', () => {
+    expect(captureRepeatChipLabel(NO_RECURRENCE)).toBe('No Repeat')
+  })
+
+  it('reads the rule once one is picked', () => {
+    expect(captureRepeatChipLabel({ kind: 'daily', interval: 1 })).toBe('Daily')
+  })
+
+  it('keeps the plural form for an interval above one', () => {
+    expect(captureRepeatChipLabel({ kind: 'daily', interval: 3 })).toBe(
+      'Every 3 days',
+    )
+  })
+})

--- a/packages/app/src/features/capture/pages/__tests__/useInboxSurface.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/useInboxSurface.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * The Inbox's stateful wrapper.
+ *
+ * Exercised through a probe component rather than a renderer-less hook harness,
+ * because what is under test is the view model both Pages read — the sections,
+ * the row layout, the clock the rows are classified against, and the fact that
+ * every callback goes to the slice.
+ */
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { userDidTapOpenInbox } from '../../CaptureFeature'
+import { captureFixtureRecords } from '../../CaptureMocks'
+import { loadCaptureContextThunk } from '../../CaptureProducer'
+import { useInboxSurface } from '../useInboxSurface'
+import {
+  type CaptureStore,
+  CaptureStoreStage,
+  desktopSurface,
+  handheldSurface,
+  installCaptureEnvironment,
+  makeCaptureStore,
+} from './captureHarness'
+
+let teardownCapture: () => void
+
+beforeEach(() => {
+  teardownCapture = installCaptureEnvironment()
+})
+
+afterEach(() => {
+  cleanup()
+  teardownCapture()
+})
+
+/** Prints the view model so a test can read it without a renderer harness. */
+function Probe() {
+  const inbox = useInboxSurface()
+  return (
+    <dl>
+      <dt>rowLayout</dt>
+      <dd data-testid="rowLayout">{inbox.rowLayout}</dd>
+      <dt>totalCount</dt>
+      <dd data-testid="totalCount">{inbox.totalCount}</dd>
+      <dt>isEmpty</dt>
+      <dd data-testid="isEmpty">{String(inbox.isEmpty)}</dd>
+      <dt>isOpen</dt>
+      <dd data-testid="isOpen">{String(inbox.isOpen)}</dd>
+      <dt>pending</dt>
+      <dd data-testid="pending">
+        {inbox.pendingTriage.map((card) => card.title).join('|')}
+      </dd>
+      <dt>capabilities</dt>
+      <dd data-testid="capabilities">
+        {inbox.capabilities.operations
+          .map((binding) => binding.operation)
+          .join('|')}
+      </dd>
+      <button type="button" onClick={() => inbox.onTapTriage('fresh-task')}>
+        triage
+      </button>
+      <button
+        type="button"
+        onClick={() => inbox.onRequestAddForToday('fresh-task')}
+      >
+        add
+      </button>
+    </dl>
+  )
+}
+
+const mount = (store: CaptureStore) =>
+  render(
+    <CaptureStoreStage store={store}>
+      <Probe />
+    </CaptureStoreStage>,
+  )
+
+describe('the view model', () => {
+  it('reads the row layout off the ported decision table', () => {
+    const { unmount } = mount(
+      makeCaptureStore({ endeavors: [], surface: desktopSurface }),
+    )
+    expect(screen.getByTestId('rowLayout').textContent).toBe('compactDesktop')
+    unmount()
+
+    mount(makeCaptureStore({ endeavors: [], surface: handheldSurface }))
+    expect(screen.getByTestId('rowLayout').textContent).toBe('comfortable')
+  })
+
+  it('reports an empty tray on a store with nothing in it', () => {
+    mount(makeCaptureStore({ endeavors: [] }))
+
+    expect(screen.getByTestId('isEmpty').textContent).toBe('true')
+    expect(screen.getByTestId('totalCount').textContent).toBe('0')
+  })
+
+  it('carries the Inbox vista\'s own operations, never a hand-written pair', () => {
+    mount(makeCaptureStore({ endeavors: [] }))
+
+    expect(screen.getByTestId('capabilities').textContent).toBe(
+      'markComplete|delete',
+    )
+  })
+
+  it('follows the slice when the Inbox opens', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+    expect(screen.getByTestId('isOpen').textContent).toBe('false')
+
+    store.dispatch(userDidTapOpenInbox())
+
+    await waitFor(() => {
+      expect(screen.getByTestId('isOpen').textContent).toBe('true')
+    })
+  })
+})
+
+describe('the intents it raises', () => {
+  it('seeds a Triage request with today\'s first free gap, computed at the tap', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+    // The probe is not a Page, so nothing loads the pool for it — and a row id
+    // means nothing until it has landed. The Pages do this on mount.
+    await store.dispatch(loadCaptureContextThunk({ now: new Date() }))
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+
+    screen.getByRole('button', { name: 'triage' }).click()
+
+    const request = store.getState().capture.triageRequest
+    expect(request?.endeavorId).toBe('fresh-task')
+    expect((request?.nextFreeSlotToday.getMinutes() ?? 1) % 15).toBe(0)
+  })
+
+  it('opens Add for Today on the row that asked, pre-filled by the slice', async () => {
+    const store = makeCaptureStore({ endeavors: captureFixtureRecords() })
+    mount(store)
+    await store.dispatch(loadCaptureContextThunk({ now: new Date() }))
+    await waitFor(() => {
+      expect(store.getState().capture.load.kind).toBe('loaded')
+    })
+
+    screen.getByRole('button', { name: 'add' }).click()
+
+    expect(store.getState().capture.addForToday?.endeavorId).toBe('fresh-task')
+    expect(
+      (store.getState().capture.addForToday?.pickedTime.getMinutes() ?? 1) % 15,
+    ).toBe(0)
+  })
+
+  it('is a no-op on a row the pool does not hold — a stale tap opens nothing', () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+
+    screen.getByRole('button', { name: 'add' }).click()
+
+    expect(store.getState().capture.addForToday).toBeNull()
+  })
+})

--- a/packages/app/src/features/capture/pages/captureIcons.ts
+++ b/packages/app/src/features/capture/pages/captureIcons.ts
@@ -1,0 +1,122 @@
+/**
+ * The SF Symbols the capture surfaces name that neither the design system's map
+ * nor the endeavor kit's extension carries yet.
+ *
+ * WHY THIS FILE EXISTS, AND WHY IT IS NOT A FORK. Exactly the seam
+ * `design/endeavor/endeavorIcons.ts` already established, for the same reason:
+ * `design/system/icons/icons.ts` is the one place an SF Symbol is answered, and
+ * these eight rows belong there — but the design-system tier is a merged, closed
+ * lane for this child (KC-IS-#6 owns it), and editing it would put a feature
+ * child inside a lane it does not hold.
+ *
+ * The seam is kept honest three ways, the same three:
+ *   · `captureIcon()` resolves the SYSTEM map first, then the endeavor kit's,
+ *     then this one — so a symbol two files know has exactly one answer and it
+ *     is the more general file's.
+ *   · `captureIcons.test.ts` proves the key sets are DISJOINT, so this file can
+ *     never shadow a row above it.
+ *   · Folding these rows upstream deletes this map entirely; every call site
+ *     already goes through `captureIcon()`.
+ *
+ * Keys are KroApple's exact `Image(systemName:)` strings, taken from
+ * `CaptureRules`' ported glyph tables and `InboxView.swift`'s section headers,
+ * so a port stays a lookup rather than a judgement call.
+ */
+import {
+  AlarmClockCheck,
+  CircleHelp,
+  CircleX,
+  Cloud,
+  Grid2x2,
+  Inbox,
+  type LucideIcon,
+  Repeat,
+  Smartphone,
+  Star,
+} from 'lucide-react'
+import {
+  ENDEAVOR_SF_SYMBOL_TO_LUCIDE,
+  endeavorIcon,
+  type KitSymbolName,
+} from '../../../design/endeavor/endeavorIcons'
+import { SF_SYMBOL_TO_LUCIDE } from '../../../design/system/icons/icons'
+
+/**
+ * SF Symbol name -> lucide component, for the symbols the capture prompt and
+ * the Inbox use and neither map above has adopted.
+ *
+ * Two rows draw a glyph another key already draws, deliberately:
+ *   · `repeat.circle` (the Habit kind chip) reuses `Repeat`, because lucide
+ *     ships no circled repeat and one product concept deserves one drawing —
+ *     the same call `endeavorIcons.ts` makes for `tray`.
+ *   · `tray.full` (the Pending Triage section header) reuses `Inbox`, for the
+ *     same reason `tray` does.
+ */
+export const CAPTURE_SF_SYMBOL_TO_LUCIDE = {
+  // Kind chips (`EndeavorKind.glyph`)
+  'repeat.circle': Repeat,
+
+  // Hosting destinations (`EndeavorHostingDestination.glyph`)
+  'cloud.fill': Cloud,
+  iphone: Smartphone,
+
+  // The prompt's date/time row
+  'clock.badge.checkmark': AlarmClockCheck,
+  'xmark.circle.fill': CircleX,
+  'star.fill': Star,
+
+  // Inbox sections and row buttons
+  'tray.full': Inbox,
+  'rectangle.split.2x2.fill': Grid2x2,
+} as const satisfies Record<string, LucideIcon>
+
+export type CaptureSfSymbolName = keyof typeof CAPTURE_SF_SYMBOL_TO_LUCIDE
+
+/** Every SF Symbol name the capture surfaces can draw. */
+export type CaptureSymbolName = KitSymbolName | CaptureSfSymbolName
+
+/**
+ * The lucide component for an SF Symbol name.
+ *
+ * The system map wins, then the endeavor kit's, then this one — which is why
+ * the suite asserts all three key sets are disjoint: a shadowing row would be a
+ * silent second answer to "which glyph is that", and a second answer is the
+ * whole failure this indirection exists to prevent.
+ */
+export function captureIcon(name: CaptureSymbolName): LucideIcon {
+  const known =
+    (name as string) in SF_SYMBOL_TO_LUCIDE ||
+    (name as string) in ENDEAVOR_SF_SYMBOL_TO_LUCIDE
+  if (known) return endeavorIcon(name as KitSymbolName)
+  return CAPTURE_SF_SYMBOL_TO_LUCIDE[name as CaptureSfSymbolName]
+}
+
+/**
+ * The glyph for an SF Symbol name that arrives as a plain `string`.
+ *
+ * `CaptureRules`' glyph tables (`captureKindGlyph`,
+ * `captureDestinationGlyph`, `inboxRowButtons[].icon`) are typed `string`,
+ * because the logic tier names canon's symbols and cannot know which union the
+ * render tier happens to hold. So this is the one resolver that can fail, and
+ * it fails VISIBLY: an unmapped symbol draws the help glyph rather than
+ * returning `undefined`, which React renders as a crash.
+ *
+ * `captureIcons.test.ts` walks every one of those tables and asserts each entry
+ * resolves without the fallback — the same guarantee `iconForBindingSymbol`
+ * gives the vista registry.
+ */
+export function captureIconFor(name: string): LucideIcon {
+  if (isCaptureMappedSymbol(name)) return captureIcon(name as CaptureSymbolName)
+  return CircleHelp
+}
+
+/** Whether `name` resolves to a real drawing rather than the help fallback. */
+export function isCaptureMappedSymbol(name: string): boolean {
+  return (
+    name in SF_SYMBOL_TO_LUCIDE ||
+    name in ENDEAVOR_SF_SYMBOL_TO_LUCIDE ||
+    name in CAPTURE_SF_SYMBOL_TO_LUCIDE
+  )
+}
+
+export type { LucideIcon }

--- a/packages/app/src/features/capture/pages/capturePresentation.ts
+++ b/packages/app/src/features/capture/pages/capturePresentation.ts
@@ -193,9 +193,20 @@ export const schedulingToastMessage = (
 ): string =>
   `"${displayTitle(title)}" scheduled for ${formatCaptureTime(scheduledAt, locale)}`
 
-/** The Inbox header's subtitle — canon's `"\(totalCount) endeavors"`. */
-export const inboxCountCaption = (totalCount: number): string | undefined =>
-  totalCount > 0 ? `${totalCount} endeavors` : undefined
+/**
+ * The Inbox header's subtitle — canon's `"\(totalCount) endeavors"`, with the
+ * singular fixed.
+ *
+ * **A deliberate divergence.** Canon's format string has no plural rule, so an
+ * Inbox holding one row reads *"1 endeavors"* on iOS. That is an English bug in
+ * canon's copy rather than a product decision — the string is user-facing and,
+ * here, also the dialog's accessible description, so it is not reproduced.
+ * Upstream candidate for KroApple; noted in the delivery PR.
+ */
+export const inboxCountCaption = (totalCount: number): string | undefined => {
+  if (totalCount <= 0) return undefined
+  return totalCount === 1 ? '1 endeavor' : `${totalCount} endeavors`
+}
 
 // ---------------------------------------------------------------------------
 // Recurrence presets

--- a/packages/app/src/features/capture/pages/capturePresentation.ts
+++ b/packages/app/src/features/capture/pages/capturePresentation.ts
@@ -1,0 +1,261 @@
+/**
+ * The Capture & Inbox surfaces' pure presentation rules.
+ *
+ * Everything here is a function of its arguments — no clock, no store, no DOM.
+ * The clock arrives as `now` exactly as it does one tier down in
+ * `CaptureRules`, which is what makes "Today" vs "Tomorrow" and the undo
+ * toast's copy plain unit tests rather than snapshots of the day the suite ran.
+ *
+ * ## Why the presentation split is asked of the ported table, not re-derived
+ *
+ * `MainPresentation.presentationFor` already answers "sheet or popover" from
+ * `DoSurfaceLayout.presentsNotificationsInline` — canon's own "is there room
+ * beside the content the user is already reading" cell — and it already carries
+ * the Inbox's canon frame (560 x 620). The Inbox therefore asks it directly.
+ *
+ * The **prompt** has no row in that table: canon presents it with
+ * `bottomAnchoredSheet` on the phone and a plain `.sheet` on the Mac, so there
+ * is no canon popover frame to port. KC-IS-#24 fixes the web idiom as
+ * "bottom sheet with a custom detent / desktop glass popover", so the prompt's
+ * kind is derived from the **same cell** (`presentsNotificationsInline`) rather
+ * than from a second rule that could drift, and its desktop width is named once
+ * here — see `CAPTURE_PROMPT_POPOVER_WIDTH`.
+ */
+import {
+  type Month,
+  type WeekDay,
+  monthFromDate,
+  weekDays,
+} from '@kro/core'
+import { displayTitle } from '../../../design/endeavor/endeavorCardModel'
+import type { DoSurfaceLayout } from '../../main/DoSurfaceLayout'
+import {
+  type CaptureRecurrence,
+  NO_RECURRENCE,
+  captureRecurrenceLabel,
+} from '../CaptureRules'
+
+// ---------------------------------------------------------------------------
+// Presentation
+// ---------------------------------------------------------------------------
+
+/** How one of this feature's overlay surfaces is presented. */
+export type CapturePresentationKind = 'sheet' | 'popover'
+
+/**
+ * The prompt's presentation.
+ *
+ * The same cell `presentationFor` reads, so the prompt and the Inbox can never
+ * disagree about whether this surface has room beside the content.
+ */
+export const capturePromptPresentation = (
+  layout: DoSurfaceLayout,
+): CapturePresentationKind =>
+  layout.presentsNotificationsInline ? 'popover' : 'sheet'
+
+/**
+ * The prompt panel's desktop width, in CSS pixels.
+ *
+ * **Not a canon frame** — canon's macOS prompt is an unsized `.sheet`, so there
+ * is nothing to port. 420 sits between the two neighbouring canon popovers the
+ * design system already fixed (Do notifications 380, Visibility 460): the form
+ * is one column of chips over a single-line title field, so it wants less than
+ * the Visibility filter list and more than the notification stack. Named here
+ * rather than inlined so a re-tune is one edit.
+ */
+export const CAPTURE_PROMPT_POPOVER_WIDTH = 420
+
+/**
+ * Which `EndeavorRow` preset the Inbox draws with — canon's `InboxView.Layout`.
+ *
+ * Canon picks `.compactDesktop` for the Mac popover and `.comfortable` for the
+ * phone sheet. The web reads the same distinction off the ported table's
+ * `isTouchPrimary`, because canon's own note on the compact preset is that it
+ * exists "for pointer-first use" — which is precisely that cell, not the
+ * window's width. A tablet in landscape therefore keeps the comfortable row and
+ * its 44px targets, which is the whole reason the table kept the `tablet`
+ * idiom.
+ */
+export type InboxRowLayout = 'comfortable' | 'compactDesktop'
+
+export const inboxRowLayoutFor = (layout: DoSurfaceLayout): InboxRowLayout =>
+  layout.isTouchPrimary ? 'comfortable' : 'compactDesktop'
+
+/** The `EndeavorRow` config name each Inbox layout draws with. */
+export const inboxRowConfigFor = (
+  rowLayout: InboxRowLayout,
+): 'inbox' | 'compactDesktopInbox' =>
+  rowLayout === 'compactDesktop' ? 'compactDesktopInbox' : 'inbox'
+
+// ---------------------------------------------------------------------------
+// Native input <-> Date
+// ---------------------------------------------------------------------------
+
+const pad = (value: number): string => String(value).padStart(2, '0')
+
+/**
+ * A `Date` as the `YYYY-MM-DD` string `<input type="date">` expects, in the
+ * runtime's own zone.
+ *
+ * Never `toISOString().slice(0, 10)`: that converts to UTC first, so a user in
+ * UTC+2 capturing at 00:30 would see yesterday. Same reasoning — and the same
+ * bug class — as the design kit's `localInputValue`.
+ */
+export const dateInputValue = (date: Date): string =>
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+
+/** A `Date` as the `HH:mm` string `<input type="time">` expects. */
+export const timeInputValue = (date: Date): string =>
+  `${pad(date.getHours())}:${pad(date.getMinutes())}`
+
+const DATE_INPUT = /^\d{4}-\d{2}-\d{2}$/
+const TIME_INPUT = /^\d{2}:\d{2}(:\d{2})?$/
+
+/**
+ * The inverse of `dateInputValue`, at local midnight. `null` for the empty or
+ * half-typed value the input allows while the user is still typing.
+ *
+ * The shape check is load-bearing: `new Date('2026-04-')` resolves to a real
+ * instant in V8, so a `Number.isNaN` guard alone would let a half-typed value
+ * through as a confident, wrong day.
+ */
+export const parseDateInput = (value: string): Date | null => {
+  if (!DATE_INPUT.test(value)) return null
+  const [year, month, day] = value.split('-').map(Number)
+  if (year === undefined || month === undefined || day === undefined) return null
+  const parsed = new Date(year, month - 1, day, 0, 0, 0, 0)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+/**
+ * The inverse of `timeInputValue`, projected onto `day`'s calendar date so the
+ * draft's committed instant stays on the day the user picked.
+ */
+export const parseTimeInput = (value: string, day: Date): Date | null => {
+  if (!TIME_INPUT.test(value)) return null
+  const [hours, minutes] = value.split(':').map(Number)
+  if (hours === undefined || minutes === undefined) return null
+  if (hours > 23 || minutes > 59) return null
+  const parsed = new Date(day)
+  parsed.setHours(hours, minutes, 0, 0)
+  return parsed
+}
+
+// ---------------------------------------------------------------------------
+// Copy
+// ---------------------------------------------------------------------------
+
+const isSameDay = (left: Date, right: Date): boolean =>
+  left.getFullYear() === right.getFullYear() &&
+  left.getMonth() === right.getMonth() &&
+  left.getDate() === right.getDate()
+
+/**
+ * Canon's `formattedDate`: "Today", "Tomorrow", else a medium date.
+ *
+ * `now` is a parameter for the same reason it is one everywhere else in this
+ * feature — a chip that reads "Today" only when the suite happens to run on the
+ * fixture's day is not a test.
+ */
+export const formatCaptureDate = (
+  date: Date,
+  now: Date,
+  locale?: string,
+): string => {
+  if (isSameDay(date, now)) return 'Today'
+  const tomorrow = new Date(now)
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  if (isSameDay(date, tomorrow)) return 'Tomorrow'
+  return date.toLocaleDateString(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+/** Canon's `formattedTime` / `toastTimeFormatter` — a short local time. */
+export const formatCaptureTime = (date: Date, locale?: string): string =>
+  date.toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' })
+
+/**
+ * The scheduling toast's message — canon's
+ * `"\(title)" scheduled for \(toastTimeFormatter.string(from: scheduledAt))`,
+ * quotes included.
+ *
+ * The title goes through `displayTitle` because canon reads
+ * `state.endeavors[index].displayTitle`, which strips a leading emoji: the
+ * toast already carries its own glyph, so a second one reads as a typo.
+ */
+export const schedulingToastMessage = (
+  title: string,
+  scheduledAt: Date,
+  locale?: string,
+): string =>
+  `"${displayTitle(title)}" scheduled for ${formatCaptureTime(scheduledAt, locale)}`
+
+/** The Inbox header's subtitle — canon's `"\(totalCount) endeavors"`. */
+export const inboxCountCaption = (totalCount: number): string | undefined =>
+  totalCount > 0 ? `${totalCount} endeavors` : undefined
+
+// ---------------------------------------------------------------------------
+// Recurrence presets
+// ---------------------------------------------------------------------------
+
+/**
+ * `WeekDay` for a `Date`.
+ *
+ * `getDay()` is Sunday-indexed (0) and `weekDays` is canon's Monday-first
+ * `allCases`, so the shift is `(day + 6) % 7`. Lives here rather than in
+ * `@kro/core` because it is the only caller; folding it into `WeekDay.ts`
+ * beside `monthFromDate` is a one-line follow-up in that lane.
+ */
+export const weekDayFromDate = (date: Date): WeekDay => {
+  const index = (date.getDay() + 6) % 7
+  // `weekDays` has exactly seven entries and `index` is 0…6, so the fallback is
+  // unreachable — it exists because `noUncheckedIndexedAccess` is on.
+  return weekDays[index] ?? 'monday'
+}
+
+/** One row of the repeat chip's inline picker. */
+export interface CaptureRecurrencePreset {
+  readonly id: string
+  readonly label: string
+  readonly recurrence: CaptureRecurrence
+}
+
+/**
+ * The repeat presets offered for a draft dated `date`.
+ *
+ * Canon's repeat chip pushes a second page (`EndeavorCalendarPrompt`) with a
+ * full weekday/month editor; that surface is its own canon screen and is out of
+ * this issue's scope (KC-IS-#24 names the row's chips, not the calendar page).
+ * What ships instead is the five shapes `EndeavorRecurrence` declares, each
+ * anchored to the day the draft is already on — "weekly" means the drafted
+ * weekday, "monthly" the drafted day-of-month, "yearly" that month and day.
+ * That is what every calendar app defaults to, and it exercises the whole
+ * `CaptureRecurrence -> RepeatConfig` map rather than a subset of it.
+ */
+export const captureRecurrencePresets = (
+  date: Date,
+): readonly CaptureRecurrencePreset[] => {
+  const month: Month = monthFromDate(date)
+  const day = date.getDate()
+  const presets: readonly CaptureRecurrence[] = [
+    NO_RECURRENCE,
+    { kind: 'daily', interval: 1 },
+    { kind: 'weekly', interval: 1, weekdays: [weekDayFromDate(date)] },
+    { kind: 'monthly', interval: 1, day },
+    { kind: 'yearly', interval: 1, month, day },
+  ]
+  return presets.map((recurrence) => ({
+    id: recurrence.kind,
+    label: captureRecurrenceLabel(recurrence),
+    recurrence,
+  }))
+}
+
+/** The repeat chip's own label — canon's `"No Repeat"` when nothing repeats. */
+export const captureRepeatChipLabel = (
+  recurrence: CaptureRecurrence,
+): string =>
+  recurrence.kind === 'never' ? 'No Repeat' : captureRecurrenceLabel(recurrence)

--- a/packages/app/src/features/capture/pages/index.ts
+++ b/packages/app/src/features/capture/pages/index.ts
@@ -1,0 +1,61 @@
+/**
+ * The Capture & Inbox render tier (KC-IS-#24) — a pure re-export barrel.
+ *
+ * `apps/web` reaches exactly two of these: `CaptureOverlays` (one anchor in the
+ * shell wrapper) and `InboxDestinationPage` (the `/inbox` route). Everything
+ * else is exported for stories, tests and the feature children that reuse the
+ * open-prompt intent (KC-IS-#17, KC-IS-#19, KC-IS-#26).
+ */
+
+export {
+  CAPTURE_PROMPT_POPOVER_WIDTH,
+  type CapturePresentationKind,
+  type CaptureRecurrencePreset,
+  type InboxRowLayout,
+  capturePromptPresentation,
+  captureRecurrencePresets,
+  captureRepeatChipLabel,
+  dateInputValue,
+  formatCaptureDate,
+  formatCaptureTime,
+  inboxCountCaption,
+  inboxRowConfigFor,
+  inboxRowLayoutFor,
+  parseDateInput,
+  parseTimeInput,
+  schedulingToastMessage,
+  timeInputValue,
+  weekDayFromDate,
+} from './capturePresentation'
+export {
+  CAPTURE_SF_SYMBOL_TO_LUCIDE,
+  type CaptureSfSymbolName,
+  type CaptureSymbolName,
+  captureIcon,
+  captureIconFor,
+  isCaptureMappedSymbol,
+} from './captureIcons'
+export {
+  type CapturePromptFragmentProps,
+  CapturePromptFragment,
+  captureRewardStep,
+} from './CapturePromptFragment'
+export { CapturePromptPage } from './CapturePromptPage'
+export {
+  type CaptureQuickActionFragmentProps,
+  CaptureQuickActionFragment,
+  captureQuickActionShows,
+} from './CaptureQuickActionFragment'
+export { CaptureQuickActionPage } from './CaptureQuickActionPage'
+export {
+  type InboxFragmentProps,
+  type InboxPresentation,
+  InboxFragment,
+} from './InboxFragment'
+export { InboxOverlayPage } from './InboxOverlayPage'
+export { InboxDestinationPage } from './InboxDestinationPage'
+export { CaptureOverlays } from './CaptureOverlays'
+export {
+  type InboxSurfaceViewModel,
+  useInboxSurface,
+} from './useInboxSurface'

--- a/packages/app/src/features/capture/pages/useInboxSurface.ts
+++ b/packages/app/src/features/capture/pages/useInboxSurface.ts
@@ -1,0 +1,190 @@
+'use client'
+
+/**
+ * The Inbox's stateful wrapper (`UZF-4`) — the headless hook both Inbox Pages
+ * sit on.
+ *
+ * Two Pages render this surface: the overlay (`InboxOverlayPage`, the sheet or
+ * the 560 x 620 popover a capture routes into) and the destination
+ * (`InboxDestinationPage`, the sidebar's "Jot Down" page). They differ only in
+ * their chrome, so the selection and the intent wiring live here once rather
+ * than being copied and then drifting the first time one of them is edited.
+ *
+ * It holds **no `useState`** (`RC-4`): every value is read through a named
+ * Selector and every intent is a dispatch. The one non-reactive value it keeps
+ * is a mount-time instant, and only as a fallback — see `now` below.
+ */
+
+import type { EndeavorOperation } from '@kro/core'
+import { useCallback, useMemo, useRef } from 'react'
+import {
+  type EndeavorCardModel,
+  endeavorCardModelFrom,
+} from '../../../design/endeavor/endeavorCardModel'
+import { useAppDispatch, useAppSelector } from '../../../library/hooks'
+import { selectLayout } from '../../main/MainSelectors'
+import {
+  userDidCancelAddForToday,
+  userDidDismissInbox,
+  userDidRequestAddForToday,
+  userDidTapTriage,
+  userDidAdjustAddForTodayTime,
+} from '../CaptureFeature'
+import type { CaptureAddForTodayState } from '../CaptureFeature'
+import {
+  applyInboxOperationThunk,
+  scheduleForTodayThunk,
+} from '../CaptureProducer'
+import {
+  selectAddForToday,
+  selectInboxTotalCount,
+  selectInboxVista,
+  selectIsInboxEmpty,
+  selectIsInboxOpen,
+  selectJustCreatedEndeavor,
+  selectPendingTriageEndeavors,
+} from '../CaptureSelectors'
+import { type InboxRowLayout, inboxRowLayoutFor } from './capturePresentation'
+
+export interface InboxSurfaceViewModel {
+  readonly isOpen: boolean
+  readonly justCreated: EndeavorCardModel | null
+  readonly pendingTriage: readonly EndeavorCardModel[]
+  readonly totalCount: number
+  readonly isEmpty: boolean
+  readonly capabilities: ReturnType<typeof selectInboxVista>['capabilities']
+  readonly rowLayout: InboxRowLayout
+  readonly addForToday: CaptureAddForTodayState | null
+  readonly now: Date
+
+  readonly onDismiss: () => void
+  readonly onTapTriage: (endeavorId: string) => void
+  readonly onRequestAddForToday: (endeavorId: string) => void
+  readonly onAdjustAddForTodayTime: (time: Date) => void
+  readonly onCancelAddForToday: () => void
+  readonly onConfirmAddForToday: () => void
+  readonly onOperation: (
+    operation: EndeavorOperation,
+    endeavorId: string,
+  ) => void
+}
+
+export function useInboxSurface(): InboxSurfaceViewModel {
+  const dispatch = useAppDispatch()
+
+  const isOpen = useAppSelector(selectIsInboxOpen)
+  const justCreatedEndeavor = useAppSelector(selectJustCreatedEndeavor)
+  const pendingTriageEndeavors = useAppSelector(selectPendingTriageEndeavors)
+  const totalCount = useAppSelector(selectInboxTotalCount)
+  const isEmpty = useAppSelector(selectIsInboxEmpty)
+  const vista = useAppSelector(selectInboxVista)
+  const addForToday = useAppSelector(selectAddForToday)
+  const layout = useAppSelector(selectLayout)
+
+  /**
+   * The instant the rows are classified against.
+   *
+   * The slice already parks one — `clockAnchor`, re-stamped by every event that
+   * carries a `now` — so the view reads that rather than a clock, exactly as
+   * `CaptureSelectors`' header describes. An O(1) field read is all `RC-5`
+   * allows in a `useAppSelector` callback, and all this needs.
+   *
+   * The `useRef` is the fallback for the one window where the anchor is still
+   * `null`: the first paint, before the context load lands. A ref rather than
+   * state because it must not trigger a render, and never a bare `new Date()`
+   * in the render body — that would make every re-render a different `now` and
+   * every memoized card model a fresh object.
+   */
+  const mountedAt = useRef(new Date())
+  const anchoredAt = useAppSelector((state) => state.capture.clockAnchor)
+  const now = anchoredAt ?? mountedAt.current
+
+  const nowMs = now.getTime()
+
+  const justCreated = useMemo(
+    () =>
+      justCreatedEndeavor === null
+        ? null
+        : endeavorCardModelFrom(justCreatedEndeavor, new Date(nowMs)),
+    [justCreatedEndeavor, nowMs],
+  )
+
+  const pendingTriage = useMemo(
+    () =>
+      pendingTriageEndeavors.map((endeavor) =>
+        endeavorCardModelFrom(endeavor, new Date(nowMs)),
+      ),
+    [pendingTriageEndeavors, nowMs],
+  )
+
+  const onDismiss = useCallback(() => {
+    dispatch(userDidDismissInbox())
+  }, [dispatch])
+
+  const onTapTriage = useCallback(
+    (endeavorId: string) => {
+      // `now` is read here, at the moment of the tap: canon seeds the Triage
+      // form with `nextFreeSlotToday` computed against today's events **as they
+      // stand right then**, which a render-time instant could not give.
+      dispatch(userDidTapTriage({ endeavorId, now: new Date() }))
+    },
+    [dispatch],
+  )
+
+  const onRequestAddForToday = useCallback(
+    (endeavorId: string) => {
+      dispatch(userDidRequestAddForToday({ endeavorId, now: new Date() }))
+    },
+    [dispatch],
+  )
+
+  const onAdjustAddForTodayTime = useCallback(
+    (time: Date) => {
+      dispatch(userDidAdjustAddForTodayTime({ time }))
+    },
+    [dispatch],
+  )
+
+  const onCancelAddForToday = useCallback(() => {
+    dispatch(userDidCancelAddForToday())
+  }, [dispatch])
+
+  const onConfirmAddForToday = useCallback(() => {
+    if (addForToday === null) return
+    void dispatch(
+      scheduleForTodayThunk({
+        endeavorId: addForToday.endeavorId,
+        scheduledAt: addForToday.pickedTime,
+        now: new Date(),
+      }),
+    )
+  }, [dispatch, addForToday])
+
+  const onOperation = useCallback(
+    (operation: EndeavorOperation, endeavorId: string) => {
+      void dispatch(
+        applyInboxOperationThunk({ operation, endeavorId, now: new Date() }),
+      )
+    },
+    [dispatch],
+  )
+
+  return {
+    isOpen,
+    justCreated,
+    pendingTriage,
+    totalCount,
+    isEmpty,
+    capabilities: vista.capabilities,
+    rowLayout: inboxRowLayoutFor(layout),
+    addForToday,
+    now,
+    onDismiss,
+    onTapTriage,
+    onRequestAddForToday,
+    onAdjustAddForTodayTime,
+    onCancelAddForToday,
+    onConfirmAddForToday,
+    onOperation,
+  }
+}

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -46,6 +46,14 @@ export {
  */
 export * from './features/main'
 
+/**
+ * The Capture & Inbox render tier (KC-IS-#24) — the capture prompt, the Inbox
+ * in all three of its presentations, and the `CaptureOverlays` mount the shell
+ * wrapper anchors in one line. A feature child that wants to open the prompt
+ * dispatches `userDidRequestCapture`; it needs nothing from here.
+ */
+export * from './features/capture/pages'
+
 // SCAFFOLDING — the demo feature proving the loop. Feature children replace it.
 export {
   type GreetingLoadState,


### PR DESCRIPTION
> 🟥 **Ichigo · Substitute** — the local plane, entire · *local, on your creds · I open PRs for **you** to merge (I never merge `main`, never review my own work)*
>
> Acting as **Shinigami** (product code). Authored locally in a Claude Code session on behalf of @zheref — no CI run.

Closes #24 · Part of #1

# What this changes for you

Kro Web can now **capture**. `packages/app/src/features/capture/pages/**` renders the surfaces
`#23` already had all the rules for:

- **The capture prompt** — kind chips (Task · Event · Reminder · Habit), an autofocused title,
  the date/time chip row with canon's inline pickers, the rewards stepper, the repeat chip, the
  hosting-destination picker seeded from the last used one, and Discard / Add. On a phone it is a
  bottom sheet **sized to the form**; on a desktop it is a glass popover in the FAB's corner.
- **The Inbox**, in all three presentations canon gives it: the phone **sheet**, the desktop
  **560 × 620 popover**, and the sidebar's **Jot Down destination** at `/inbox`. Just Created and
  Pending Triage, per-row **Triage** and **Add for Today**, the vista's swipe/hover operations,
  and a pinned header over a centred tray when there is nothing waiting.
- **Add for Today** pre-filled with the next quarter hour, the switch to Plan, and the **~8 s Undo
  toast** through the chrome kit's host — which nothing had mounted until now.
- **The default quick-action FAB**, canon's `plus` disc, on every destination whose own child does
  not own one.

It is all reachable: the disc opens the prompt, Add writes through the real Producer, the routing
sends an Event to Plan and everything else to the Inbox, and Undo puts the row back exactly as it
was — defer entry included.

**Three integration defects only a browser could find are fixed here, and all three are really
somebody else's lane.** See *Cross-lane findings* — they are the reason this PR touches a
`position`, a `marginRight` and a `pointerdown` that would otherwise have no business being here.

---

## How to verify

```bash
git fetch origin && git checkout ichigo/24-capture-inbox-ui
make setup
make lint && make typecheck && make test && make build
pnpm --filter @kro/web start          # http://localhost:3000
```

Everything below is the **built** app, not Storybook. Use a private window each time you want the
empty tray back — the pool lives in IndexedDB.

### 1. The prompt, and the disabled Add that names what blocks it

1. Go to **`/tasks`**. A 62px glass disc sits in the bottom-right. Press it.
2. A sheet (narrow window) or a popover (wide window) rises with the caret already in the title
   field — you can type immediately, without clicking.
3. Type nothing. **Add is disabled and the line under it reads
   _"Enter a title to add this task."_** That sentence is the acceptance criterion: canon computes
   only a boolean here.
4. Type `Design review`, then press the **Event** chip. The reason changes to
   _"Pick a start time and an end time to add this event."_ Press **Start**, then **Done**; it
   becomes _"Pick an end time to add this event."_ Press **End** → **Done**; Add lights up.
   Events are the one kind canon gates on both times.
5. Press **Habit**. The date chip disappears entirely — habits are timeless in canon.
6. Press **Task**, type a title, press **Add**.

### 2. Capture → route

- The Task you just added routes to the **Inbox**, after canon's 500 ms pause, and lands in
  **Just Created**.
- Add another one, this time an **Event** with both times. It routes to **Plan** instead and the
  Inbox never opens — canon: *"this is the only path that auto-navigates a captured endeavor away
  from the Inbox."*
- Reload `/inbox`. The row that was in Just Created is now in **Pending Triage**: the slot fires
  once per capture and drains on dismissal.

### 3. The Inbox, both idioms

- **Narrow window** (≤ 767px): the sheet, comfortable rows, the two action buttons stacked in a
  130px column, **Done** in the header.
- **Wide window**: the 560 × 620 popover, compact rows, the two actions side by side, and the
  compact header's close button. Measure the panel — it must be exactly 560 × 620.
- **Hover a row on the wide window.** The vista's two operations (green Complete, red Delete)
  appear *beside* Triage and Add for Today, not on top of them. Right-click the row for the same
  set as a menu.
- **Swipe a row on a touch device / with touch emulation.** Complete and Delete are revealed from
  the trailing edge; the leading edge has nothing, which is what `EndeavorsVistas.inbox` declares.
- Navigate to **Jot Down** in the sidebar: the same surface, inline, with no dismiss control.
- With nothing captured, `/inbox` pins the header at the top and centres the tray illustration in
  the remaining height.

### 4. Add for Today → Undo

1. Press **Add for Today** on any row. A confirm panel expands under it, pre-filled with the
   **next quarter hour** — 10:07 offers 10:15, never 10:00. (The prompt's own seed rounds the
   other way, to the *nearest* quarter hour; the two differ on purpose.)
2. Press **Schedule**. The Inbox dismisses, the app switches to **Plan**, and a toast appears
   reading `"<title>" scheduled for <time>` with an **Undo** button. It sits clear of the tab bar.
3. Press **Undo** within ~8 s. The row returns to Pending Triage with its due date *and* its
   defer history exactly as they were.
4. Do it again and let the toast time out instead. The window closes; there is nothing to undo.

### 5. Where the disc is, and is not

`/tasks`, `/inbox`, `/matrix`, `/habits`, … all draw it. **Plan**, **Do (My Day)** and **Earn** do
not — those tabs own their own FAB (`#19`, `#17`, `#28`) — and **Search** hides it outright, which
is canon's `isQuickActionAvailable`.

---

## Screenshots

Captured from the built app at 390 × 844 and 1440 × 900, in both schemes, seeded by capturing
through the real prompt — every row below was written to IndexedDB by the Producer, not painted
from a fixture.

### Capture prompt

| | Empty — Add names the missing title | Validating — an Event named but not timed |
|---|---|---|
| **Mobile · light** | ![prompt empty, mobile light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/prompt-empty-mobile-light.png) | ![prompt validating, mobile light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/prompt-validating-mobile-light.png) |
| **Mobile · dark** | ![prompt empty, mobile dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/prompt-empty-mobile-dark.png) | ![prompt validating, mobile dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/prompt-validating-mobile-dark.png) |
| **Desktop · light** | ![prompt empty, desktop light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/prompt-empty-desktop-light.png) | ![prompt validating, desktop light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/prompt-validating-desktop-light.png) |
| **Desktop · dark** | ![prompt empty, desktop dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/prompt-empty-desktop-dark.png) | ![prompt validating, desktop dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/prompt-validating-desktop-dark.png) |

### Inbox — the overlay (sheet on mobile, 560 × 620 popover on desktop)

| | Both sections | Add for Today, pre-filled | The ~8 s Undo toast |
|---|---|---|---|
| **Mobile · light** | ![inbox overlay, mobile light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-overlay-mobile-light.png) | ![add for today, mobile light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/add-for-today-mobile-light.png) | ![undo toast, mobile light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/undo-toast-mobile-light.png) |
| **Mobile · dark** | ![inbox overlay, mobile dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-overlay-mobile-dark.png) | ![add for today, mobile dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/add-for-today-mobile-dark.png) | ![undo toast, mobile dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/undo-toast-mobile-dark.png) |
| **Desktop · light** | ![inbox overlay, desktop light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-overlay-desktop-light.png) | ![add for today, desktop light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/add-for-today-desktop-light.png) | ![undo toast, desktop light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/undo-toast-desktop-light.png) |
| **Desktop · dark** | ![inbox overlay, desktop dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-overlay-desktop-dark.png) | ![add for today, desktop dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/add-for-today-desktop-dark.png) | ![undo toast, desktop dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/undo-toast-desktop-dark.png) |

### Inbox — the Jot Down destination (`/inbox`)

| | Seeded through the real capture path | Empty — pinned header, centred tray |
|---|---|---|
| **Mobile · light** | ![inbox destination, mobile light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-destination-mobile-light.png) | ![empty tray, mobile light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-empty-tray-mobile-light.png) |
| **Mobile · dark** | ![inbox destination, mobile dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-destination-mobile-dark.png) | ![empty tray, mobile dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-empty-tray-mobile-dark.png) |
| **Desktop · light** | ![inbox destination, desktop light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-destination-desktop-light.png) | ![empty tray, desktop light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-empty-tray-desktop-light.png) |
| **Desktop · dark** | ![inbox destination, desktop dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-destination-desktop-dark.png) | ![empty tray, desktop dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/24-capture-inbox-ui/inbox-empty-tray-desktop-dark.png) |

---

## Cross-lane findings — three defects a browser found and a jsdom suite could not

All three are in **merged, already-reviewed** kits. Each is worked around here with a comment
naming the real fix and the lane it belongs to; none of the workarounds is load-bearing once the
upstream fix lands.

**1. `glass.css` un-fixes every `Sheet` and `Dialog` in the repo.** `.kro-glass` sets
`position: relative`, and it is **unlayered** CSS — unlayered rules beat every `@layer utilities`
rule regardless of source order, so Tailwind's `fixed` on `SheetContent`/`DialogContent` is
overridden on any glass panel. The panel then lays out in normal flow at the end of the portal; an
85vh sheet lands entirely below the fold. Invisible until now because the primitives' own suites
deliberately never put a panel on screen (`radixEnvironment.tsx` explains why). *Worked around
with an inline `position: fixed` on both panels. Real fix: one line in `glass.css` —
`@layer components`, or drop `position` from the base rule. Lane: `#6`.*

**2. `EndeavorActionSurface`'s pointer capture eats taps on `trailing` content.** The row calls
`setPointerCapture` on `pointerdown`; a captured pointer retargets the subsequent `click` to the
capturing element, so **canon's two in-row buttons never fire in a real browser**. jsdom
implements no pointer capture, which is why the kit's suite is green. *Worked around by stopping
`pointerdown` propagation on the action cluster — a swipe should not start on a button anyway.
Lane: `#14`.*

**3. `EndeavorActionSurface` reserves no gutter for its own pointer chrome.** The hover strip
(`right-2`, one 28px button per binding) and the context-menu trigger (28px at `top-1 right-1`)
overlay exactly where a row's `trailing` content sits, and both become clickable on hover — so on
a pointer they cover Triage and Add for Today completely. *Worked around with a 72px reserved
gutter on pointer (8 + 28 + 4 + 28, measured from the kit). Real fix: the kit reserves it when a
row carries `trailing`. Lane: `#14`.*

**4. The chrome kit's toast has no bottom inset for the shell's tab bar.** Canon's 24pt is
measured inside a tab, where SwiftUI's safe area already excludes the tab bar; the web shell's tab
bar is an ordinary flex child, so a viewport-anchored toast lands underneath it. *Worked around by
lifting the layer `fabBottomPadding − toastBottomPadding` (60 − 24 = 36px), which is canon's own
"line the toast's centre up with the FAB's". Real fix: the layer takes a bottom inset, or the
shell publishes its tab bar's height. Lanes: `#15` / `#13`.*

---

## Divergences from canon, and why

**Canon re-fetched at `2117efc` (2026-08-31), not the epic's pin `2c1ee45`.** Nothing in
`EndeavorInputPrompt.swift`, `InboxView.swift` or `MainScreen.swift`'s presentation code moved
between the two.

1. **The default FAB opens the prompt, not the Inbox.** Canon's `default:` branch calls
   `selectInbox()` and says why in its own comment: *"Routes a quick-input / quick-action tap to
   the Inbox **until each option has its own dedicated creation flow**. Keeps the menus functional
   today and makes the future wiring an obvious one-line swap per case."* This PR ships that
   dedicated creation flow, so the disc takes the swap canon signposted — using canon's own
   `plus`/"Quick Add" → `showPrompt(kind: .task)` pairing from the Do menu. **This is also where
   issue #24's own wording ("FAB default `plus` opens Inbox") is superseded**, deliberately: the
   Inbox keeps two front doors of its own (the shell's tray button and the sidebar's Jot Down
   row), and without this the prompt would have no entry point at all until `#17`/`#19` land.
2. **The disc is drawn on both shells.** Canon puts `quickActionFAB` in the two phone bodies only;
   `padBody` and `wideBody` have none, because macOS reaches the prompt through Do's empty-state
   Create and Plan's press-to-create. Neither exists on the web yet, so confining it to the tab-bar
   shell would leave the desktop with no capture entry point. Narrowing it later is one line.
3. **The Add-for-Today confirm expands inline instead of popping over.** Canon anchors a
   `SchedulePopover` to the row's button. Radix's popover is built on `@radix-ui/react-popper`,
   which this repo cannot mount in a test — 5–12 **seconds** per mount under jsdom, enough to fail
   `make test` outright, measured and documented in `radixEnvironment.tsx`. The
   add-for-today → undo interaction test is a requirement of this issue, so the confirm has to be
   drivable. Same content, same one-tap confirm, same prefill; and inline expansion is the idiom
   the prompt already uses for every one of its own pickers. The **hosting-destination menu** is
   inline for the same reason.
4. **The `/inbox` destination stands down while the overlay is up.** The shell turns a capture's
   inbox route into a navigation to `/inbox` (`selectPendingShellRoute` → `deliverCaptureRouteThunk`)
   while the capture slice independently opens `inbox.isOpen` — rendering both would put the same
   surface on screen twice. The page yields; dismissing the overlay reveals it. Worth noting for
   `#13`: `CaptureRules` states that an inbox route *"never auto-navigates"*, so the navigation for
   that branch is arguably the shell's to drop — the composed behaviour is correct either way.
5. **The prompt's desktop popover is 420px wide and centred low-right rather than anchored.**
   Canon's macOS prompt is an unsized `.sheet`, so there is no frame to port; 420 sits between the
   two neighbouring canon popovers the design system already fixed (Do notifications 380,
   Visibility 460). The Inbox popover **is** canon's, read from `PRESENTATION_SIZE.inbox`.
6. **The repeat chip offers the five `EndeavorRecurrence` shapes anchored to the drafted day**,
   not canon's second page. `EndeavorCalendarPrompt` is its own canon screen with a weekday/month
   editor; #24's scope names the row's chips, not that page. The five presets exercise the whole
   `CaptureRecurrence → RepeatConfig` map.
7. **The undo toast draws `calendar`, not `calendar.badge.plus`.** `ActiveToastInput.icon` is typed
   to the design system's `SfSymbolName`, which does not carry that row yet; the endeavor kit's
   extension map does, and the toast host cannot see it. One line in
   `design/system/icons/icons.ts` restores canon's glyph with no change here.
8. **`captureIcons.ts` is a third icon map.** Eight rows the system map and the endeavor kit both
   lack. Exactly the seam `endeavorIcons.ts` established, with the same three guarantees: the more
   general map always wins, the key sets are proven disjoint by a test, and folding the rows
   upstream deletes the file.

---

## Definition of Done

- [x] `make lint && make typecheck && make test && make build` green locally — `@kro/app` 5552
      tests / 246 files, `@kro/core` 1843, `@kro/web` 141.
- [x] **≥3 stories and ≥3 mirroring render tests per Page and per Fragment** (`RC-11`):
      `CapturePromptFragment` 9 / 23 · `InboxFragment` 9 / 19 · `CaptureQuickActionFragment` 4 / 8 ·
      `CapturePromptPage` 5 / 11 · `InboxOverlayPage` 4 / 9 · `InboxDestinationPage` 4 / 7 ·
      `CaptureQuickActionPage` 4 / 6. Every story consumes `CaptureMocks`; none constructs a
      `CaptureState` inline (`RC-31`).
- [x] **Interaction tests for both required flows** — `__tests__/CaptureOverlays.test.tsx` drives
      capture → route (Task → Inbox with its Just Created row; Event → Plan, Inbox never opens) and
      add-for-today → undo (prefill, toast copy, restore, double-undo no-op) through the real
      composition against a seeded `LocalStore`.
- [x] ≥3 cases per pure function in `capturePresentation.ts` and the icon seam — 43 unit tests.
- [x] Tests use `stubbedThunkExtra` / an in-memory `LocalStore` — never the network, never a
      mocked `fetch`.
- [x] No new `any`, no `@ts-ignore`. The two `biome-ignore`-free suppressions in this diff are
      inline comments explaining a `position` and a `stopPropagation`, both cited above.
- [x] Conventional Commit; `Closes #24`; inside the declared file lane, with the two shared
      anchors below named.
- [x] `# What this changes for you` and `## How to verify` present (`CON-17`).
- [x] Nothing committed with `--no-verify`.
- [ ] **≥80 % line coverage on touched files** — *not measured*. `make test` runs no coverage
      provider and `turbo.json` declares no coverage output, so there is no number to quote and I
      will not invent one. The per-artifact minimums above are met with room to spare; wiring
      `--coverage` is a toolchain change outside this lane.

### Outside the declared lane, deliberately

The issue's lane is `packages/app/src/features/capture/pages/**`. Three files outside it changed,
each the minimum the wiring needs:

- `apps/web/src/app/(shell)/AppShellClient.tsx` — the shared one-line overlay anchor, as briefed.
- `packages/app/src/index.ts` — **one line**, `export * from './features/capture/pages'`, beside the
  shell's identical line. `apps/web` cannot deep-import past the package's `exports` map, and every
  feature child will need the same line; appended at the end so parallel children do not contend.
- `apps/web/src/app/(shell)/inbox/**` — the route directory, as briefed. The passive `page.tsx` now
  renders a ≤10-line client wrapper over the real Page instead of the shared placeholder.

---

## Review rounds

### Round 1 — Copilot (3 findings) · Cursor Bugbot (1) — all fixed in `c00cd69`, all threads replied to and resolved

| Finding | Disposition |
|---|---|
| **Bugbot · medium — Add allows duplicate captures.** The write is async and `submitCaptureThunk` has no `.pending` arm by design, so Add stays enabled and a second press mints a second id. | **Fixed.** A press-scoped `useRef` guard in `CapturePromptPage`, set before the dispatch and cleared in `.finally()` so a *failed* capture is still retryable — which is the reason the slice omits the `.pending` arm. A ref rather than state (`RC-4`): it is one press's lifetime, and it must not paint. Covered by a test that fires two `.click()`s inside one frame — a shape an awaited `userEvent.click` cannot produce. |
| **Copilot — toast `duration` derived from `expiresAt − Date.now()`** can drift and go negative. | **Fixed.** Now `ADD_FOR_TODAY_UNDO_WINDOW_MS / 1000`, the constant the slice sizes its own window with. The sharp edge was real and silent: the host clamps its input into 3–12 s, so a negative would have become 3 rather than thrown. |
| **Copilot — `inboxCountCaption` reads "1 endeavors".** | **Fixed, as a named divergence.** Canon's format string has no plural rule, so iOS reads "1 endeavors" today; that is an English defect in canon's copy rather than a product decision, and here the string is also the dialog's accessible description. Upstream candidate for KroApple. |
| **Copilot — the prompt's `now` read from the wall clock in render.** | **Fixed.** Reads `state.capture.clockAnchor` (an O(1) field read, `RC-5`) with a `useRef` mount fallback — the shape `useInboxSurface` already used. Worse than a style point: a `new Date()` per render is a clock read in a render *and* a fresh object defeating every memo below it. Covered by a test that opens the prompt with an instant a day behind the wall clock and asserts the chip still reads **Date: Today** — impossible under the old code. |

---

## Readiness

Run from a shallow clone of `bankai-core@main`:

```
$ REPO=zheref/kro-pwa bash scripts/pr_ready_gate.sh --verdict 64
#64: not-ready: a configured reviewer's round is still owed at the current head (CON-32b): sasuke (no round at head);tenma (no round at head)
```

That residue is the **whole** of it, and it is not something this branch can clear: `sasuke` and
`tenma` are not wired on this repo at all. `.github/workflows/` holds `pr.yml` and nothing else —
there is no `bankai.yml`, because installing the reviewer Apps and their secrets is an open **G5**
item in `docs/BANKAI-OPERATIONS.md` § *Human-only (G5) — the queue that blocks "everything runs"*,
tracked by epic #1. The gate's `default_reviewers` always includes both, so it will name them on
every PR opened here until that queue clears.

Everything the gate *can* evaluate on this repo is green:

- **mergeable** — no conflicts with `main`.
- **CON-32(a)** — `lint · typecheck · test · build` **pass** at the current head.
- **CON-32(b), Copilot (bounded)** — no pending request; Copilot's round was answered and
  re-requested after the fix commit.
- **CON-32(d)** — **0** unresolved review threads.

---

## Open questions

None. Everything above is decided, and every decision names the canon or the measurement it rests
on.
