### PR TITLE
feat(find): Find, All Tasks and the Endeavor Detail overlay

### DIFF
--- a/apps/web/src/app/(shell)/AppShellClient.spec.tsx
+++ b/apps/web/src/app/(shell)/AppShellClient.spec.tsx
@@ -54,4 +54,20 @@ describe('AppShellClient', () => {
     // anything of its own.
     expect(screen.getByTestId('shell-sidebar')).toBeTruthy()
   })
+
+  it('mounts the global overlays, which draw nothing until one is presented', () => {
+    render(
+      <StoreProvider store={makeStore(stubbedThunkExtra)}>
+        <AppShellClient isDevelopment={false}>
+          <p>destination content</p>
+        </AppShellClient>
+      </StoreProvider>,
+    )
+
+    // `DetailOverlays` renders `null` while no endeavor is presented, so its
+    // presence is asserted by the shell still rendering cleanly around it —
+    // an overlay that threw on mount would take the whole shell with it.
+    expect(screen.queryByTestId('detail-overlay')).toBeNull()
+    expect(screen.getByText('destination content')).toBeTruthy()
+  })
 })

--- a/apps/web/src/app/(shell)/AppShellClient.tsx
+++ b/apps/web/src/app/(shell)/AppShellClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { MainShellPage } from '@kro/app'
+import { DetailOverlays, MainShellPage } from '@kro/app'
 import type { ReactNode } from 'react'
 
 interface Props {
@@ -8,7 +8,21 @@ interface Props {
   readonly children: ReactNode
 }
 
-/** Client wrapper (`RC-39`): imports the Page, forwards props. Nothing else. */
+/**
+ * Client wrapper (`RC-39`): imports the Page, forwards props. Nothing else.
+ *
+ * The overlay area below the destination is the shared anchor for the app's
+ * global presentations — one line per overlay, each mounted once for every
+ * surface rather than per destination. `DetailOverlays` (KC-IS-#30) opens on
+ * the `viewDetail` / `edit` intents any endeavor row can raise.
+ */
 export function AppShellClient({ isDevelopment, children }: Props) {
-  return <MainShellPage isDevelopment={isDevelopment}>{children}</MainShellPage>
+  return (
+    <MainShellPage isDevelopment={isDevelopment}>
+      {children}
+      {/* --- overlay area --- */}
+      <DetailOverlays />
+      {/* --- end overlay area --- */}
+    </MainShellPage>
+  )
 }

--- a/apps/web/src/app/(shell)/lists/[listId]/ListPageClient.spec.tsx
+++ b/apps/web/src/app/(shell)/lists/[listId]/ListPageClient.spec.tsx
@@ -1,0 +1,29 @@
+import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ListPageClient } from './ListPageClient'
+
+/**
+ * The wrapper is a passive shell (`RC-39`, `RC-57`), so this asserts only what
+ * a wrapper can get wrong: which Page it mounts, and that the route's id
+ * reaches the vista instead of being dropped.
+ */
+describe('ListPageClient', () => {
+  it('mounts the All Tasks surface over the list the route names', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    render(
+      <StoreProvider store={store}>
+        <ListPageClient listId="p-9" />
+      </StoreProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tasks-surface')).toBeTruthy()
+    })
+    expect(store.getState().find.tasksSelection).toMatchObject({
+      kind: 'list',
+      listId: 'p-9',
+    })
+  })
+})

--- a/apps/web/src/app/(shell)/lists/[listId]/ListPageClient.tsx
+++ b/apps/web/src/app/(shell)/lists/[listId]/ListPageClient.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { TasksPage } from '@kro/app'
+
+interface Props {
+  readonly listId: string
+}
+
+/** Client wrapper (`RC-39`): imports the Page, forwards props, nothing else. */
+export function ListPageClient({ listId }: Props) {
+  return <TasksPage selection={{ kind: 'list', listId, listTitle: null }} />
+}

--- a/apps/web/src/app/(shell)/lists/[listId]/page.spec.tsx
+++ b/apps/web/src/app/(shell)/lists/[listId]/page.spec.tsx
@@ -1,10 +1,27 @@
 import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import ListRoute from './page'
 
 describe('/lists/[listId]', () => {
   it('forwards the project id from the route to the shared Page', async () => {
+    const store = makeStore(stubbedThunkExtra)
+    const element = await ListRoute({
+      params: Promise.resolve({ listId: 'p-2' }),
+    })
+
+    render(<StoreProvider store={store}>{element}</StoreProvider>)
+
+    await waitFor(() => {
+      expect(store.getState().find.tasksSelection).toEqual({
+        kind: 'list',
+        listId: 'p-2',
+        listTitle: null,
+      })
+    })
+  })
+
+  it('renders the list destination as the All Tasks surface over that vista', async () => {
     const element = await ListRoute({
       params: Promise.resolve({ listId: 'p-2' }),
     })
@@ -15,9 +32,24 @@ describe('/lists/[listId]', () => {
       </StoreProvider>,
     )
 
-    // No projects are loaded in this store, so the heading is empty rather
-    // than a guessed name — the id is the identity, the title is presentation.
-    expect(screen.getByTestId('destination-placeholder')).toBeTruthy()
-    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('')
+    await waitFor(() => {
+      expect(screen.getByTestId('tasks-surface')).toBeTruthy()
+    })
+  })
+
+  it('selects the Lists row so the sidebar highlight follows the URL', async () => {
+    const store = makeStore(stubbedThunkExtra)
+    const element = await ListRoute({
+      params: Promise.resolve({ listId: 'p-2' }),
+    })
+
+    render(<StoreProvider store={store}>{element}</StoreProvider>)
+
+    await waitFor(() => {
+      expect(store.getState().main.selected).toMatchObject({
+        kind: 'list',
+        listId: 'p-2',
+      })
+    })
   })
 })

--- a/apps/web/src/app/(shell)/lists/[listId]/page.tsx
+++ b/apps/web/src/app/(shell)/lists/[listId]/page.tsx
@@ -1,4 +1,4 @@
-import { DestinationPageClient } from '../../DestinationPageClient'
+import { ListPageClient } from './ListPageClient'
 
 /**
  * `/lists/<id>` — one project from the sidebar's Lists section.
@@ -7,6 +7,10 @@ import { DestinationPageClient } from '../../DestinationPageClient'
  * differs from its thirteen siblings: it resolves `params` (a Promise in
  * Next 15) and forwards the id as a plain prop. Still passive — no hook, no
  * store read (`RC-38`).
+ *
+ * Its content is the All Tasks surface over the `tasksForList(id)` vista, which
+ * is what a list destination *is* after the vista migration: the same grouped
+ * list, scoped by one `lists` term in the query.
  */
 export default async function ListRoute({
   params,
@@ -14,5 +18,5 @@ export default async function ListRoute({
   params: Promise<{ listId: string }>
 }) {
   const { listId } = await params
-  return <DestinationPageClient kind="list" listId={listId} />
+  return <ListPageClient listId={listId} />
 }

--- a/apps/web/src/app/(shell)/search/SearchPageClient.spec.tsx
+++ b/apps/web/src/app/(shell)/search/SearchPageClient.spec.tsx
@@ -1,0 +1,22 @@
+import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { SearchPageClient } from './SearchPageClient'
+
+/**
+ * The wrapper is a passive shell (`RC-39`, `RC-57`), so this asserts only what
+ * a wrapper can get wrong: which Page it mounts.
+ */
+describe('SearchPageClient', () => {
+  it('mounts the Find surface', async () => {
+    render(
+      <StoreProvider store={makeStore(stubbedThunkExtra)}>
+        <SearchPageClient />
+      </StoreProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('find-surface')).toBeTruthy()
+    })
+  })
+})

--- a/apps/web/src/app/(shell)/search/SearchPageClient.tsx
+++ b/apps/web/src/app/(shell)/search/SearchPageClient.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { FindPage } from '@kro/app'
+
+/** Client wrapper (`RC-39`): imports the Page, forwards props, nothing else. */
+export function SearchPageClient() {
+  return <FindPage />
+}

--- a/apps/web/src/app/(shell)/search/page.spec.tsx
+++ b/apps/web/src/app/(shell)/search/page.spec.tsx
@@ -1,16 +1,35 @@
 import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import SearchRoute from './page'
 
 describe('/search', () => {
-  it("mounts the Search destination inside the shell's store", () => {
+  it("mounts the Find surface inside the shell's store", async () => {
     render(
       <StoreProvider store={makeStore(stubbedThunkExtra)}>
         <SearchRoute />
       </StoreProvider>,
     )
 
-    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('Search')
+    await waitFor(() => {
+      expect(screen.getByTestId('find-surface')).toBeTruthy()
+    })
+    expect(
+      screen.getByRole('searchbox', { name: 'Search endeavors' }),
+    ).toBeTruthy()
+  })
+
+  it('selects the Search destination, so the shell highlight follows the URL', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    render(
+      <StoreProvider store={store}>
+        <SearchRoute />
+      </StoreProvider>,
+    )
+
+    await waitFor(() => {
+      expect(store.getState().main.selected.kind).toBe('search')
+    })
   })
 })

--- a/apps/web/src/app/(shell)/search/page.tsx
+++ b/apps/web/src/app/(shell)/search/page.tsx
@@ -1,13 +1,17 @@
-import { DestinationPageClient } from '../DestinationPageClient'
+import { SearchPageClient } from './SearchPageClient'
 
 /**
- * `/search` — the Search destination.
+ * `/search` — the Search destination, and Find's home.
  *
- * A passive Server Component (`RC-38`): it names its destination and renders
- * the client wrapper. No hook, no store read, no markup. The surface itself
- * lives in `packages/app`, so the feature child that builds Search replaces
- * a Page there and never touches this file.
+ * A passive Server Component (`RC-38`): it renders the client wrapper and
+ * nothing else. No hook, no store read, no markup. The surface itself lives in
+ * `packages/app`; this file only names which one.
+ *
+ * The shell's `DestinationPage` placeholder is gone from this route: the Page
+ * it mounted was the "not built yet" card, and `FindPage` now carries the
+ * `onDestinationRouteMounted` dispatch that placeholder was there for — see its
+ * own header.
  */
 export default function SearchRoute() {
-  return <DestinationPageClient kind="search" />
+  return <SearchPageClient />
 }

--- a/apps/web/src/app/(shell)/tasks/TasksPageClient.spec.tsx
+++ b/apps/web/src/app/(shell)/tasks/TasksPageClient.spec.tsx
@@ -1,0 +1,25 @@
+import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { TasksPageClient } from './TasksPageClient'
+
+/**
+ * The wrapper is a passive shell (`RC-39`, `RC-57`), so this asserts only what
+ * a wrapper can get wrong: which Page it mounts, and which vista it names.
+ */
+describe('TasksPageClient', () => {
+  it('mounts the All Tasks surface over the default vista', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    render(
+      <StoreProvider store={store}>
+        <TasksPageClient />
+      </StoreProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tasks-surface')).toBeTruthy()
+    })
+    expect(store.getState().find.tasksSelection).toEqual({ kind: 'default' })
+  })
+})

--- a/apps/web/src/app/(shell)/tasks/TasksPageClient.tsx
+++ b/apps/web/src/app/(shell)/tasks/TasksPageClient.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { TasksPage } from '@kro/app'
+
+/** Client wrapper (`RC-39`): imports the Page, forwards props, nothing else. */
+export function TasksPageClient() {
+  return <TasksPage selection={{ kind: 'default' }} />
+}

--- a/apps/web/src/app/(shell)/tasks/page.spec.tsx
+++ b/apps/web/src/app/(shell)/tasks/page.spec.tsx
@@ -1,18 +1,34 @@
 import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import TasksRoute from './page'
 
 describe('/tasks', () => {
-  it("mounts the All Tasks destination inside the shell's store", () => {
+  it("mounts the All Tasks surface inside the shell's store", async () => {
     render(
       <StoreProvider store={makeStore(stubbedThunkExtra)}>
         <TasksRoute />
       </StoreProvider>,
     )
 
-    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe(
-      'All Tasks',
+    await waitFor(() => {
+      expect(screen.getByTestId('tasks-surface')).toBeTruthy()
+    })
+    expect(screen.getByRole('radiogroup', { name: 'Group by' })).toBeTruthy()
+  })
+
+  it('installs the default `.tasks*` vista this route names', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    render(
+      <StoreProvider store={store}>
+        <TasksRoute />
+      </StoreProvider>,
     )
+
+    await waitFor(() => {
+      expect(store.getState().find.tasksSelection).toEqual({ kind: 'default' })
+    })
+    expect(store.getState().main.selected.kind).toBe('allTasks')
   })
 })

--- a/apps/web/src/app/(shell)/tasks/page.tsx
+++ b/apps/web/src/app/(shell)/tasks/page.tsx
@@ -1,13 +1,12 @@
-import { DestinationPageClient } from '../DestinationPageClient'
+import { TasksPageClient } from './TasksPageClient'
 
 /**
  * `/tasks` — the All Tasks destination.
  *
- * A passive Server Component (`RC-38`): it names its destination and renders
- * the client wrapper. No hook, no store read, no markup. The surface itself
- * lives in `packages/app`, so the feature child that builds All Tasks replaces
- * a Page there and never touches this file.
+ * A passive Server Component (`RC-38`): it renders the client wrapper and
+ * nothing else. The surface lives in `packages/app`; the `tasksDefault` vista
+ * is the selection this route names.
  */
 export default function TasksRoute() {
-  return <DestinationPageClient kind="allTasks" />
+  return <TasksPageClient />
 }

--- a/packages/app/src/design/system/styles.css
+++ b/packages/app/src/design/system/styles.css
@@ -8,9 +8,29 @@
    Order matters in exactly one place: `tokens.css` declares the custom
    properties every other file reads. Beyond that the files are independent —
    they define disjoint class names and no cascade between them.
+
+   ONE OF THEM IS LAYERED, AND ONLY ONE (KC-IS-#30).
+   `glass.css` is the only file here whose rules a caller is meant to
+   OVERRIDE with a utility class. `.kro-glass` sets `position: relative` and
+   `border-radius`, and its consumers say otherwise: `sheet.tsx` asks for
+   `fixed inset-x-0 bottom-0 rounded-t-kro-surface`, `dialog.tsx` for
+   `fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2`, and
+   `dropdown-menu.tsx` for `rounded-kro-field`.
+
+   Unlayered rules beat layered ones, and Tailwind emits every utility inside
+   `@layer utilities` — so an unlayered `.kro-glass` silently won all three,
+   and every glass OVERLAY rendered inline in the document flow instead of
+   over it. jsdom applies no CSS, so the primitives' own suites could not see
+   it; the first build to put a sheet on screen did (KC-IS-#30's Detail
+   overlay). Importing this one file into `components` restores the intended
+   cascade: the material is the default, a utility on the element wins.
+
+   The other three stay unlayered on purpose — `tokens.css` declares custom
+   properties (which no utility competes with) and the motion/gradient files
+   define behaviour a caller is not meant to override.
    ========================================================================== */
 
 @import "./tokens/tokens.css";
 @import "./motion/motion.css";
-@import "./glass/glass.css";
+@import "./glass/glass.css" layer(components);
 @import "./gradient/gradient.css";

--- a/packages/app/src/features/endeavorDetail/pages/DetailOverlaySelectors.ts
+++ b/packages/app/src/features/endeavorDetail/pages/DetailOverlaySelectors.ts
@@ -1,0 +1,62 @@
+/**
+ * The one derived read the global Detail overlay needs that neither feature
+ * already exports (`RC-5`, `RC-20`).
+ *
+ * `#29` parks every cross-feature request as an **intent** on the Find slice —
+ * `{ id, operation, endeavorId, surface }` — deliberately without the endeavor
+ * itself, because a slice may not import a sibling's shape and an intent is a
+ * request, not a payload. The overlay needs the endeavor to present it, so the
+ * two are joined here: composed from `find`'s **own exported Selectors**, never
+ * by reaching into `state.find`'s shape, which is exactly the cross-slice route
+ * `UZF-6`/`RC-20` sanction.
+ *
+ * Only the two operations this overlay owns resolve. `startSession`, `triage`,
+ * `share` and `dismissSuggestion` belong to other features and stay in the
+ * queue untouched — draining an intent the overlay cannot serve would
+ * acknowledge it on that feature's behalf and lose the request.
+ */
+import type { Endeavor, EndeavorOperation } from '@kro/core'
+import { createSelector } from '@reduxjs/toolkit'
+import {
+  selectFindNextIntent,
+  selectFindRows,
+  selectTasksRows,
+} from '../../find/FindSelectors'
+
+/** The operations the Detail overlay answers. Everything else is somebody else's. */
+export const DETAIL_INTENT_OPERATIONS: readonly EndeavorOperation[] = [
+  'viewDetail',
+  'edit',
+]
+
+/** One resolved request: which intent, which endeavor, and how to present it. */
+export interface DetailIntentRequest {
+  readonly intentId: number
+  readonly operation: EndeavorOperation
+  readonly endeavor: Endeavor
+}
+
+/**
+ * The next request the overlay should serve, or `null`.
+ *
+ * `null` also covers "the intent names a row this surface no longer holds" — an
+ * optimistic delete can remove the row between the tap and the drain — because
+ * presenting Detail on an endeavor that is gone would be worse than dropping
+ * the request. The intent stays queued in that case, and the reducer's own
+ * `childIntentDelegatedConsumed` is the only thing that removes it.
+ */
+export const selectDetailIntentRequest = createSelector(
+  [selectFindNextIntent, selectFindRows, selectTasksRows],
+  (intent, findRows, tasksRows): DetailIntentRequest | null => {
+    if (intent === null) return null
+    if (!DETAIL_INTENT_OPERATIONS.includes(intent.operation)) return null
+    const pool = intent.surface === 'find' ? findRows : tasksRows
+    const endeavor = pool.find((row) => row.id === intent.endeavorId)
+    if (endeavor === undefined) return null
+    return {
+      intentId: intent.id,
+      operation: intent.operation,
+      endeavor,
+    }
+  },
+)

--- a/packages/app/src/features/endeavorDetail/pages/DetailOverlays.stories.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/DetailOverlays.stories.tsx
@@ -1,0 +1,99 @@
+/**
+ * The global Detail overlay, mounted on a real store (`RC-11`).
+ *
+ * Each scene drives the overlay the way the app does — by parking the
+ * `viewDetail` intent the row would raise — so what is drawn is what the intent
+ * queue, the drain and the presentation actually produce.
+ */
+import { Stage } from '../../../design/endeavor/storyStage'
+import {
+  Harness,
+  makeSeededStore,
+} from '../../find/pages/__tests__/pagesHarness'
+import { onDetailRequested, onEditRequested } from '../EndeavorDetailFeature'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import { userDidTapField, userDidTapManageRelation } from '../EndeavorDetailFeature'
+import { DetailOverlays } from './DetailOverlays'
+import type { AppStore } from '../../../library/store'
+
+type Mock = (typeof detailEndeavorMocks)[keyof typeof detailEndeavorMocks]
+
+const presented = (endeavor: Mock, then?: (store: AppStore) => void) => {
+  const store = makeSeededStore({ endeavors: [endeavor] })
+  store.dispatch(onDetailRequested({ endeavor }))
+  then?.(store)
+  return store
+}
+
+export default {
+  title: 'Endeavor Detail/Overlay',
+  component: DetailOverlays,
+  parameters: { layout: 'fullscreen' },
+}
+
+/** The read surface, over a task. The sheet is the shell's own presentation. */
+export const DetailSheet = {
+  render: () => (
+    <Stage width={900}>
+      <Harness store={presented(detailEndeavorMocks.task)}>
+        <DetailOverlays locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}
+
+/** The full editor, opened directly by another surface's `edit` operation. */
+export const EditOverDetail = {
+  render: () => (
+    <Stage width={900}>
+      <Harness
+        store={presented(detailEndeavorMocks.event, (store) => {
+          store.dispatch(onEditRequested({ endeavor: detailEndeavorMocks.event }))
+        })}
+      >
+        <DetailOverlays locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}
+
+/** The Duration profile, reached from the Detail row that opens it. */
+export const DurationProfile = {
+  render: () => (
+    <Stage width={900}>
+      <Harness
+        store={presented(detailEndeavorMocks.taskWithSessions, (store) => {
+          store.dispatch(userDidTapField({ field: 'duration' }))
+        })}
+      >
+        <DetailOverlays locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}
+
+/** A relation screen, reached from its Manage affordance. */
+export const RelationScreen = {
+  render: () => (
+    <Stage width={900}>
+      <Harness
+        store={presented(detailEndeavorMocks.task, (store) => {
+          store.dispatch(userDidTapManageRelation({ relation: 'hosts' }))
+        })}
+      >
+        <DetailOverlays locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}
+
+/** Nothing presented: the overlay renders nothing at all. */
+export const Closed = {
+  render: () => (
+    <Stage width={900}>
+      <Harness store={makeSeededStore()}>
+        <DetailOverlays locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}

--- a/packages/app/src/features/endeavorDetail/pages/DetailOverlays.test.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/DetailOverlays.test.tsx
@@ -1,0 +1,400 @@
+/**
+ * The global Detail overlay, against a real store over a seeded database
+ * (`RC-22`, `RC-35`).
+ *
+ * Two of these are the issue's own acceptance criteria and neither can be read
+ * from a screenshot: Detail **opens from another surface's row**, and the
+ * editor's **dirty tracking** decides whether Save is offered at all.
+ */
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+import { installRadixEnvironment } from '../../../design/system/primitives/__tests__/radixEnvironment'
+import { findEndeavorMocks } from '../../find/FindMocks'
+import { TasksPage } from '../../find/pages/TasksPage'
+import {
+  Harness,
+  makeSeededStore,
+} from '../../find/pages/__tests__/pagesHarness'
+import type { AppStore } from '../../../library/store'
+import { onShellMounted } from '../../main/MainFeature'
+import { handheldSurface } from '../../main/MainMocks'
+import {
+  onDetailRequested,
+  userDidChangeField,
+  userDidChangeRelationDraft,
+  userDidTapField,
+  userDidTapManageRelation,
+} from '../EndeavorDetailFeature'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import { DetailOverlays } from './DetailOverlays'
+
+let teardown: () => void
+
+afterEach(() => {
+  cleanup()
+  teardown?.()
+})
+
+type Mock = (typeof detailEndeavorMocks)[keyof typeof detailEndeavorMocks]
+
+const mountPresented = (
+  endeavor: Mock,
+  then?: (store: AppStore) => void,
+): AppStore => {
+  teardown = installRadixEnvironment()
+  const store = makeSeededStore({ endeavors: [endeavor] })
+  store.dispatch(onDetailRequested({ endeavor }))
+  then?.(store)
+  render(
+    <Harness store={store}>
+      <DetailOverlays locale="en-US" />
+    </Harness>,
+  )
+  return store
+}
+
+describe('Detail opens from ANY surface, through the intent queue', () => {
+  it('presents the endeavor an All Tasks row asked for', async () => {
+    teardown = installRadixEnvironment()
+    const store = makeSeededStore({
+      endeavors: [findEndeavorMocks.morningTask],
+    })
+
+    render(
+      <Harness store={store}>
+        <TasksPage selection={{ kind: 'default' }} input="touch" locale="en-US" />
+        <DetailOverlays locale="en-US" />
+      </Harness>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tasks-row-open')).toBeTruthy()
+    })
+    await userEvent.click(screen.getByTestId('tasks-row-open'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('detail-overlay')).toBeTruthy()
+    })
+    // Two headings carry the title: the sheet's own `sr-only` accessible name
+    // and the Detail header's visible one. Both are correct; neither is the
+    // claim, which is that the overlay is presenting THIS endeavor.
+    expect(
+      within(screen.getByTestId('detail-overlay')).getAllByRole('heading', {
+        name: findEndeavorMocks.morningTask.title,
+      }).length,
+    ).toBeGreaterThan(0)
+  })
+
+  it('acknowledges the intent by id, so a re-render cannot replay it', async () => {
+    teardown = installRadixEnvironment()
+    const store = makeSeededStore({
+      endeavors: [findEndeavorMocks.morningTask],
+    })
+
+    render(
+      <Harness store={store}>
+        <TasksPage selection={{ kind: 'default' }} input="touch" locale="en-US" />
+        <DetailOverlays locale="en-US" />
+      </Harness>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tasks-row-open')).toBeTruthy()
+    })
+    await userEvent.click(screen.getByTestId('tasks-row-open'))
+
+    await waitFor(() => {
+      expect(store.getState().find.intents).toHaveLength(0)
+    })
+  })
+
+  it('renders nothing at all while no endeavor is presented', () => {
+    teardown = installRadixEnvironment()
+    render(
+      <Harness store={makeSeededStore()}>
+        <DetailOverlays locale="en-US" />
+      </Harness>,
+    )
+
+    expect(screen.queryByTestId('detail-overlay')).toBeNull()
+  })
+})
+
+describe('the title bar', () => {
+  it('offers Close on the read surface and no Save — there is nothing to save', () => {
+    mountPresented(detailEndeavorMocks.task)
+
+    expect(screen.getByRole('button', { name: 'Close' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull()
+  })
+
+  it('dismisses the whole surface from the title bar, not the bottom of a scroll', async () => {
+    const store = mountPresented(detailEndeavorMocks.task)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    await waitFor(() => {
+      expect(store.getState().endeavorDetail.endeavor).toBeNull()
+    })
+  })
+
+  it('swaps Close for Back once an editor is presented over Detail', async () => {
+    const store = mountPresented(detailEndeavorMocks.task, (each) => {
+      each.dispatch(userDidTapField({ field: 'status' }))
+    })
+
+    expect(screen.getByRole('button', { name: 'Back' })).toBeTruthy()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+    await waitFor(() => {
+      expect(store.getState().endeavorDetail.destination).toBeNull()
+    })
+    // Back leaves Detail open; only Close dismisses it.
+    expect(store.getState().endeavorDetail.endeavor).not.toBeNull()
+  })
+
+  it('names the endeavor\'s kind and state under the title', () => {
+    mountPresented(detailEndeavorMocks.task)
+
+    expect(screen.getByText(/Task · Pending/)).toBeTruthy()
+  })
+})
+
+describe('dirty tracking decides whether Save is offered', () => {
+  it('disables Save on a clean editor — there is nothing to write', () => {
+    mountPresented(detailEndeavorMocks.task, (store) => {
+      store.dispatch(userDidTapField({ field: 'status' }))
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'Save' }).hasAttribute('disabled'),
+    ).toBe(true)
+  })
+
+  it('enables Save the moment the working copy differs from the saved one', async () => {
+    mountPresented(detailEndeavorMocks.task, (store) => {
+      store.dispatch(userDidTapField({ field: 'status' }))
+      store.dispatch(
+        userDidChangeField({ change: { field: 'status', value: 'blocked' } }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Save' }).hasAttribute('disabled'),
+      ).toBe(false)
+    })
+  })
+
+  it('persists the working copy and leaves the editor clean again', async () => {
+    const store = mountPresented(detailEndeavorMocks.task, (each) => {
+      each.dispatch(userDidTapField({ field: 'status' }))
+      each.dispatch(
+        userDidChangeField({ change: { field: 'status', value: 'blocked' } }),
+      )
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(store.getState().endeavorDetail.endeavor?.status).toBe('blocked')
+    })
+    // The baseline moved with the save, so nothing is left to write.
+    const draft = store.getState().endeavorDetail.edit
+    expect(draft?.working).toEqual(draft?.original)
+  })
+
+  it('refuses a change the matrix forbids, leaving the draft clean', async () => {
+    mountPresented(detailEndeavorMocks.event, (store) => {
+      store.dispatch(userDidTapField({ field: 'status' }))
+      // A calendar event has no editable `due`; the domain's guarded helper
+      // returns the same object, so the draft never becomes dirty.
+      store.dispatch(
+        userDidChangeField({
+          change: { field: 'due', value: new Date(2026, 0, 1) },
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Save' }).hasAttribute('disabled'),
+      ).toBe(true)
+    })
+  })
+})
+
+describe('the destinations the overlay presents', () => {
+  it('opens the Duration profile from the Detail row that owns it', () => {
+    mountPresented(detailEndeavorMocks.taskWithSessions, (store) => {
+      store.dispatch(userDidTapField({ field: 'duration' }))
+    })
+
+    expect(screen.getByTestId('endeavor-duration')).toBeTruthy()
+    expect(screen.getByTestId('observed-average')).toBeTruthy()
+  })
+
+  it('opens a relation screen from its Manage affordance', () => {
+    mountPresented(detailEndeavorMocks.task, (store) => {
+      store.dispatch(userDidTapManageRelation({ relation: 'hosts' }))
+    })
+
+    const relation = screen.getByTestId('endeavor-relation')
+    expect(relation.dataset.relation).toBe('hosts')
+    expect(within(relation).getByRole('heading', { name: 'Hosts' })).toBeTruthy()
+  })
+
+  it('offers no Save on a relation screen — each entry commits on its own', () => {
+    mountPresented(detailEndeavorMocks.task, (store) => {
+      store.dispatch(userDidTapManageRelation({ relation: 'defers' }))
+    })
+
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull()
+  })
+
+  it('presents a bottom SHEET on the tab-bar shell, not a centred dialog', () => {
+    const store = mountPresented(detailEndeavorMocks.task, (each) => {
+      each.dispatch(
+        onShellMounted({ surface: handheldSurface, isDevelopment: false }),
+      )
+    })
+
+    expect(store.getState().main.surface).toEqual(handheldSurface)
+    expect(screen.getByTestId('detail-overlay').dataset.side).toBe('bottom')
+  })
+})
+
+describe('a relation write commits on its own, through the real Producer', () => {
+  it('adds a hand-logged performance and refreshes the presented endeavor', async () => {
+    const store = mountPresented(detailEndeavorMocks.task, (each) => {
+      each.dispatch(userDidTapManageRelation({ relation: 'performances' }))
+      each.dispatch(
+        userDidChangeRelationDraft({
+          draft: {
+            relation: 'performances',
+            draft: {
+              date: new Date(2026, 5, 18, 9),
+              durationSeconds: 1500,
+              resolution: 'complete',
+              notes: 'Focused block',
+              rewardPoints: 10,
+              wasCompletedInSession: true,
+              editingIndex: null,
+            },
+          },
+        }),
+      )
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add Performance' }),
+    )
+
+    await waitFor(() => {
+      expect(store.getState().endeavorDetail.endeavor?.performances).toHaveLength(
+        1,
+      )
+    })
+    expect(
+      store.getState().endeavorDetail.endeavor?.performances[0]?.rewardPoints,
+    ).toBe(10)
+  })
+
+  it('removes a recorded performance by its position', async () => {
+    const store = mountPresented(
+      detailEndeavorMocks.taskWithSessions,
+      (each) => {
+        each.dispatch(userDidTapManageRelation({ relation: 'performances' }))
+      },
+    )
+
+    const removes = screen.getAllByRole('button', {
+      name: /^Remove performance/,
+    })
+    await userEvent.click(removes[0] as HTMLElement)
+
+    await waitFor(() => {
+      expect(
+        store.getState().endeavorDetail.endeavor?.performances,
+      ).toHaveLength(2)
+    })
+  })
+
+  it('adds a defer, which is two rows: the moved due date and its audit entry', async () => {
+    const store = mountPresented(detailEndeavorMocks.task, (each) => {
+      each.dispatch(userDidTapManageRelation({ relation: 'defers' }))
+      each.dispatch(
+        userDidChangeRelationDraft({
+          draft: {
+            relation: 'defers',
+            draft: { target: new Date(2026, 5, 25, 9), reason: 'Blocked' },
+          },
+        }),
+      )
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add Defer' }))
+
+    await waitFor(() => {
+      expect(store.getState().endeavorDetail.endeavor?.defers).toHaveLength(1)
+    })
+    expect(store.getState().endeavorDetail.endeavor?.defers[0]?.reason).toBe(
+      'Blocked',
+    )
+  })
+
+  it('adds a shadow from the four identity columns', async () => {
+    const store = mountPresented(detailEndeavorMocks.task, (each) => {
+      each.dispatch(userDidTapManageRelation({ relation: 'shadows' }))
+      each.dispatch(
+        userDidChangeRelationDraft({
+          draft: {
+            relation: 'shadows',
+            draft: {
+              originalTitle: 'Mirrored',
+              sourceIdentifier: 'rem-1',
+              source: 'appleReminders',
+              kind: 'task',
+              group: '',
+            },
+          },
+        }),
+      )
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add Shadow' }))
+
+    await waitFor(() => {
+      expect(store.getState().endeavorDetail.endeavor?.shadows).toHaveLength(1)
+    })
+  })
+
+  it('refuses to attach a provider this build has no adapter for, and says why', async () => {
+    const store = mountPresented(detailEndeavorMocks.event, (each) => {
+      each.dispatch(userDidTapManageRelation({ relation: 'hosts' }))
+      each.dispatch(
+        userDidChangeRelationDraft({
+          draft: { relation: 'hosts', host: 'outlookCalendar' },
+        }),
+      )
+    })
+
+    // The Attach control is disabled, so the commit path is the one the form's
+    // submit takes — the refusal is the Producer's, not the button's.
+    await waitFor(() => {
+      expect(store.getState().endeavorDetail.relationDraft).not.toBeNull()
+    })
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Detach Google Calendar' }),
+    )
+
+    await waitFor(() => {
+      expect(store.getState().endeavorDetail.save.kind).toBe('failed')
+    })
+    expect(
+      screen.getByText('Google Calendar mirroring is not connected yet.'),
+    ).toBeTruthy()
+  })
+})

--- a/packages/app/src/features/endeavorDetail/pages/DetailOverlays.test.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/DetailOverlays.test.tsx
@@ -371,21 +371,31 @@ describe('a relation write commits on its own, through the real Producer', () =>
     })
   })
 
-  it('refuses to attach a provider this build has no adapter for, and says why', async () => {
-    const store = mountPresented(detailEndeavorMocks.event, (each) => {
+  it('offers no Attach control this build can honour, and says why per provider', () => {
+    mountPresented(detailEndeavorMocks.event, (each) => {
       each.dispatch(userDidTapManageRelation({ relation: 'hosts' }))
-      each.dispatch(
-        userDidChangeRelationDraft({
-          draft: { relation: 'hosts', host: 'outlookCalendar' },
-        }),
-      )
     })
 
-    // The Attach control is disabled, so the commit path is the one the form's
-    // submit takes — the refusal is the Producer's, not the button's.
-    await waitFor(() => {
-      expect(store.getState().endeavorDetail.relationDraft).not.toBeNull()
+    // Every provider is listed rather than hidden — a hidden control makes the
+    // gap invisible — and every one of them is disabled with its reason.
+    const attach = screen.getAllByRole('button', { name: /^Attach / })
+    expect(attach.length).toBeGreaterThan(0)
+    for (const button of attach) {
+      expect(button.hasAttribute('disabled')).toBe(true)
+    }
+    expect(
+      screen.getByText('Outlook mirroring is off in this build.'),
+    ).toBeTruthy()
+  })
+
+  it('refuses a DETACH this build has no adapter for, and surfaces the reason', async () => {
+    const store = mountPresented(detailEndeavorMocks.event, (each) => {
+      each.dispatch(userDidTapManageRelation({ relation: 'hosts' }))
     })
+
+    // Detach is the one host control that is enabled today, so it is the one
+    // that actually reaches the Producer — which refuses, because no provider
+    // adapter is wired (KC-IS-#29 / KC-IS-#33).
     await userEvent.click(
       screen.getByRole('button', { name: 'Detach Google Calendar' }),
     )

--- a/packages/app/src/features/endeavorDetail/pages/DetailOverlays.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/DetailOverlays.tsx
@@ -44,7 +44,7 @@ import {
   type Shadow,
   assertNever,
 } from '@kro/core'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { CompactPresentationHeader } from '../../../design/endeavor/CompactPresentationHeader'
 import {
   Dialog,
@@ -123,6 +123,10 @@ export interface DetailOverlaysProps {
 
 export function DetailOverlays({ locale }: DetailOverlaysProps) {
   const dispatch = useAppDispatch()
+  // The instant an unopened draft seeds itself from — stable for the life of
+  // one presented screen (RC-5: never a per-render clock). Event-time reads
+  // stay inside the callbacks, where the clock belongs.
+  const seededAt = useMemo(() => new Date(), [])
 
   const request = useAppSelector(selectDetailIntentRequest)
   const endeavor = useAppSelector(selectDetailEndeavor)
@@ -320,7 +324,7 @@ export function DetailOverlays({ locale }: DetailOverlaysProps) {
         isDraftCommittable={isDraftCommittable}
         attachedHosts={attachedHosts}
         hostCandidates={hostCandidates}
-        now={new Date()}
+        now={seededAt}
         locale={locale}
         onChangeDraft={(draft) => dispatch(userDidChangeRelationDraft({ draft }))}
         onCommitDraft={onCommitDraft}

--- a/packages/app/src/features/endeavorDetail/pages/DetailOverlays.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/DetailOverlays.tsx
@@ -1,0 +1,413 @@
+'use client'
+
+/**
+ * The global Endeavor Detail overlay (`RC-37`) — canon's `EndeavorDetailScreen`
+ * and the five children it presents, mounted **once** for the whole app.
+ *
+ * ## Why it is global, and why that is one line in the shell
+ *
+ * Canon presents Detail from wherever the user was: a Find row, a Plan block, a
+ * Do card. Mounting it per surface would be one copy per surface, each with its
+ * own dismissal and its own dirty state, and the fifth copy is the one that
+ * disagrees. So it is mounted beside the shell's content and listens for the
+ * `viewDetail` / `edit` intents `#29` parks — which is what makes "long-press
+ * or secondary-click opens Detail from any endeavor row" a property of the
+ * intent queue rather than of any one surface.
+ *
+ * The overlay drains only the two intents it owns, and acknowledges each by id
+ * (`childIntentDelegatedConsumed`), so two taps on two rows are two requests
+ * rather than one that swallows the other.
+ *
+ * ## Presentation follows the shell's own decision table
+ *
+ * `selectShellShape` is the ported `DoSurfaceLayout` answer, so the overlay
+ * takes the epic's idiom rule without re-deriving it: a bottom **sheet** on the
+ * tab-bar shell (the edge a thumb reaches) and a centred **dialog** on the
+ * sidebar shell. Both are the same Radix primitive on the same KroGlass
+ * material — the design system built them that way for exactly this pairing.
+ *
+ * ## The title bar owns dismiss and save
+ *
+ * Canon moved dismissal out of the scroll body and into the navigation toolbar,
+ * and its own header says why: the previous Close button "sat at the bottom of
+ * the scroll, reachable only after scrolling past every section". The leading
+ * control is therefore *Close* on the read surface and *Back* on an editor, and
+ * Save sits opposite — enabled by `selectIsSaveEnabled`, which is dirty AND
+ * valid AND not already saving AND (on the Duration screen) a coherent profile.
+ */
+import {
+  type Defer,
+  type EndeavorField,
+  type EndeavorHost,
+  type EndeavorRelation,
+  type Perform,
+  type Shadow,
+  assertNever,
+} from '@kro/core'
+import { useCallback, useEffect } from 'react'
+import { CompactPresentationHeader } from '../../../design/endeavor/CompactPresentationHeader'
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '../../../design/system/primitives/dialog'
+import { Sheet, SheetContent, SheetTitle } from '../../../design/system/primitives/sheet'
+import { colorVar } from '../../../design/system/tokens/roles'
+import { useAppDispatch, useAppSelector } from '../../../library/hooks'
+import { childIntentDelegatedConsumed } from '../../find/FindFeature'
+import { selectShellShape } from '../../main/MainSelectors'
+import { selectProjects } from '../../main/MainSelectors'
+import {
+  onDetailRequested,
+  onEditRequested,
+  userDidAdjustDurationBound,
+  userDidChangeField,
+  userDidChangeRelationDraft,
+  userDidDismissDestination,
+  userDidTapDismiss,
+  userDidTapField,
+  userDidTapManageRelation,
+  userDidToggleDurationBound,
+} from '../EndeavorDetailFeature'
+import {
+  addDeferThunk,
+  addPerformanceThunk,
+  addShadowThunk,
+  attachHostThunk,
+  detachHostThunk,
+  removeDeferThunk,
+  removePerformanceThunk,
+  removeShadowThunk,
+  saveEndeavorThunk,
+} from '../EndeavorDetailProducer'
+import {
+  selectDetailAttachedHosts,
+  selectDetailBadges,
+  selectDetailEndeavor,
+  selectDetailException,
+  selectDetailHostCandidates,
+  selectDetailRelationCards,
+  selectDetailTitle,
+  selectDetailVisibleSections,
+  selectDurationDraft,
+  selectDetailDestination,
+  selectEditWorkingCopy,
+  selectEditableSections,
+  selectEditNavigationTitle,
+  selectIsDetailSaving,
+  selectIsEditValid,
+  selectIsRelationDraftCommittable,
+  selectIsSaveEnabled,
+  selectManagedRelation,
+  selectObservedFocusTime,
+  selectRelationDraft,
+  selectRelationEmptyState,
+  selectRelationReadOnlyReason,
+  selectDurationValidationMessage,
+} from '../EndeavorDetailSelectors'
+import type { EndeavorDetailBadge } from '../EndeavorDetailCards'
+import type { DurationBound } from '../EndeavorDuration'
+import { EndeavorDetailFragment } from './EndeavorDetailFragment'
+import { EndeavorDurationFragment } from './EndeavorDurationFragment'
+import { EndeavorEditFragment } from './EndeavorEditFragment'
+import {
+  EndeavorRelationFragment,
+  relationEntryFromDraft,
+} from './EndeavorRelationFragment'
+import { selectDetailIntentRequest } from './DetailOverlaySelectors'
+import { relationLabel } from './endeavorDetailDisplay'
+
+export interface DetailOverlaysProps {
+  readonly locale?: string
+}
+
+export function DetailOverlays({ locale }: DetailOverlaysProps) {
+  const dispatch = useAppDispatch()
+
+  const request = useAppSelector(selectDetailIntentRequest)
+  const endeavor = useAppSelector(selectDetailEndeavor)
+  const destination = useAppSelector(selectDetailDestination)
+  const title = useAppSelector(selectDetailTitle)
+  const sections = useAppSelector(selectDetailVisibleSections)
+  const relations = useAppSelector(selectDetailRelationCards)
+  const editSections = useAppSelector(selectEditableSections)
+  const working = useAppSelector(selectEditWorkingCopy)
+  const editTitle = useAppSelector(selectEditNavigationTitle)
+  const isValid = useAppSelector(selectIsEditValid)
+  const isSaving = useAppSelector(selectIsDetailSaving)
+  const isSaveEnabled = useAppSelector(selectIsSaveEnabled)
+  const exception = useAppSelector(selectDetailException)
+  const durationDraft = useAppSelector(selectDurationDraft)
+  const observed = useAppSelector(selectObservedFocusTime)
+  const validationMessage = useAppSelector(selectDurationValidationMessage)
+  const managedRelation = useAppSelector(selectManagedRelation)
+  const relationDraft = useAppSelector(selectRelationDraft)
+  const isDraftCommittable = useAppSelector(selectIsRelationDraftCommittable)
+  const readOnlyReason = useAppSelector(selectRelationReadOnlyReason)
+  const relationEmptyState = useAppSelector(selectRelationEmptyState)
+  const attachedHosts = useAppSelector(selectDetailAttachedHosts)
+  const hostCandidates = useAppSelector(selectDetailHostCandidates)
+  const badges = useAppSelector(selectDetailBadges)
+  const projects = useAppSelector(selectProjects)
+  const shape = useAppSelector(selectShellShape)
+
+  /**
+   * Drain the intents this overlay owns.
+   *
+   * `viewDetail` presents the read surface; `edit` opens the full editor
+   * directly, which is canon's own two entry points. Both acknowledge by id
+   * immediately after, so a remount cannot replay the same request.
+   */
+  useEffect(() => {
+    if (request === null) return
+    if (request.operation === 'edit') {
+      dispatch(onEditRequested({ endeavor: request.endeavor }))
+    } else {
+      dispatch(onDetailRequested({ endeavor: request.endeavor }))
+    }
+    dispatch(childIntentDelegatedConsumed({ intentId: request.intentId }))
+  }, [dispatch, request])
+
+  const onSave = useCallback(() => {
+    if (working === null) return
+    void dispatch(saveEndeavorThunk({ endeavor: working, now: new Date() }))
+  }, [dispatch, working])
+
+  const onCommitDraft = useCallback(() => {
+    if (endeavor === null || relationDraft === null) return
+    const now = new Date()
+
+    if (relationDraft.relation === 'hosts') {
+      if (relationDraft.host === null) return
+      void dispatch(
+        attachHostThunk({ endeavorId: endeavor.id, host: relationDraft.host }),
+      )
+      return
+    }
+
+    const entry = relationEntryFromDraft(relationDraft, now)
+    if (entry === null) return
+
+    switch (relationDraft.relation) {
+      case 'performances':
+        void dispatch(
+          addPerformanceThunk({
+            endeavorId: endeavor.id,
+            performance: entry as Perform,
+            now,
+          }),
+        )
+        return
+      case 'defers':
+        void dispatch(
+          addDeferThunk({ endeavorId: endeavor.id, entry: entry as Defer, now }),
+        )
+        return
+      default:
+        void dispatch(
+          addShadowThunk({
+            endeavorId: endeavor.id,
+            shadow: entry as Shadow,
+            now,
+          }),
+        )
+    }
+  }, [dispatch, endeavor, relationDraft])
+
+  const onRemoveEntry = useCallback(
+    (index: number) => {
+      if (endeavor === null || managedRelation === null) return
+      const now = new Date()
+      const endeavorId = endeavor.id
+      switch (managedRelation) {
+        case 'performances':
+          void dispatch(removePerformanceThunk({ endeavorId, index, now }))
+          return
+        case 'defers':
+          void dispatch(removeDeferThunk({ endeavorId, index, now }))
+          return
+        case 'shadows':
+          void dispatch(removeShadowThunk({ endeavorId, index, now }))
+          return
+        default:
+          // `hosts` removes by provider, not by position — see `onDetachHost`.
+          return
+      }
+    },
+    [dispatch, endeavor, managedRelation],
+  )
+
+  const onDetachHost = useCallback(
+    (host: EndeavorHost) => {
+      if (endeavor === null) return
+      void dispatch(detachHostThunk({ endeavorId: endeavor.id, host }))
+    },
+    [dispatch, endeavor],
+  )
+
+  const onAttachHost = useCallback(
+    (host: EndeavorHost) => {
+      if (endeavor === null) return
+      void dispatch(attachHostThunk({ endeavorId: endeavor.id, host }))
+    },
+    [dispatch, endeavor],
+  )
+
+  if (endeavor === null) return null
+
+  const isEditor = destination !== null
+  const headerTitle =
+    destination === null
+      ? title
+      : destination.kind === 'edit'
+        ? editTitle
+        : destination.kind === 'duration'
+          ? 'Duration'
+          : relationLabel(destination.relation)
+
+  const showsSave =
+    destination !== null &&
+    (destination.kind === 'edit' || destination.kind === 'duration')
+
+  const body =
+    destination === null ? (
+      <EndeavorDetailFragment
+        endeavor={endeavor}
+        title={title}
+        sections={sections}
+        relations={relations}
+        locale={locale}
+        onEditField={(field: EndeavorField) => dispatch(userDidTapField({ field }))}
+        onManageRelation={(relation: EndeavorRelation) =>
+          dispatch(userDidTapManageRelation({ relation }))
+        }
+      />
+    ) : destination.kind === 'edit' && working !== null ? (
+      <EndeavorEditFragment
+        working={working}
+        sections={editSections}
+        isValid={isValid}
+        isSaving={isSaving}
+        exception={exception}
+        projects={projects}
+        onChangeField={(change) => dispatch(userDidChangeField({ change }))}
+        onOpenDuration={() =>
+          dispatch(userDidTapField({ field: 'duration' as EndeavorField }))
+        }
+      />
+    ) : destination.kind === 'duration' && durationDraft !== null && observed !== null ? (
+      <EndeavorDurationFragment
+        draft={durationDraft}
+        observed={observed}
+        validationMessage={validationMessage}
+        isSaving={isSaving}
+        onToggleBound={(bound: DurationBound, isEnabled: boolean) =>
+          dispatch(userDidToggleDurationBound({ bound, isEnabled }))
+        }
+        onAdjustBound={(bound: DurationBound, seconds: number) =>
+          dispatch(userDidAdjustDurationBound({ bound, seconds }))
+        }
+      />
+    ) : destination.kind === 'relation' && relationEmptyState !== null ? (
+      <EndeavorRelationFragment
+        relation={destination.relation}
+        endeavor={endeavor}
+        readOnlyReason={readOnlyReason}
+        emptyState={relationEmptyState}
+        isSaving={isSaving}
+        exception={exception}
+        draft={relationDraft}
+        isDraftCommittable={isDraftCommittable}
+        attachedHosts={attachedHosts}
+        hostCandidates={hostCandidates}
+        now={new Date()}
+        locale={locale}
+        onChangeDraft={(draft) => dispatch(userDidChangeRelationDraft({ draft }))}
+        onCommitDraft={onCommitDraft}
+        onRemoveEntry={onRemoveEntry}
+        onAttachHost={onAttachHost}
+        onDetachHost={onDetachHost}
+      />
+    ) : null
+
+  const chrome = (
+    <>
+      <div className="flex items-center gap-kro-small">
+        <div className="min-w-0 flex-1">
+          <CompactPresentationHeader
+            title={headerTitle}
+            subtitle={badges.map((badge) => badgeLabel(badge)).join(' · ')}
+            leadingAction={
+              isEditor
+                ? {
+                    kind: 'back',
+                    onPress: () => dispatch(userDidDismissDestination()),
+                  }
+                : { kind: 'dismiss', onPress: () => dispatch(userDidTapDismiss()) }
+            }
+          />
+        </div>
+        {showsSave ? (
+          <button
+            type="button"
+            disabled={!isSaveEnabled}
+            onClick={onSave}
+            className="shrink-0 rounded-kro-pill px-4 text-sm font-semibold outline-none focus-visible:shadow-[var(--kro-ring)] disabled:opacity-[var(--kro-opacity-disabled)]"
+            style={{
+              minHeight: 'var(--kro-size-min-touch-target)',
+              backgroundColor: colorVar('accent'),
+              color: colorVar('onAccent'),
+            }}
+          >
+            {isSaving ? 'Saving…' : 'Save'}
+          </button>
+        ) : null}
+      </div>
+      {body}
+    </>
+  )
+
+  const onOpenChange = (open: boolean) => {
+    if (!open) dispatch(userDidTapDismiss())
+  }
+
+  return shape === 'sidebar' ? (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent
+        hideClose
+        data-testid="detail-overlay"
+        className="max-h-[85vh] max-w-[620px] grid-rows-[auto_1fr] overflow-hidden"
+      >
+        <DialogTitle className="sr-only">{headerTitle}</DialogTitle>
+        {chrome}
+      </DialogContent>
+    </Dialog>
+  ) : (
+    <Sheet open onOpenChange={onOpenChange}>
+      <SheetContent hideClose data-testid="detail-overlay" side="bottom">
+        <SheetTitle className="sr-only">{headerTitle}</SheetTitle>
+        {chrome}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+/**
+ * The subtitle line under the overlay's title: the endeavor's kind and state,
+ * labelled — canon's own header badges, which `#29` already derives.
+ */
+const badgeLabel = (badge: EndeavorDetailBadge): string => {
+  switch (badge.kind) {
+    case 'kind':
+    case 'status':
+      return badge.label
+    case 'duration':
+      return `${Math.round(badge.seconds / 60)} min`
+    case 'rewardPoints':
+      return `${badge.points} pts`
+    case 'repeats':
+      return 'Repeats'
+    default:
+      return assertNever(badge)
+  }
+}

--- a/packages/app/src/features/endeavorDetail/pages/DetailOverlays.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/DetailOverlays.tsx
@@ -173,17 +173,17 @@ export function DetailOverlays({ locale }: DetailOverlaysProps) {
     void dispatch(saveEndeavorThunk({ endeavor: working, now: new Date() }))
   }, [dispatch, working])
 
+  /**
+   * Commit the open add form.
+   *
+   * `hosts` is deliberately absent: that screen has no form at all — a provider
+   * is attached by its own row control, so the commit path never sees one. A
+   * branch for it would be code no interaction can reach.
+   */
   const onCommitDraft = useCallback(() => {
     if (endeavor === null || relationDraft === null) return
+    if (relationDraft.relation === 'hosts') return
     const now = new Date()
-
-    if (relationDraft.relation === 'hosts') {
-      if (relationDraft.host === null) return
-      void dispatch(
-        attachHostThunk({ endeavorId: endeavor.id, host: relationDraft.host }),
-      )
-      return
-    }
 
     const entry = relationEntryFromDraft(relationDraft, now)
     if (entry === null) return

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorDetailFragment.stories.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorDetailFragment.stories.tsx
@@ -1,0 +1,85 @@
+/**
+ * The Detail read surface's visual evidence (`RC-11`, `UZF-26`).
+ *
+ * The scenes are chosen so the **matrix** is visible, not just the happy path:
+ * a task (every field and relation), a calendar event (three fields gone, two
+ * relations read-only), a habit, a blueprint (the sparsest Core of any kind)
+ * and a blank title.
+ */
+import { BothSchemes, Stage } from '../../../design/endeavor/storyStage'
+import { relationCards, visibleSections } from '../EndeavorDetailCards'
+import { detailDisplayTitle } from '../EndeavorDetailCards'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import { EndeavorDetailFragment } from './EndeavorDetailFragment'
+
+const noop = () => {}
+
+const scene = (endeavor: (typeof detailEndeavorMocks)[keyof typeof detailEndeavorMocks]) => ({
+  endeavor,
+  title: detailDisplayTitle(endeavor),
+  sections: visibleSections(endeavor.kind),
+  relations: relationCards(endeavor),
+  locale: 'en-US',
+  onEditField: noop,
+  onManageRelation: noop,
+})
+
+export default {
+  title: 'Endeavor Detail/Read surface',
+  component: EndeavorDetailFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+/** A task: every field and every relation is editable for this kind. */
+export const TypicalTask = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorDetailFragment {...scene(detailEndeavorMocks.task)} />
+    </Stage>
+  ),
+}
+
+/** A calendar event: the matrix removes Due, Reward and Performances. */
+export const CalendarEvent = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorDetailFragment {...scene(detailEndeavorMocks.event)} />
+    </Stage>
+  ),
+}
+
+/** A habit — session-trackable, never due-dated. */
+export const Habit = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorDetailFragment {...scene(detailEndeavorMocks.habit)} />
+    </Stage>
+  ),
+}
+
+/** A blueprint: one of the three meta kinds, and the sparsest Core section. */
+export const MetaKind = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorDetailFragment {...scene(detailEndeavorMocks.blueprint)} />
+    </Stage>
+  ),
+}
+
+/** A blank title, which canon renders as "Untitled" rather than nothing. */
+export const UntitledEndeavor = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorDetailFragment {...scene(detailEndeavorMocks.untitled)} />
+    </Stage>
+  ),
+}
+
+/** Both schemes, so the grouped cards and chips are judged in dark too. */
+export const BothColorSchemes = {
+  render: () => (
+    <BothSchemes>
+      <EndeavorDetailFragment {...scene(detailEndeavorMocks.task)} />
+    </BothSchemes>
+  ),
+}

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorDetailFragment.test.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorDetailFragment.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * The Detail read surface's render tests, mirroring its stories (`RC-11`).
+ *
+ * The claims worth making are the per-kind ones: a field the matrix hides is
+ * ABSENT, a relation the matrix locks says "Read only" and offers no Manage,
+ * and the title is drawn once — by the header, never twice.
+ */
+import { cleanup, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  detailDisplayTitle,
+  relationCards,
+  visibleSections,
+} from '../EndeavorDetailCards'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import { EndeavorDetailFragment } from './EndeavorDetailFragment'
+
+afterEach(cleanup)
+
+type Mock = (typeof detailEndeavorMocks)[keyof typeof detailEndeavorMocks]
+
+const mount = (
+  endeavor: Mock,
+  handlers: {
+    onEditField?: (field: string) => void
+    onManageRelation?: (relation: string) => void
+  } = {},
+) =>
+  render(
+    <EndeavorDetailFragment
+      endeavor={endeavor}
+      title={detailDisplayTitle(endeavor)}
+      sections={visibleSections(endeavor.kind)}
+      relations={relationCards(endeavor)}
+      locale="en-US"
+      onEditField={handlers.onEditField ?? (() => {})}
+      onManageRelation={handlers.onManageRelation ?? (() => {})}
+    />,
+  )
+
+describe('the header', () => {
+  it('leads with the kind chip, which is the endeavor\'s strongest identity signal', () => {
+    mount(detailEndeavorMocks.task)
+    expect(screen.getByText('Task')).toBeTruthy()
+  })
+
+  it('renders a blank title as "Untitled" rather than an invisible heading', () => {
+    mount(detailEndeavorMocks.untitled)
+    expect(screen.getByRole('heading', { name: 'Untitled' })).toBeTruthy()
+  })
+
+  it('draws the title ONCE — the Core section does not repeat it', () => {
+    mount(detailEndeavorMocks.task)
+    expect(screen.queryByText('Title')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Edit title' })).toBeTruthy()
+  })
+
+  it('carries the facts that are set, and only those', () => {
+    mount(detailEndeavorMocks.task)
+    const header = screen.getByTestId('detail-header')
+
+    // Duration and reward are set on this fixture; recurrence is not, so the
+    // header stays compact rather than showing a row of placeholders. Scoped
+    // to the header because "Repeats" is also the Recurrence ROW's label.
+    expect(within(header).getByText('30m')).toBeTruthy()
+    expect(within(header).getByText('8 pts')).toBeTruthy()
+    expect(within(header).queryByText('Repeats')).toBeNull()
+  })
+})
+
+describe('the matrix decides which rows exist', () => {
+  it('gives a task a Due row', () => {
+    mount(detailEndeavorMocks.task)
+    expect(screen.getByText('Due')).toBeTruthy()
+  })
+
+  it('gives a calendar event NO Due row — absent, not disabled', () => {
+    mount(detailEndeavorMocks.event)
+    expect(screen.queryByText('Due')).toBeNull()
+    expect(screen.getByText('Start')).toBeTruthy()
+  })
+
+  it('drops the fields a meta kind has no use for, rather than disabling them', () => {
+    mount(detailEndeavorMocks.blueprint)
+    // A blueprint is one of the three meta kinds: no Start, no Duration, no
+    // Reward. Absent, not greyed out — the matrix decides, and the surface
+    // renders its answer.
+    expect(screen.queryByText('Start')).toBeNull()
+    expect(screen.queryByText('Duration')).toBeNull()
+    expect(screen.queryByText('Reward')).toBeNull()
+    expect(screen.getByText('Status')).toBeTruthy()
+  })
+
+  it('opens the field\'s editor through a named control', async () => {
+    const onEditField = vi.fn()
+    mount(detailEndeavorMocks.task, { onEditField })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit status' }))
+
+    expect(onEditField).toHaveBeenCalledWith('status')
+  })
+})
+
+describe('relations', () => {
+  it('always shows all four cards, whatever the kind', () => {
+    mount(detailEndeavorMocks.event)
+    for (const label of ['Performances', 'Defers', 'Hosts', 'Shadows']) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('offers Manage only where the kind allows editing that relation', async () => {
+    const onManageRelation = vi.fn()
+    mount(detailEndeavorMocks.task, { onManageRelation })
+
+    const manage = screen.getAllByRole('button', { name: 'Manage' })
+    expect(manage.length).toBeGreaterThan(0)
+    await userEvent.click(manage[0] as HTMLElement)
+
+    expect(onManageRelation).toHaveBeenCalled()
+  })
+
+  it('marks a locked relation "Read only" instead of rendering an inert header', () => {
+    mount(detailEndeavorMocks.event)
+
+    const performances = screen.getByTestId('endeavor-detail')
+    expect(within(performances).getAllByText('Read only').length).toBeGreaterThan(0)
+  })
+
+  it('summarises an empty relation with WHY it is empty', () => {
+    mount(detailEndeavorMocks.task)
+    expect(screen.getAllByText('Never deferred').length).toBeGreaterThan(0)
+  })
+
+  it('counts a relation that has entries', () => {
+    mount(detailEndeavorMocks.taskWithSessions)
+    expect(screen.getAllByText('3 sessions logged').length).toBeGreaterThan(0)
+  })
+})

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorDetailFragment.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorDetailFragment.tsx
@@ -1,0 +1,252 @@
+'use client'
+
+/**
+ * The Endeavor Detail read surface — the port of
+ * `KroUI/EndeavorDetail/EndeavorDetailView.swift` (`RC-15`).
+ *
+ * Canon's structure, part for part: a hero header carrying the kind chip, the
+ * title and the at-a-glance facts; one grouped card per non-relation section,
+ * each row opening that field's editor; then one card per relation, each
+ * stating its summary and offering *Manage* only where the kind allows it.
+ *
+ * ## `title` is drawn once, by the header
+ *
+ * Canon filters `.title` out of the Core section for exactly this reason: the
+ * matrix marks it visible for every kind, and the header already renders it as
+ * the heading — with its own pencil affordance, so the row it replaces is not a
+ * lost entry point.
+ *
+ * ## The editor affordance is a trailing control, not the whole row
+ *
+ * Canon wraps each row in a `Button`. SwiftUI has no content model; HTML does,
+ * and a `<button>` may hold only phrasing content — so wrapping the kit's
+ * `PropertyRow` (a `div` of `span`s) in one produces invalid markup that no
+ * assistive technology recovers from, and the same is true of the `h2` in the
+ * header. Each row therefore carries a labelled trailing control — *"Edit
+ * due"*, *"Edit title"* — which is the same affordance canon's chevron already
+ * advertises, reachable by keyboard and announced by name.
+ *
+ * ## The tinted page, and the "no scrollbar" requirement
+ *
+ * Canon puts these cards on a grouped background and hides the scroll
+ * indicators. The web equivalent is `scrollbar-width: none` plus the WebKit
+ * pseudo-element, which is a pair `styles.css` has no utility for yet, so it is
+ * written here with the reason beside it rather than added to a merged lane's
+ * stylesheet.
+ */
+import type { Endeavor, EndeavorField, EndeavorRelation } from '@kro/core'
+import { ChipFlow, KroChip, semanticTint } from '../../../design/endeavor/KroChip'
+import { PropertyRow } from '../../../design/endeavor/PropertyRow'
+import {
+  CardRowStack,
+  SectionCard,
+  SurfaceCard,
+} from '../../../design/endeavor/SurfaceCard'
+import { endeavorIcon } from '../../../design/endeavor/endeavorIcons'
+import { colorVar } from '../../../design/system/tokens/roles'
+import type { EndeavorRelationCard } from '../EndeavorDetailCards'
+import type { EndeavorDetailSectionModel } from '../EndeavorDetailEditing'
+import {
+  fieldIcon,
+  fieldLabel,
+  fieldValue,
+  headerChips,
+  kindChip,
+  relationIcon,
+  relationLabel,
+  relationSummary,
+} from './endeavorDetailDisplay'
+
+const Pencil = endeavorIcon('pencil')
+const ChevronRight = endeavorIcon('chevron.right')
+
+/**
+ * Canon hides the scroll indicators (`.scrollIndicators(.hidden)`); the web
+ * needs both spellings, and neither has a Tailwind utility in this repo.
+ */
+export const HIDDEN_SCROLLBAR_STYLE = {
+  scrollbarWidth: 'none',
+  msOverflowStyle: 'none',
+} as const
+
+export interface EndeavorDetailFragmentProps {
+  readonly endeavor: Endeavor
+  /** Canon's `displayTitle` — "Untitled" for a blank one. */
+  readonly title: string
+  /** The sections worth a header, per-kind, from `#29`'s Selectors. */
+  readonly sections: readonly EndeavorDetailSectionModel[]
+  /** All four relations, each carrying its per-kind manageability. */
+  readonly relations: readonly EndeavorRelationCard[]
+  readonly locale?: string
+  readonly onEditField: (field: EndeavorField) => void
+  readonly onManageRelation: (relation: EndeavorRelation) => void
+}
+
+export function EndeavorDetailFragment({
+  endeavor,
+  title,
+  sections,
+  relations,
+  locale,
+  onEditField,
+  onManageRelation,
+}: EndeavorDetailFragmentProps) {
+  const kind = kindChip(endeavor)
+  const chips = headerChips(endeavor)
+
+  return (
+    <div
+      data-testid="endeavor-detail"
+      className="flex min-h-0 flex-1 flex-col gap-kro-large overflow-y-auto pb-kro-x-large [&>*]:shrink-0 [&::-webkit-scrollbar]:hidden"
+      style={HIDDEN_SCROLLBAR_STYLE}
+    >
+      <SurfaceCard>
+        <div data-testid="detail-header" className="flex flex-col gap-2.5">
+          <div>
+            <KroChip
+              title={kind.title}
+              icon={kind.icon}
+              tint={kind.tint}
+              emphasis="prominent"
+            />
+          </div>
+
+          <div className="flex items-start gap-kro-small">
+            <h2
+              className="m-0 flex-1 font-bold text-xl"
+              style={{ color: colorVar('fore') }}
+            >
+              {title}
+            </h2>
+            <IconAction
+              label="Edit title"
+              onPress={() => onEditField('title')}
+            >
+              <Pencil size={14} aria-hidden />
+            </IconAction>
+          </div>
+
+          {chips.length === 0 ? null : (
+            <ChipFlow>
+              {chips.map((chip) => (
+                <KroChip
+                  key={chip.id}
+                  title={chip.title}
+                  icon={chip.icon}
+                  tint={chip.tint}
+                  size="small"
+                />
+              ))}
+            </ChipFlow>
+          )}
+        </div>
+      </SurfaceCard>
+
+      {sections.map((section) => {
+        // The header already drew the title; canon filters it out here.
+        const rows = section.fields.filter((field) => field !== 'title')
+        if (rows.length === 0) return null
+        return (
+          <SectionCard
+            key={section.section}
+            title={section.title}
+            padding={null}
+          >
+            <CardRowStack>
+              {rows.map((field) => (
+                <div
+                  key={field}
+                  data-detail-field={field}
+                  className="flex items-center gap-kro-small px-kro-medium py-2.5"
+                >
+                  <div className="min-w-0 flex-1">
+                    <PropertyRow
+                      label={fieldLabel(field)}
+                      value={fieldValue(endeavor, field, locale)}
+                      icon={fieldIcon(field)}
+                    />
+                  </div>
+                  <IconAction
+                    label={`Edit ${fieldLabel(field).toLowerCase()}`}
+                    onPress={() => onEditField(field)}
+                  >
+                    <ChevronRight size={13} aria-hidden />
+                  </IconAction>
+                </div>
+              ))}
+            </CardRowStack>
+          </SectionCard>
+        )
+      })}
+
+      {relations.map((card) => (
+        <SectionCard
+          key={card.relation}
+          title={relationLabel(card.relation)}
+          icon={relationIcon(card.relation)}
+          count={card.count === 0 ? undefined : card.count}
+          actionTitle={card.isManageable ? 'Manage' : undefined}
+          onAction={
+            card.isManageable ? () => onManageRelation(card.relation) : undefined
+          }
+        >
+          <div
+            data-detail-relation={card.relation}
+            className="flex items-start gap-kro-small"
+          >
+            <div className="min-w-0 flex-1">
+              <PropertyRow
+                label={relationLabel(card.relation)}
+                value={relationSummary(endeavor, card.relation)}
+              />
+            </div>
+            {card.isManageable ? null : (
+              <span className="shrink-0">
+                <KroChip
+                  title="Read only"
+                  icon="eye.circle.fill"
+                  tint={semanticTint('chipNeutral')}
+                  emphasis="outline"
+                  size="small"
+                />
+              </span>
+            )}
+          </div>
+        </SectionCard>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * A named, keyboard-reachable icon control at the 44px floor.
+ *
+ * The glyph is 13–14px, which is canon's drawing; the floor belongs to the
+ * BUTTON, exactly as `CompactPresentationHeader` does it — so the hit area
+ * grows and the drawing does not.
+ */
+function IconAction({
+  label,
+  onPress,
+  children,
+}: {
+  readonly label: string
+  readonly onPress: () => void
+  readonly children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onPress}
+      className="inline-flex shrink-0 items-center justify-center rounded-kro-pill outline-none focus-visible:shadow-[var(--kro-ring)]"
+      style={{
+        minWidth: 'var(--kro-size-min-touch-target)',
+        minHeight: 'var(--kro-size-min-touch-target)',
+        color: colorVar('foreSecondary'),
+      }}
+    >
+      {children}
+    </button>
+  )
+}

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorDurationFragment.stories.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorDurationFragment.stories.tsx
@@ -1,0 +1,112 @@
+/**
+ * The Duration profile's visual evidence (`RC-11`, `UZF-26`).
+ *
+ * Canon's own three previews, plus both schemes: no history (the
+ * recommendation is locked), an empirical recommendation with all three bounds
+ * enabled, and an incoherent profile whose validation message says so.
+ */
+import { BothSchemes, Stage } from '../../../design/endeavor/storyStage'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import {
+  durationDraftFor,
+  durationValidationMessage,
+  observedFocusTime,
+} from '../EndeavorDuration'
+import { EndeavorDurationFragment } from './EndeavorDurationFragment'
+
+const noop = () => {}
+
+const scene = (
+  endeavor: (typeof detailEndeavorMocks)[keyof typeof detailEndeavorMocks],
+) => {
+  const draft = durationDraftFor(endeavor)
+  return {
+    draft,
+    observed: observedFocusTime(endeavor),
+    validationMessage: durationValidationMessage(draft),
+    isSaving: false,
+    onToggleBound: noop,
+    onAdjustBound: noop,
+  }
+}
+
+export default {
+  title: 'Endeavor Detail/Duration',
+  component: EndeavorDurationFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+/** One session logged — below the sample minimum, so the card stays locked. */
+export const NoRecommendationYet = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorDurationFragment {...scene(detailEndeavorMocks.taskWithOneSession)} />
+    </Stage>
+  ),
+}
+
+/** Three qualifying sessions — the observed average is unlocked and read-only. */
+export const EmpiricalRecommendation = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorDurationFragment
+        {...scene(detailEndeavorMocks.taskWithSessions)}
+        draft={{
+          ...durationDraftFor(detailEndeavorMocks.taskWithSessions),
+          isPreferredEnabled: true,
+          isMinimumEnabled: true,
+          isMaximumEnabled: true,
+          minimumSeconds: 20 * 60,
+          maximumSeconds: 45 * 60,
+        }}
+      />
+    </Stage>
+  ),
+}
+
+/** A minimum above the maximum — canon's one validation rule, stated. */
+export const InvalidBounds = {
+  render: () => {
+    const draft = {
+      ...durationDraftFor(detailEndeavorMocks.taskWithSessions),
+      isMinimumEnabled: true,
+      isMaximumEnabled: true,
+      minimumSeconds: 60 * 60,
+      maximumSeconds: 20 * 60,
+    }
+    return (
+      <Stage width={430}>
+        <EndeavorDurationFragment
+          {...scene(detailEndeavorMocks.taskWithSessions)}
+          draft={draft}
+          validationMessage={durationValidationMessage(draft)}
+        />
+      </Stage>
+    )
+  },
+}
+
+/** A save in flight: the dials go read-only rather than disappearing. */
+export const Saving = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorDurationFragment
+        {...scene(detailEndeavorMocks.taskWithSessions)}
+        draft={{
+          ...durationDraftFor(detailEndeavorMocks.taskWithSessions),
+          isPreferredEnabled: true,
+        }}
+        isSaving
+      />
+    </Stage>
+  ),
+}
+
+/** Both schemes, so the dial's ticks and the cards are judged in dark too. */
+export const BothColorSchemes = {
+  render: () => (
+    <BothSchemes>
+      <EndeavorDurationFragment {...scene(detailEndeavorMocks.taskWithSessions)} />
+    </BothSchemes>
+  ),
+}

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorDurationFragment.test.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorDurationFragment.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * The Duration profile's render tests, mirroring its stories (`RC-11`).
+ *
+ * The claim that matters is the read-only one: the observed average has **no
+ * control at all**, so an empirical recommendation can never be turned into an
+ * authored preference by accident — which is canon's stated reason for keeping
+ * the two apart.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import {
+  type EndeavorDurationDraft,
+  durationDraftFor,
+  durationValidationMessage,
+  observedFocusTime,
+} from '../EndeavorDuration'
+import { EndeavorDurationFragment } from './EndeavorDurationFragment'
+
+afterEach(cleanup)
+
+type Mock = (typeof detailEndeavorMocks)[keyof typeof detailEndeavorMocks]
+
+const mount = (
+  endeavor: Mock,
+  overrides: {
+    draft?: EndeavorDurationDraft
+    isSaving?: boolean
+    onToggleBound?: (bound: string, isEnabled: boolean) => void
+    onAdjustBound?: (bound: string, seconds: number) => void
+  } = {},
+) => {
+  const draft = overrides.draft ?? durationDraftFor(endeavor)
+  return render(
+    <EndeavorDurationFragment
+      draft={draft}
+      observed={observedFocusTime(endeavor)}
+      validationMessage={durationValidationMessage(draft)}
+      isSaving={overrides.isSaving ?? false}
+      onToggleBound={overrides.onToggleBound ?? (() => {})}
+      onAdjustBound={overrides.onAdjustBound ?? (() => {})}
+    />,
+  )
+}
+
+describe('the observed focus time is read-only', () => {
+  it('states the average once the sample is large enough', () => {
+    mount(detailEndeavorMocks.taskWithSessions)
+
+    expect(screen.getByTestId('observed-average').textContent).toBe('30m')
+    expect(
+      screen.getByText(
+        'Average of 3 completed focus sessions, rounded to the nearest minute.',
+      ),
+    ).toBeTruthy()
+  })
+
+  it('says how many more sessions are needed rather than averaging one', () => {
+    mount(detailEndeavorMocks.taskWithOneSession)
+
+    expect(screen.queryByTestId('observed-average')).toBeNull()
+    expect(
+      screen.getByText(
+        'Complete at least 3 focus sessions to unlock an empirical recommendation.',
+      ),
+    ).toBeTruthy()
+  })
+
+  it('offers no control on that card at all — the observation is never authored', () => {
+    mount(detailEndeavorMocks.taskWithSessions)
+
+    // Every control on the screen belongs to one of the three BOUNDS.
+    for (const checkbox of screen.getAllByRole('checkbox')) {
+      expect(checkbox.dataset.durationToggle).toBeDefined()
+    }
+  })
+})
+
+describe('the three bounds', () => {
+  it('offers a switch per bound, in canon\'s order', () => {
+    mount(detailEndeavorMocks.taskWithSessions)
+
+    expect(
+      screen.getAllByRole('checkbox').map((box) => box.dataset.durationToggle),
+    ).toEqual(['preferred', 'minimum', 'maximum'])
+  })
+
+  it('shows a dial only for the bounds the user has enabled', () => {
+    mount(detailEndeavorMocks.taskWithSessions, {
+      draft: {
+        ...durationDraftFor(detailEndeavorMocks.taskWithSessions),
+        isPreferredEnabled: true,
+      },
+    })
+
+    expect(screen.getAllByRole('slider')).toHaveLength(1)
+    expect(
+      screen.getByRole('slider', { name: 'Preferred duration' }),
+    ).toBeTruthy()
+  })
+
+  it('reports a switch flip as an explicit act on that bound', async () => {
+    const onToggleBound = vi.fn()
+    mount(detailEndeavorMocks.taskWithSessions, { onToggleBound })
+
+    const minimum = screen
+      .getAllByRole('checkbox')
+      .find((box) => box.dataset.durationToggle === 'minimum')
+    if (minimum === undefined) throw new Error('no minimum toggle')
+    await userEvent.click(minimum)
+
+    expect(onToggleBound).toHaveBeenCalledWith('minimum', true)
+  })
+
+  it('reports a dial adjustment in seconds, keyboard included', async () => {
+    const onAdjustBound = vi.fn()
+    mount(detailEndeavorMocks.taskWithSessions, {
+      draft: {
+        ...durationDraftFor(detailEndeavorMocks.taskWithSessions),
+        isPreferredEnabled: true,
+      },
+      onAdjustBound,
+    })
+
+    screen.getByRole('slider', { name: 'Preferred duration' }).focus()
+    await userEvent.keyboard('{ArrowRight}')
+
+    expect(onAdjustBound).toHaveBeenCalledWith('preferred', expect.any(Number))
+  })
+})
+
+describe('validation', () => {
+  it('says a minimum above a maximum is incoherent, in canon\'s words', () => {
+    mount(detailEndeavorMocks.taskWithSessions, {
+      draft: {
+        ...durationDraftFor(detailEndeavorMocks.taskWithSessions),
+        isMinimumEnabled: true,
+        isMaximumEnabled: true,
+        minimumSeconds: 3600,
+        maximumSeconds: 1200,
+      },
+    })
+
+    expect(
+      screen.getByText('Minimum duration must not exceed maximum duration.'),
+    ).toBeTruthy()
+  })
+
+  it('says nothing when the profile is coherent', () => {
+    mount(detailEndeavorMocks.taskWithSessions)
+
+    expect(
+      screen.queryByText('Minimum duration must not exceed maximum duration.'),
+    ).toBeNull()
+  })
+
+  it('makes the dials read-only while a save is in flight', () => {
+    mount(detailEndeavorMocks.taskWithSessions, {
+      draft: {
+        ...durationDraftFor(detailEndeavorMocks.taskWithSessions),
+        isPreferredEnabled: true,
+      },
+      isSaving: true,
+    })
+
+    expect(
+      screen
+        .getByRole('slider', { name: 'Preferred duration' })
+        .getAttribute('aria-readonly'),
+    ).toBe('true')
+  })
+})

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorDurationFragment.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorDurationFragment.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+/**
+ * The Duration profile — the port of
+ * `Kro/Application/EndeavorDetail/EndeavorDurationView.swift` (`RC-15`).
+ *
+ * Three optional bounds the user authors, over one number the app **observes**.
+ * Canon's order, kept: the observed card first (so the recommendation is read
+ * before a preference is set against it), then the validation message, then
+ * Preferred, Minimum, Maximum.
+ *
+ * ## The observed card is read-only, and that is the whole point
+ *
+ * `#29`'s `EndeavorDuration` header states canon's reason verbatim: the
+ * empirical history *prefills* the drafts, and enabling a bound is an explicit
+ * act, so the observation is never written back. Nothing in this Fragment can
+ * write it — there is no control on that card at all, and below the sample
+ * minimum it says how many sessions are still needed rather than averaging one
+ * data point.
+ *
+ * ## The dial is the chrome kit's, at canon's own geometry
+ *
+ * `DurationDial` is a real `role="slider"` with arrow-key stepping, so the
+ * three bounds are keyboard-operable without a second numeric field beside each
+ * one. Its `maxSeconds` is raised past the kit's 60-minute session default,
+ * because a *task's* preferred duration is not a focus session's and canon's
+ * bounds are unbounded above.
+ */
+import type { TimeIntervalSeconds } from '@kro/core'
+import { InlineBanner } from '../../../design/endeavor/InlineBanner'
+import { SectionCard } from '../../../design/endeavor/SurfaceCard'
+import { formatDuration } from '../../../design/endeavor/formatting'
+import { DurationDial } from '../../../design/chrome/dial/DurationDial'
+import { colorVar } from '../../../design/system/tokens/roles'
+import type { DurationBound, EndeavorDurationDraft, ObservedFocusTime } from '../EndeavorDuration'
+import { HIDDEN_SCROLLBAR_STYLE } from './EndeavorDetailFragment'
+
+/** Four hours. A preferred duration is not capped at one focus session. */
+export const DURATION_MAX_SECONDS = 4 * 60 * 60
+
+interface BoundRow {
+  readonly bound: DurationBound
+  readonly title: string
+  readonly explanation: string
+  readonly seconds: TimeIntervalSeconds
+  readonly isEnabled: boolean
+}
+
+export interface EndeavorDurationFragmentProps {
+  readonly draft: EndeavorDurationDraft
+  readonly observed: ObservedFocusTime
+  /** Canon's `validationMessage` — `null` when the profile is coherent. */
+  readonly validationMessage: string | null
+  readonly isSaving: boolean
+  readonly onToggleBound: (bound: DurationBound, isEnabled: boolean) => void
+  readonly onAdjustBound: (bound: DurationBound, seconds: number) => void
+}
+
+export function EndeavorDurationFragment({
+  draft,
+  observed,
+  validationMessage,
+  isSaving,
+  onToggleBound,
+  onAdjustBound,
+}: EndeavorDurationFragmentProps) {
+  const rows: readonly BoundRow[] = [
+    {
+      bound: 'preferred',
+      title: 'Preferred duration',
+      explanation: 'Used before the empirical recommendation.',
+      seconds: draft.preferredSeconds,
+      isEnabled: draft.isPreferredEnabled,
+    },
+    {
+      bound: 'minimum',
+      title: 'Minimum duration',
+      explanation: 'Optional lower bound for the empirical average.',
+      seconds: draft.minimumSeconds,
+      isEnabled: draft.isMinimumEnabled,
+    },
+    {
+      bound: 'maximum',
+      title: 'Maximum duration',
+      explanation: 'Optional upper bound for the empirical average.',
+      seconds: draft.maximumSeconds,
+      isEnabled: draft.isMaximumEnabled,
+    },
+  ]
+
+  return (
+    <div
+      data-testid="endeavor-duration"
+      className="flex min-h-0 flex-1 flex-col gap-kro-large overflow-y-auto pb-kro-x-large [&>*]:shrink-0 [&::-webkit-scrollbar]:hidden"
+      style={HIDDEN_SCROLLBAR_STYLE}
+    >
+      <SectionCard title="Observed focus time" icon="clock.arrow.circlepath">
+        {observed.seconds === null ? (
+          <p
+            data-testid="observed-locked"
+            className="m-0 text-sm"
+            style={{ color: colorVar('foreSecondary') }}
+          >
+            {`Complete at least ${observed.requiredSampleCount} focus sessions to unlock an empirical recommendation.`}
+          </p>
+        ) : (
+          <div className="flex flex-col gap-kro-small">
+            <p
+              data-testid="observed-average"
+              className="m-0 font-semibold text-xl"
+              style={{ color: colorVar('fore') }}
+            >
+              {formatDuration(observed.seconds)}
+            </p>
+            <p className="m-0 text-sm" style={{ color: colorVar('foreSecondary') }}>
+              {`Average of ${observed.sampleCount} completed focus sessions, rounded to the nearest minute.`}
+            </p>
+          </div>
+        )}
+      </SectionCard>
+
+      {validationMessage === null ? null : (
+        <InlineBanner kind="warning" message={validationMessage} />
+      )}
+
+      {rows.map((row) => (
+        <SectionCard key={row.bound} title={row.title} icon="timer">
+          <div className="flex flex-col gap-kro-medium">
+            <label
+              className="flex items-center gap-kro-small text-sm"
+              style={{ color: colorVar('fore') }}
+            >
+              <input
+                type="checkbox"
+                checked={row.isEnabled}
+                disabled={isSaving}
+                data-duration-toggle={row.bound}
+                onChange={(event) =>
+                  onToggleBound(row.bound, event.target.checked)
+                }
+                className="size-5 accent-[var(--kro-color-accent)]"
+              />
+              {`Use ${row.title.toLowerCase()}`}
+            </label>
+
+            <p className="m-0 text-sm" style={{ color: colorVar('foreSecondary') }}>
+              {row.explanation}
+            </p>
+
+            {row.isEnabled ? (
+              <DurationDial
+                seconds={row.seconds}
+                maxSeconds={DURATION_MAX_SECONDS}
+                diameter={148}
+                label={row.title}
+                readOnly={isSaving}
+                onChange={(seconds) => onAdjustBound(row.bound, seconds)}
+              />
+            ) : null}
+          </div>
+        </SectionCard>
+      ))}
+    </div>
+  )
+}

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorEditFragment.stories.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorEditFragment.stories.tsx
@@ -1,0 +1,108 @@
+/**
+ * The Edit form's visual evidence (`RC-11`, `UZF-26`).
+ *
+ * The scene that matters most is `MetaKindFewerFields`: the same form over a
+ * kind whose matrix removes Start, Duration and Reward, so the *absence* is
+ * visible side by side with the task's full set.
+ */
+import { makeProject } from '@kro/core'
+import { BothSchemes, Stage } from '../../../design/endeavor/storyStage'
+import { editableSections } from '../EndeavorDetailEditing'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import { EndeavorDetailExceptions } from '../EndeavorDetailException'
+import { EndeavorEditFragment } from './EndeavorEditFragment'
+
+const noop = () => {}
+
+const projects = [
+  makeProject({ id: 'proj-1', title: 'Household' }),
+  makeProject({ id: 'proj-2', title: 'Work' }),
+]
+
+const scene = (
+  endeavor: (typeof detailEndeavorMocks)[keyof typeof detailEndeavorMocks],
+) => ({
+  working: endeavor,
+  sections: editableSections(endeavor.kind),
+  isValid: endeavor.title.trim().length > 0,
+  isSaving: false,
+  exception: null,
+  projects,
+  onChangeField: noop,
+  onOpenDuration: noop,
+})
+
+export default {
+  title: 'Endeavor Detail/Edit',
+  component: EndeavorEditFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+/** A task: every editable field the matrix allows. */
+export const TypicalTask = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorEditFragment {...scene(detailEndeavorMocks.task)} />
+    </Stage>
+  ),
+}
+
+/** A blueprint: Start, Duration and Reward are ABSENT, not disabled. */
+export const MetaKindFewerFields = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorEditFragment {...scene(detailEndeavorMocks.blueprint)} />
+    </Stage>
+  ),
+}
+
+/** A calendar event: no Due row for this kind. */
+export const CalendarEvent = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorEditFragment {...scene(detailEndeavorMocks.event)} />
+    </Stage>
+  ),
+}
+
+/** A blank title — the one v1 validation rule, stated rather than implied. */
+export const InvalidTitle = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorEditFragment
+        {...scene(detailEndeavorMocks.untitled)}
+        isValid={false}
+      />
+    </Stage>
+  ),
+}
+
+/** A save in flight: every control disabled so a double-tap cannot race it. */
+export const Saving = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorEditFragment {...scene(detailEndeavorMocks.task)} isSaving />
+    </Stage>
+  ),
+}
+
+/** A save that failed — the working copy is untouched and still dirty. */
+export const SaveFailed = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorEditFragment
+        {...scene(detailEndeavorMocks.task)}
+        exception={EndeavorDetailExceptions.localPersistenceFailed('disk full')}
+      />
+    </Stage>
+  ),
+}
+
+/** Both schemes, so the fields and pickers are judged in dark too. */
+export const BothColorSchemes = {
+  render: () => (
+    <BothSchemes>
+      <EndeavorEditFragment {...scene(detailEndeavorMocks.habit)} />
+    </BothSchemes>
+  ),
+}

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorEditFragment.test.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorEditFragment.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * The Edit form's render tests, mirroring its stories (`RC-11`).
+ *
+ * The acceptance criterion this file exists for is the matrix one: a field the
+ * domain marks non-editable for a kind is ABSENT from the form, so a change the
+ * domain would silently refuse cannot even be expressed.
+ */
+import {
+  EndeavorKind,
+  endeavorFields,
+  isFieldEditable,
+  makeProject,
+} from '@kro/core'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { editableSections } from '../EndeavorDetailEditing'
+import { EndeavorDetailExceptions } from '../EndeavorDetailException'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import { fieldLabel } from './endeavorDetailDisplay'
+import { EndeavorEditFragment } from './EndeavorEditFragment'
+
+afterEach(cleanup)
+
+const projects = [
+  makeProject({ id: 'proj-1', title: 'Household' }),
+  makeProject({ id: 'proj-2', title: 'Work' }),
+]
+
+type Mock = (typeof detailEndeavorMocks)[keyof typeof detailEndeavorMocks]
+
+const mount = (
+  endeavor: Mock,
+  overrides: {
+    isSaving?: boolean
+    isValid?: boolean
+    exception?: ReturnType<typeof EndeavorDetailExceptions.localPersistenceFailed> | null
+    onChangeField?: (change: unknown) => void
+    onOpenDuration?: () => void
+  } = {},
+) =>
+  render(
+    <EndeavorEditFragment
+      working={endeavor}
+      sections={editableSections(endeavor.kind)}
+      isValid={overrides.isValid ?? endeavor.title.trim().length > 0}
+      isSaving={overrides.isSaving ?? false}
+      exception={overrides.exception ?? null}
+      projects={projects}
+      onChangeField={overrides.onChangeField ?? (() => {})}
+      onOpenDuration={overrides.onOpenDuration ?? (() => {})}
+    />,
+  )
+
+describe('the form is the matrix, rendered', () => {
+  it('offers exactly the fields the matrix marks editable for a task', () => {
+    mount(detailEndeavorMocks.task)
+
+    for (const field of endeavorFields) {
+      const label = fieldLabel(field)
+      const isPresent =
+        screen.queryAllByText(label, { exact: true }).length > 0 ||
+        screen.queryAllByLabelText(label).length > 0
+      expect({ field, isPresent }).toEqual({
+        field,
+        isPresent: isFieldEditable(field, EndeavorKind.task),
+      })
+    }
+  })
+
+  it('drops Start, Duration and Reward for a meta kind rather than disabling them', () => {
+    mount(detailEndeavorMocks.blueprint)
+
+    expect(screen.queryByLabelText('Start')).toBeNull()
+    expect(screen.queryByText('Duration')).toBeNull()
+    expect(screen.queryByLabelText('Reward')).toBeNull()
+    expect(screen.getByLabelText('Title')).toBeTruthy()
+  })
+
+  it('drops the Due row for a calendar event, whose due date the matrix denies', () => {
+    mount(detailEndeavorMocks.event)
+
+    expect(screen.queryByLabelText('Due')).toBeNull()
+    expect(screen.getByLabelText('Start')).toBeTruthy()
+  })
+})
+
+describe('editing reports one change at a time', () => {
+  it('reports a title edit as the domain\'s own field change', async () => {
+    const onChangeField = vi.fn()
+    mount(detailEndeavorMocks.task, { onChangeField })
+
+    await userEvent.type(screen.getByLabelText('Title'), '!')
+
+    expect(onChangeField).toHaveBeenLastCalledWith({
+      field: 'title',
+      value: `${detailEndeavorMocks.task.title}!`,
+    })
+  })
+
+  it('reports a status pick, not a status index', async () => {
+    const onChangeField = vi.fn()
+    mount(detailEndeavorMocks.task, { onChangeField })
+
+    await userEvent.selectOptions(screen.getByLabelText('Status'), 'blocked')
+
+    expect(onChangeField).toHaveBeenCalledWith({
+      field: 'status',
+      value: 'blocked',
+    })
+  })
+
+  it('toggles a tag by its own letter — canon\'s `applyTagToggled`', async () => {
+    const onChangeField = vi.fn()
+    mount(detailEndeavorMocks.task, { onChangeField })
+
+    await userEvent.click(screen.getByRole('button', { name: /Engaging/ }))
+
+    expect(onChangeField).toHaveBeenCalledWith({
+      field: 'tagToggled',
+      value: 'E',
+    })
+  })
+
+  it('assigns a project by picking a list, and clears it back to none', async () => {
+    const onChangeField = vi.fn()
+    mount(detailEndeavorMocks.task, { onChangeField })
+
+    await userEvent.selectOptions(screen.getByLabelText('Project'), 'proj-2')
+    expect(onChangeField).toHaveBeenCalledWith({
+      field: 'project',
+      value: projects[1],
+    })
+
+    await userEvent.selectOptions(screen.getByLabelText('Project'), '')
+    expect(onChangeField).toHaveBeenCalledWith({ field: 'project', value: null })
+  })
+
+  it('hands the duration profile to its own screen rather than editing one number', async () => {
+    const onOpenDuration = vi.fn()
+    mount(detailEndeavorMocks.task, { onOpenDuration })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit profile' }))
+
+    expect(onOpenDuration).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('recurrence', () => {
+  it('starts at "Does not repeat" and builds a whole config when a base is picked', async () => {
+    const onChangeField = vi.fn()
+    mount(detailEndeavorMocks.task, { onChangeField })
+
+    await userEvent.selectOptions(screen.getByLabelText('Repeats'), 'weekly')
+
+    expect(onChangeField).toHaveBeenCalledWith({
+      field: 'repeatConfig',
+      value: { base: { type: 'weekly', weekdays: [] }, everyOther: 1 },
+    })
+  })
+
+  it('clears the whole rule when the user picks "Does not repeat"', async () => {
+    const onChangeField = vi.fn()
+    const repeating = {
+      ...detailEndeavorMocks.task,
+      repeatConfig: { base: { type: 'daily' as const }, everyOther: 1 },
+    }
+    mount(repeating, { onChangeField })
+
+    await userEvent.selectOptions(screen.getByLabelText('Repeats'), '')
+
+    expect(onChangeField).toHaveBeenCalledWith({
+      field: 'repeatConfig',
+      value: null,
+    })
+  })
+
+  it('offers the weekday toggles only for a weekly rule', () => {
+    const weekly = {
+      ...detailEndeavorMocks.task,
+      repeatConfig: {
+        base: { type: 'weekly' as const, weekdays: ['monday' as const] },
+        everyOther: 1,
+      },
+    }
+    mount(weekly)
+
+    expect(screen.getByRole('button', { name: 'Mon' })).toBeTruthy()
+    expect(screen.getByText('Weekly on Mon')).toBeTruthy()
+  })
+})
+
+describe('validity and in-flight saves', () => {
+  it('says what blocks the save rather than only greying the control', () => {
+    mount(detailEndeavorMocks.untitled, { isValid: false })
+
+    expect(
+      screen.getByText('Give this endeavor a title before saving.'),
+    ).toBeTruthy()
+  })
+
+  it('disables every control while a save is in flight', () => {
+    mount(detailEndeavorMocks.task, { isSaving: true })
+
+    expect(screen.getByLabelText('Title').hasAttribute('disabled')).toBe(true)
+    expect(screen.getByLabelText('Status').hasAttribute('disabled')).toBe(true)
+  })
+
+  it('surfaces the failure that left the working copy dirty', () => {
+    mount(detailEndeavorMocks.task, {
+      exception: EndeavorDetailExceptions.localPersistenceFailed('disk full'),
+    })
+
+    expect(
+      screen.getByText("Couldn't save your changes: disk full"),
+    ).toBeTruthy()
+  })
+})

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorEditFragment.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorEditFragment.tsx
@@ -1,0 +1,731 @@
+'use client'
+
+/**
+ * The Edit form — canon's `EndeavorEditView`, rendered from the **matrix** and
+ * nothing else (`RC-15`).
+ *
+ * ## Acceptance criterion, structurally
+ *
+ * `#29`'s `EndeavorDetailEditing` header states the contract this Fragment is
+ * the second half of: *"the surface can tell in advance"* — `editableSections`
+ * derives the per-kind field set from `EndeavorFieldRelevance`, so a field the
+ * matrix forbids is **absent** rather than offered and silently dropped. This
+ * file therefore contains no per-kind `if` at all: it maps the sections it was
+ * given. A calendar event's form has no Due row because the matrix says so, and
+ * the only way to change that is to change the matrix.
+ *
+ * Every control is additionally **disabled while a save is in flight**, which
+ * is canon's own rule on every relation screen (`isSaving` disables the form so
+ * a double-tap cannot race the write).
+ *
+ * ## Duration is a link, not a field
+ *
+ * Canon gives the three duration bounds their own screen
+ * (`EndeavorDurationFeature`, which embeds this very edit state and reports one
+ * `durationProfile` change). So the Duration row here opens that screen rather
+ * than editing a single number — which is also what keeps the minimum/maximum
+ * invariant in one place instead of three loose inputs.
+ */
+import {
+  type AnyEndeavorList,
+  type Endeavor,
+  EndeavorField,
+  type EndeavorTag,
+  type Month,
+  type RepeatBaseType,
+  type WeekDay,
+  assertNever,
+  endeavorStatusDisplayName,
+  endeavorStatuses,
+  endeavorTags,
+  monthsOfYear,
+  weekDays,
+} from '@kro/core'
+import { InlineBanner } from '../../../design/endeavor/InlineBanner'
+import { KroChip, semanticTint } from '../../../design/endeavor/KroChip'
+import { SectionCard } from '../../../design/endeavor/SurfaceCard'
+import { localInputValue, parseLocalInput } from '../../../design/endeavor/endeavorPopovers'
+import { Input } from '../../../design/system/primitives/input'
+import { colorVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import type { EndeavorDetailSectionModel } from '../EndeavorDetailEditing'
+import type { EndeavorFieldChange } from '../EndeavorDetailEditing'
+import type { EndeavorDetailException } from '../EndeavorDetailException'
+import { formatDuration } from '../../../design/endeavor/formatting'
+import {
+  WEEKDAY_SHORT,
+  fieldLabel,
+  repeatSummary,
+  tagLabel,
+} from './endeavorDetailDisplay'
+import { HIDDEN_SCROLLBAR_STYLE } from './EndeavorDetailFragment'
+
+export interface EndeavorEditFragmentProps {
+  /** The editor's working copy — never the saved endeavor. */
+  readonly working: Endeavor
+  /** Only the sections with at least one **editable** field for this kind. */
+  readonly sections: readonly EndeavorDetailSectionModel[]
+  /** Canon's `isTitleValidSelector` — the one v1 validation rule. */
+  readonly isValid: boolean
+  readonly isSaving: boolean
+  readonly exception: EndeavorDetailException | null
+  /** The lists a project can be assigned to. Empty is a valid state. */
+  readonly projects: readonly AnyEndeavorList[]
+  readonly onChangeField: (change: EndeavorFieldChange) => void
+  /** Opens the three-bound duration profile — canon's own child screen. */
+  readonly onOpenDuration: () => void
+}
+
+export function EndeavorEditFragment({
+  working,
+  sections,
+  isValid,
+  isSaving,
+  exception,
+  projects,
+  onChangeField,
+  onOpenDuration,
+}: EndeavorEditFragmentProps) {
+  return (
+    <div
+      data-testid="endeavor-edit"
+      className="flex min-h-0 flex-1 flex-col gap-kro-large overflow-y-auto pb-kro-x-large [&>*]:shrink-0 [&::-webkit-scrollbar]:hidden"
+      style={HIDDEN_SCROLLBAR_STYLE}
+    >
+      {exception === null ? null : <InlineBanner message={exception.message} />}
+
+      {isValid ? null : (
+        <InlineBanner
+          kind="warning"
+          message="Give this endeavor a title before saving."
+        />
+      )}
+
+      {sections.map((section) => (
+        <SectionCard key={section.section} title={section.title}>
+          <div className="flex flex-col gap-kro-medium">
+            {section.fields.map((field) => (
+              <EditField
+                key={field}
+                field={field}
+                working={working}
+                isSaving={isSaving}
+                projects={projects}
+                onChangeField={onChangeField}
+                onOpenDuration={onOpenDuration}
+              />
+            ))}
+          </div>
+        </SectionCard>
+      ))}
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* One field                                                                 */
+/* ------------------------------------------------------------------------ */
+
+function EditField({
+  field,
+  working,
+  isSaving,
+  projects,
+  onChangeField,
+  onOpenDuration,
+}: {
+  readonly field: EndeavorField
+  readonly working: Endeavor
+  readonly isSaving: boolean
+  readonly projects: readonly AnyEndeavorList[]
+  readonly onChangeField: (change: EndeavorFieldChange) => void
+  readonly onOpenDuration: () => void
+}) {
+  const label = fieldLabel(field)
+
+  switch (field) {
+    case EndeavorField.title:
+      return (
+        <Labelled label={label} htmlFor={`edit-${field}`}>
+          <Input
+            id={`edit-${field}`}
+            value={working.title}
+            disabled={isSaving}
+            onChange={(event) =>
+              onChangeField({ field: 'title', value: event.target.value })
+            }
+          />
+        </Labelled>
+      )
+
+    case EndeavorField.status:
+      return (
+        <Labelled label={label} htmlFor={`edit-${field}`}>
+          <Select
+            id={`edit-${field}`}
+            value={working.status}
+            disabled={isSaving}
+            onChange={(value) =>
+              onChangeField({
+                field: 'status',
+                value: value as Endeavor['status'],
+              })
+            }
+            options={endeavorStatuses.map((status) => ({
+              value: status,
+              label: endeavorStatusDisplayName(status),
+            }))}
+          />
+        </Labelled>
+      )
+
+    case EndeavorField.due:
+    case EndeavorField.start:
+    case EndeavorField.expiry:
+      return (
+        <Labelled label={label} htmlFor={`edit-${field}`}>
+          <Input
+            id={`edit-${field}`}
+            type="datetime-local"
+            disabled={isSaving}
+            value={dateInputValue(working, field)}
+            onChange={(event) =>
+              onChangeField({
+                field,
+                value: parseLocalInput(event.target.value),
+              })
+            }
+          />
+        </Labelled>
+      )
+
+    case EndeavorField.duration:
+      return (
+        <div className="flex items-center gap-kro-small">
+          <span className="flex-1 text-sm" style={{ color: colorVar('foreSecondary') }}>
+            {label}
+          </span>
+          <span className="text-sm font-semibold" style={{ color: colorVar('fore') }}>
+            {working.duration === null ? 'Not set' : formatDuration(working.duration)}
+          </span>
+          <button
+            type="button"
+            disabled={isSaving}
+            onClick={onOpenDuration}
+            className="rounded-kro-small px-kro-small text-sm font-semibold outline-none focus-visible:shadow-[var(--kro-ring)] disabled:opacity-[var(--kro-opacity-disabled)]"
+            style={{
+              color: colorVar('accent'),
+              minHeight: 'var(--kro-size-min-touch-target)',
+            }}
+          >
+            Edit profile
+          </button>
+        </div>
+      )
+
+    case EndeavorField.sessionPoints:
+      return (
+        <NumberField
+          id={`edit-${field}`}
+          label={label}
+          value={working.sessionPoints}
+          min={0}
+          max={999}
+          step={5}
+          disabled={isSaving}
+          onChange={(value) => onChangeField({ field: 'sessionPoints', value })}
+        />
+      )
+
+    case EndeavorField.value:
+      return (
+        <NumberField
+          id={`edit-${field}`}
+          label={label}
+          value={working.value}
+          min={1}
+          max={5}
+          step={1}
+          disabled={isSaving}
+          onChange={(value) => onChangeField({ field: 'value', value })}
+        />
+      )
+
+    case EndeavorField.effort:
+      return (
+        <NumberField
+          id={`edit-${field}`}
+          label={label}
+          value={working.effort}
+          min={1}
+          max={5}
+          step={1}
+          disabled={isSaving}
+          onChange={(value) => onChangeField({ field: 'effort', value })}
+        />
+      )
+
+    case EndeavorField.tags:
+      return (
+        <fieldset className="m-0 border-0 p-0">
+          <legend
+            className="mb-kro-tiny p-0 text-sm"
+            style={{ color: colorVar('foreSecondary') }}
+          >
+            {label}
+          </legend>
+          <div className="flex flex-wrap gap-kro-small">
+            {endeavorTags.map((tag) => {
+              const isOn = (working.tags ?? []).includes(tag)
+              return (
+                <button
+                  key={tag}
+                  type="button"
+                  aria-pressed={isOn}
+                  disabled={isSaving}
+                  data-edit-tag={tag}
+                  onClick={() =>
+                    onChangeField({ field: 'tagToggled', value: tag as EndeavorTag })
+                  }
+                  className="inline-flex items-center rounded-kro-pill outline-none focus-visible:shadow-[var(--kro-ring)] disabled:opacity-[var(--kro-opacity-disabled)]"
+                  style={{ minHeight: 'var(--kro-size-min-touch-target)' }}
+                >
+                  <KroChip
+                    title={tagLabel(tag)}
+                    icon="tag"
+                    tint={semanticTint('chipNeutral')}
+                    emphasis={isOn ? 'prominent' : 'outline'}
+                    size="small"
+                  />
+                </button>
+              )
+            })}
+          </div>
+        </fieldset>
+      )
+
+    case EndeavorField.associatedColor:
+      return (
+        <Labelled label={label} htmlFor={`edit-${field}`}>
+          <div className="flex items-center gap-kro-small">
+            <input
+              id={`edit-${field}`}
+              type="color"
+              disabled={isSaving}
+              value={working.associatedColor ?? '#4f46e5'}
+              onChange={(event) =>
+                onChangeField({
+                  field: 'associatedColor',
+                  value: event.target.value,
+                })
+              }
+              className="size-11 cursor-pointer rounded-kro-small border-0 bg-transparent p-0"
+            />
+            <button
+              type="button"
+              disabled={isSaving || working.associatedColor === null}
+              onClick={() =>
+                onChangeField({ field: 'associatedColor', value: null })
+              }
+              className="rounded-kro-small px-kro-small text-sm outline-none focus-visible:shadow-[var(--kro-ring)] disabled:opacity-[var(--kro-opacity-disabled)]"
+              style={{
+                color: colorVar('foreSecondary'),
+                minHeight: 'var(--kro-size-min-touch-target)',
+              }}
+            >
+              Clear
+            </button>
+          </div>
+        </Labelled>
+      )
+
+    case EndeavorField.project:
+      return (
+        <Labelled label={label} htmlFor={`edit-${field}`}>
+          <Select
+            id={`edit-${field}`}
+            value={working.list?.id ?? ''}
+            disabled={isSaving}
+            onChange={(value) =>
+              onChangeField({
+                field: 'project',
+                value: projects.find((list) => list.id === value) ?? null,
+              })
+            }
+            options={[
+              { value: '', label: 'No project' },
+              ...projects.map((list) => ({ value: list.id, label: list.title })),
+            ]}
+          />
+        </Labelled>
+      )
+
+    case EndeavorField.repeatConfig:
+      return (
+        <RepeatField
+          working={working}
+          isSaving={isSaving}
+          onChangeField={onChangeField}
+        />
+      )
+
+    default:
+      return assertNever(field)
+  }
+}
+
+/** The three `Date | null` fields share one input, so they share one reader. */
+function dateInputValue(working: Endeavor, field: EndeavorField): string {
+  const date =
+    field === EndeavorField.due
+      ? working.due
+      : field === EndeavorField.start
+        ? working.start
+        : working.expiry
+  return date === null ? '' : localInputValue(date)
+}
+
+/* ------------------------------------------------------------------------ */
+/* Recurrence                                                                */
+/* ------------------------------------------------------------------------ */
+
+const REPEAT_OPTIONS: readonly {
+  readonly value: '' | RepeatBaseType
+  readonly label: string
+}[] = [
+  { value: '', label: 'Does not repeat' },
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'monthly', label: 'Monthly' },
+  { value: 'yearly', label: 'Yearly' },
+]
+
+/**
+ * The recurrence editor.
+ *
+ * Every change rebuilds the whole `RepeatConfig` and reports it as one
+ * `repeatConfig` change, because that is what the domain stores — a partial
+ * edit ("weekly, no weekdays yet") is a valid intermediate state of the FORM,
+ * never of the model, and `repeatSummary` prints "Weekly" for it.
+ */
+function RepeatField({
+  working,
+  isSaving,
+  onChangeField,
+}: {
+  readonly working: Endeavor
+  readonly isSaving: boolean
+  readonly onChangeField: (change: EndeavorFieldChange) => void
+}) {
+  const config = working.repeatConfig
+  const base = config?.base ?? null
+
+  const setBase = (value: string) => {
+    if (value === '') {
+      onChangeField({ field: 'repeatConfig', value: null })
+      return
+    }
+    const everyOther = config?.everyOther ?? 1
+    switch (value as RepeatBaseType) {
+      case 'daily':
+        onChangeField({
+          field: 'repeatConfig',
+          value: { base: { type: 'daily' }, everyOther },
+        })
+        return
+      case 'weekly':
+        onChangeField({
+          field: 'repeatConfig',
+          value: { base: { type: 'weekly', weekdays: [] }, everyOther },
+        })
+        return
+      case 'monthly':
+        onChangeField({
+          field: 'repeatConfig',
+          value: { base: { type: 'monthly', day: 1 }, everyOther },
+        })
+        return
+      default:
+        onChangeField({
+          field: 'repeatConfig',
+          value: { base: { type: 'yearly', day: 1, month: 1 }, everyOther },
+        })
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-kro-small">
+      <Labelled label={fieldLabel('repeatConfig')} htmlFor="edit-repeatConfig">
+        <Select
+          id="edit-repeatConfig"
+          value={base?.type ?? ''}
+          disabled={isSaving}
+          onChange={setBase}
+          options={REPEAT_OPTIONS.map((option) => ({
+            value: option.value,
+            label: option.label,
+          }))}
+        />
+      </Labelled>
+
+      {config === null || base === null ? null : (
+        <>
+          <NumberField
+            id="edit-repeat-every"
+            label="Every"
+            value={config.everyOther}
+            min={1}
+            max={99}
+            step={1}
+            disabled={isSaving}
+            onChange={(value) =>
+              onChangeField({
+                field: 'repeatConfig',
+                value: { base, everyOther: value ?? 1 },
+              })
+            }
+          />
+
+          {base.type === 'weekly' ? (
+            <fieldset className="m-0 border-0 p-0">
+              <legend
+                className="mb-kro-tiny p-0 text-sm"
+                style={{ color: colorVar('foreSecondary') }}
+              >
+                Weekdays
+              </legend>
+              <div className="flex flex-wrap gap-kro-small">
+                {weekDays.map((day: WeekDay) => {
+                  const isOn = base.weekdays.includes(day)
+                  return (
+                    <button
+                      key={day}
+                      type="button"
+                      aria-pressed={isOn}
+                      disabled={isSaving}
+                      data-repeat-weekday={day}
+                      onClick={() =>
+                        onChangeField({
+                          field: 'repeatConfig',
+                          value: {
+                            base: {
+                              type: 'weekly',
+                              weekdays: isOn
+                                ? base.weekdays.filter((each) => each !== day)
+                                : [...base.weekdays, day],
+                            },
+                            everyOther: config.everyOther,
+                          },
+                        })
+                      }
+                      className="inline-flex items-center rounded-kro-pill outline-none focus-visible:shadow-[var(--kro-ring)] disabled:opacity-[var(--kro-opacity-disabled)]"
+                      style={{ minHeight: 'var(--kro-size-min-touch-target)' }}
+                    >
+                      <KroChip
+                        title={WEEKDAY_SHORT[day]}
+                        tint={semanticTint('chipNeutral')}
+                        emphasis={isOn ? 'prominent' : 'outline'}
+                        size="small"
+                      />
+                    </button>
+                  )
+                })}
+              </div>
+            </fieldset>
+          ) : null}
+
+          {base.type === 'monthly' ? (
+            <NumberField
+              id="edit-repeat-day"
+              label="Day of month"
+              value={base.day}
+              min={1}
+              max={31}
+              step={1}
+              disabled={isSaving}
+              onChange={(value) =>
+                onChangeField({
+                  field: 'repeatConfig',
+                  value: {
+                    base: { type: 'monthly', day: value ?? 1 },
+                    everyOther: config.everyOther,
+                  },
+                })
+              }
+            />
+          ) : null}
+
+          {base.type === 'yearly' ? (
+            <div className="flex gap-kro-small">
+              <NumberField
+                id="edit-repeat-year-day"
+                label="Day"
+                value={base.day}
+                min={1}
+                max={31}
+                step={1}
+                disabled={isSaving}
+                onChange={(value) =>
+                  onChangeField({
+                    field: 'repeatConfig',
+                    value: {
+                      base: { type: 'yearly', day: value ?? 1, month: base.month },
+                      everyOther: config.everyOther,
+                    },
+                  })
+                }
+              />
+              <Labelled label="Month" htmlFor="edit-repeat-month">
+                <Select
+                  id="edit-repeat-month"
+                  value={String(base.month)}
+                  disabled={isSaving}
+                  onChange={(value) =>
+                    onChangeField({
+                      field: 'repeatConfig',
+                      value: {
+                        base: {
+                          type: 'yearly',
+                          day: base.day,
+                          month: Number(value) as Month,
+                        },
+                        everyOther: config.everyOther,
+                      },
+                    })
+                  }
+                  options={monthsOfYear.map((month) => ({
+                    value: String(month),
+                    label: MONTH_NAMES[month],
+                  }))}
+                />
+              </Labelled>
+            </div>
+          ) : null}
+
+          <p className="m-0 text-sm" style={{ color: colorVar('foreSecondary') }}>
+            {repeatSummary(config)}
+          </p>
+        </>
+      )}
+    </div>
+  )
+}
+
+const MONTH_NAMES: Readonly<Record<Month, string>> = {
+  1: 'January',
+  2: 'February',
+  3: 'March',
+  4: 'April',
+  5: 'May',
+  6: 'June',
+  7: 'July',
+  8: 'August',
+  9: 'September',
+  10: 'October',
+  11: 'November',
+  12: 'December',
+}
+
+/* ------------------------------------------------------------------------ */
+/* Small controls                                                            */
+/* ------------------------------------------------------------------------ */
+
+function Labelled({
+  label,
+  htmlFor,
+  children,
+}: {
+  readonly label: string
+  readonly htmlFor: string
+  readonly children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-kro-tiny">
+      <label
+        htmlFor={htmlFor}
+        className="text-sm"
+        style={{ color: colorVar('foreSecondary') }}
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  )
+}
+
+function Select({
+  id,
+  value,
+  options,
+  disabled,
+  onChange,
+}: {
+  readonly id: string
+  readonly value: string
+  readonly options: readonly { readonly value: string; readonly label: string }[]
+  readonly disabled: boolean
+  readonly onChange: (value: string) => void
+}) {
+  return (
+    <select
+      id={id}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+      className={cn(
+        'w-full rounded-kro-field px-kro-small text-sm outline-none',
+        'focus-visible:shadow-[var(--kro-ring)]',
+        'disabled:opacity-[var(--kro-opacity-disabled)]',
+      )}
+      style={{
+        backgroundColor: colorVar('backInner'),
+        color: colorVar('fore'),
+        minHeight: 'var(--kro-size-min-touch-target)',
+      }}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function NumberField({
+  id,
+  label,
+  value,
+  min,
+  max,
+  step,
+  disabled,
+  onChange,
+}: {
+  readonly id: string
+  readonly label: string
+  readonly value: number | null
+  readonly min: number
+  readonly max: number
+  readonly step: number
+  readonly disabled: boolean
+  readonly onChange: (value: number | null) => void
+}) {
+  return (
+    <Labelled label={label} htmlFor={id}>
+      <Input
+        id={id}
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        value={value === null ? '' : String(value)}
+        onChange={(event) => {
+          const raw = event.target.value
+          onChange(raw === '' ? null : Number(raw))
+        }}
+      />
+    </Labelled>
+  )
+}

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorRelationFragment.stories.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorRelationFragment.stories.tsx
@@ -1,0 +1,134 @@
+/**
+ * The four relation screens' visual evidence (`RC-11`, `UZF-26`).
+ *
+ * One scene per relation, plus the two that carry the copy discipline: a
+ * read-only Performances screen (the kind cannot record sessions, so the form
+ * is replaced by the reason) and a Hosts screen where every provider is listed
+ * with why it cannot be attached in this build.
+ */
+import { EndeavorRelation } from '@kro/core'
+import { BothSchemes, Stage } from '../../../design/endeavor/storyStage'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import {
+  attachedHostsOf,
+  hostAttachCandidatesOf,
+  relationEmptyState,
+  relationReadOnlyReason,
+} from '../EndeavorRelations'
+import { EndeavorRelationFragment } from './EndeavorRelationFragment'
+
+const NOW = new Date(2026, 5, 18, 9, 40)
+const noop = () => {}
+
+const scene = (
+  endeavor: (typeof detailEndeavorMocks)[keyof typeof detailEndeavorMocks],
+  relation: EndeavorRelation,
+) => ({
+  relation,
+  endeavor,
+  readOnlyReason: relationReadOnlyReason(relation, endeavor.kind),
+  emptyState: relationEmptyState(relation, endeavor.kind),
+  isSaving: false,
+  exception: null,
+  draft: null,
+  isDraftCommittable: false,
+  attachedHosts: attachedHostsOf(endeavor),
+  hostCandidates: hostAttachCandidatesOf(endeavor),
+  now: NOW,
+  locale: 'en-US',
+  onChangeDraft: noop,
+  onCommitDraft: noop,
+  onRemoveEntry: noop,
+  onAttachHost: noop,
+  onDetachHost: noop,
+})
+
+export default {
+  title: 'Endeavor Detail/Relations',
+  component: EndeavorRelationFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+/** Performances with three sessions logged, and the hand-log form below. */
+export const Performances = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorRelationFragment
+        {...scene(
+          detailEndeavorMocks.taskWithSessions,
+          EndeavorRelation.performances,
+        )}
+      />
+    </Stage>
+  ),
+}
+
+/** The same screen on a kind that cannot record sessions — read-only, with why. */
+export const PerformancesReadOnly = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorRelationFragment
+        {...scene(detailEndeavorMocks.event, EndeavorRelation.performances)}
+      />
+    </Stage>
+  ),
+}
+
+/** Defers: an audit history that is empty, and says the endeavor kept its dates. */
+export const Defers = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorRelationFragment
+        {...scene(detailEndeavorMocks.task, EndeavorRelation.defers)}
+      />
+    </Stage>
+  ),
+}
+
+/** Hosts: every candidate listed, each disabled with the reason beside it. */
+export const Hosts = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorRelationFragment
+        {...scene(detailEndeavorMocks.task, EndeavorRelation.hosts)}
+      />
+    </Stage>
+  ),
+}
+
+/** Shadows: one mirror from a calendar, with its source and kind as chips. */
+export const Shadows = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorRelationFragment
+        {...scene(detailEndeavorMocks.event, EndeavorRelation.shadows)}
+      />
+    </Stage>
+  ),
+}
+
+/** A relation write in flight: the list dims and the controls stop responding. */
+export const Saving = {
+  render: () => (
+    <Stage width={430}>
+      <EndeavorRelationFragment
+        {...scene(
+          detailEndeavorMocks.taskWithSessions,
+          EndeavorRelation.performances,
+        )}
+        isSaving
+      />
+    </Stage>
+  ),
+}
+
+/** Both schemes, so the rows, chips and forms are judged in dark too. */
+export const BothColorSchemes = {
+  render: () => (
+    <BothSchemes>
+      <EndeavorRelationFragment
+        {...scene(detailEndeavorMocks.task, EndeavorRelation.hosts)}
+      />
+    </BothSchemes>
+  ),
+}

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorRelationFragment.test.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorRelationFragment.test.tsx
@@ -1,0 +1,495 @@
+/**
+ * The relation screens' render tests, mirroring their stories (`RC-11`).
+ *
+ * The two claims this file exists for are the copy ones: a read-only relation
+ * says WHY instead of showing a form, and its empty state changes with it —
+ * "log one below by hand" is a lie on a surface that has no form.
+ */
+import { EndeavorKind, EndeavorRelation, PerformResolution } from '@kro/core'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { detailEndeavorMocks } from '../EndeavorDetailMocks'
+import { EndeavorDetailExceptions } from '../EndeavorDetailException'
+import {
+  type RelationDraft,
+  attachedHostsOf,
+  hostAttachCandidatesOf,
+  relationEmptyState,
+  relationReadOnlyReason,
+} from '../EndeavorRelations'
+import {
+  EndeavorRelationFragment,
+  relationEntryFromDraft,
+} from './EndeavorRelationFragment'
+
+afterEach(cleanup)
+
+const NOW = new Date(2026, 5, 18, 9, 40)
+type Mock = (typeof detailEndeavorMocks)[keyof typeof detailEndeavorMocks]
+
+const mount = (
+  endeavor: Mock,
+  relation: EndeavorRelation,
+  overrides: {
+    draft?: RelationDraft | null
+    isDraftCommittable?: boolean
+    isSaving?: boolean
+    exception?: ReturnType<typeof EndeavorDetailExceptions.relationSyncFailed> | null
+    onChangeDraft?: (draft: RelationDraft | null) => void
+    onCommitDraft?: () => void
+    onRemoveEntry?: (index: number) => void
+    onAttachHost?: (host: string) => void
+    onDetachHost?: (host: string) => void
+  } = {},
+) =>
+  render(
+    <EndeavorRelationFragment
+      relation={relation}
+      endeavor={endeavor}
+      readOnlyReason={relationReadOnlyReason(relation, endeavor.kind)}
+      emptyState={relationEmptyState(relation, endeavor.kind)}
+      isSaving={overrides.isSaving ?? false}
+      exception={overrides.exception ?? null}
+      draft={overrides.draft ?? null}
+      isDraftCommittable={overrides.isDraftCommittable ?? false}
+      attachedHosts={attachedHostsOf(endeavor)}
+      hostCandidates={hostAttachCandidatesOf(endeavor)}
+      now={NOW}
+      locale="en-US"
+      onChangeDraft={overrides.onChangeDraft ?? (() => {})}
+      onCommitDraft={overrides.onCommitDraft ?? (() => {})}
+      onRemoveEntry={overrides.onRemoveEntry ?? (() => {})}
+      onAttachHost={overrides.onAttachHost ?? (() => {})}
+      onDetachHost={overrides.onDetachHost ?? (() => {})}
+    />,
+  )
+
+describe('the shared layout', () => {
+  it('introduces every relation with its own title and subtitle', () => {
+    mount(detailEndeavorMocks.task, EndeavorRelation.defers)
+
+    expect(screen.getByRole('heading', { name: 'Defers' })).toBeTruthy()
+    expect(
+      screen.getByText("Every time this endeavor's due date was pushed back."),
+    ).toBeTruthy()
+  })
+
+  it('totals the performances log in its header rather than making you add rows up', () => {
+    mount(detailEndeavorMocks.taskWithSessions, EndeavorRelation.performances)
+
+    expect(screen.getByText('3 sessions')).toBeTruthy()
+  })
+
+  it('surfaces a relation write failure above the list', () => {
+    mount(detailEndeavorMocks.task, EndeavorRelation.defers, {
+      exception: EndeavorDetailExceptions.relationSyncFailed('offline'),
+    })
+
+    expect(screen.getByText("Couldn't save that entry: offline")).toBeTruthy()
+  })
+})
+
+describe('a read-only relation says WHY, and its empty state changes with it', () => {
+  it('replaces the add form with the kind\'s own reason', () => {
+    mount(detailEndeavorMocks.event, EndeavorRelation.performances)
+
+    expect(
+      screen.getByText("This endeavor's kind can't record sessions."),
+    ).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Add Performance' })).toBeNull()
+  })
+
+  it('says sessions WILL appear here, never "log one below by hand"', () => {
+    mount(detailEndeavorMocks.event, EndeavorRelation.performances)
+
+    expect(
+      screen.getByText(
+        'Sessions logged against this endeavor will appear here.',
+      ),
+    ).toBeTruthy()
+  })
+
+  it('invites the hand-log only where the form actually exists', () => {
+    mount(detailEndeavorMocks.task, EndeavorRelation.performances)
+
+    expect(
+      screen.getByText(
+        'Start a session on this endeavor, or log one below by hand.',
+      ),
+    ).toBeTruthy()
+  })
+
+  it('offers no remove control on a read-only list that still has rows', () => {
+    // Rows can outlive editability: a mirrored item resolves to a kind whose
+    // matrix forbids recording sessions, and the three it already carries do
+    // not vanish. They render — and offer nothing.
+    mount(
+      {
+        ...detailEndeavorMocks.event,
+        performances: detailEndeavorMocks.taskWithSessions.performances,
+      },
+      EndeavorRelation.performances,
+    )
+
+    expect(screen.getByText('3 sessions')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /^Remove performance/ })).toBeNull()
+  })
+})
+
+describe('the add forms', () => {
+  it('keeps the submit disabled until the draft says enough', () => {
+    mount(detailEndeavorMocks.task, EndeavorRelation.performances)
+
+    expect(
+      screen
+        .getByRole('button', { name: 'Add Performance' })
+        .hasAttribute('disabled'),
+    ).toBe(true)
+  })
+
+  it('reports every field edit as a whole draft, so the reducer sees one shape', async () => {
+    const onChangeDraft = vi.fn()
+    mount(detailEndeavorMocks.task, EndeavorRelation.defers, { onChangeDraft })
+
+    await userEvent.type(screen.getByLabelText('Reason (optional)'), 'x')
+
+    expect(onChangeDraft).toHaveBeenLastCalledWith({
+      relation: 'defers',
+      draft: { target: NOW, reason: 'x' },
+    })
+  })
+
+  it('commits a committable draft on submit', async () => {
+    const onCommitDraft = vi.fn()
+    mount(detailEndeavorMocks.task, EndeavorRelation.defers, {
+      draft: { relation: 'defers', draft: { target: NOW, reason: '' } },
+      isDraftCommittable: true,
+      onCommitDraft,
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add Defer' }))
+
+    expect(onCommitDraft).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes an entry by its position, which is its identity here', async () => {
+    const onRemoveEntry = vi.fn()
+    mount(detailEndeavorMocks.taskWithSessions, EndeavorRelation.performances, {
+      onRemoveEntry,
+    })
+
+    const removes = screen.getAllByRole('button', { name: /^Remove performance/ })
+    await userEvent.click(removes[0] as HTMLElement)
+
+    expect(onRemoveEntry).toHaveBeenCalledWith(0)
+  })
+})
+
+describe('hosts cannot be attached in this build, and the screen says so', () => {
+  it('lists every candidate rather than hiding the gap', () => {
+    mount(detailEndeavorMocks.task, EndeavorRelation.hosts)
+
+    expect(
+      screen.getByText('Google Calendar mirroring is not connected yet.'),
+    ).toBeTruthy()
+    // Both Apple providers give the same reason, so there are two of them.
+    expect(
+      screen.getAllByText('Apple Calendar and Reminders have no web equivalent.'),
+    ).toHaveLength(2)
+  })
+
+  it('renders the Attach control disabled rather than absent', () => {
+    mount(detailEndeavorMocks.task, EndeavorRelation.hosts)
+
+    const attach = screen.getAllByRole('button', { name: /^Attach / })
+    expect(attach.length).toBeGreaterThan(0)
+    for (const button of attach) {
+      expect(button.hasAttribute('disabled')).toBe(true)
+    }
+  })
+
+  it('shows the endeavor is mirrored nowhere, with the editable invitation', () => {
+    mount(detailEndeavorMocks.task, EndeavorRelation.hosts)
+
+    expect(screen.getByText('Not mirrored anywhere')).toBeTruthy()
+    expect(
+      screen.getByText(
+        'Attach a provider below to keep this endeavor in sync outside Kro.',
+      ),
+    ).toBeTruthy()
+  })
+})
+
+describe('relationEntryFromDraft', () => {
+  it('builds a performance, normalising a blank note to null', () => {
+    const entry = relationEntryFromDraft(
+      {
+        relation: 'performances',
+        draft: {
+          date: NOW,
+          durationSeconds: 1500,
+          resolution: PerformResolution.complete,
+          notes: '   ',
+          rewardPoints: 5,
+          wasCompletedInSession: true,
+          editingIndex: null,
+        },
+      },
+      NOW,
+    )
+
+    expect(entry).toMatchObject({
+      duration: 1500,
+      notes: null,
+      rewardPoints: 5,
+      wasCompletedInSession: true,
+    })
+  })
+
+  it('stamps a defer\'s `made` from the caller\'s clock, never its own', () => {
+    const entry = relationEntryFromDraft(
+      { relation: 'defers', draft: { target: NOW, reason: 'later' } },
+      new Date(2026, 0, 1),
+    )
+
+    expect(entry).toMatchObject({
+      made: new Date(2026, 0, 1),
+      reason: 'later',
+      target: NOW,
+    })
+  })
+
+  it('trims a shadow\'s identity columns and drops an empty group', () => {
+    const entry = relationEntryFromDraft(
+      {
+        relation: 'shadows',
+        draft: {
+          originalTitle: ' Team sync ',
+          sourceIdentifier: ' gcal-1 ',
+          source: ' googleCalendar ',
+          kind: EndeavorKind.calendarEvent,
+          group: '  ',
+        },
+      },
+      NOW,
+    )
+
+    expect(entry).toMatchObject({
+      originalTitle: 'Team sync',
+      sourceIdentifier: 'gcal-1',
+      source: 'googleCalendar',
+      group: null,
+    })
+  })
+
+  it('builds nothing for hosts, which attach rather than adding a row', () => {
+    expect(
+      relationEntryFromDraft({ relation: 'hosts', host: 'googleCalendar' }, NOW),
+    ).toBeNull()
+  })
+})
+
+describe('the hosts list', () => {
+  it('lists an attached provider with a named detach control', async () => {
+    const onDetachHost = vi.fn()
+    mount(detailEndeavorMocks.event, EndeavorRelation.hosts, { onDetachHost })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Detach Google Calendar' }),
+    )
+
+    expect(onDetachHost).toHaveBeenCalledWith('googleCalendar')
+  })
+
+  it('drops an attached provider out of the candidate list', () => {
+    mount(detailEndeavorMocks.event, EndeavorRelation.hosts)
+
+    expect(
+      screen.queryByRole('button', { name: 'Attach Google Calendar' }),
+    ).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Attach Outlook Calendar' }),
+    ).toBeTruthy()
+  })
+
+  it('says "All set" when every provider is already attached', () => {
+    const everywhere = {
+      ...detailEndeavorMocks.event,
+      hostedBy: [
+        'appleCalendar' as const,
+        'appleReminders' as const,
+        'googleCalendar' as const,
+        'outlookCalendar' as const,
+      ],
+    }
+    mount(everywhere, EndeavorRelation.hosts)
+
+    expect(screen.getByText('All set')).toBeTruthy()
+    expect(screen.getByText('Every provider is already attached.')).toBeTruthy()
+  })
+})
+
+describe('the shadows list', () => {
+  it('names each mirror and chips its source and kind', () => {
+    mount(detailEndeavorMocks.event, EndeavorRelation.shadows)
+
+    expect(screen.getByText('Team sync')).toBeTruthy()
+    expect(screen.getByText('googleCalendar')).toBeTruthy()
+    expect(screen.getAllByText('Event').length).toBeGreaterThan(0)
+  })
+
+  it('collects the four identity columns a mirror is matched on', async () => {
+    const onChangeDraft = vi.fn()
+    mount(detailEndeavorMocks.event, EndeavorRelation.shadows, { onChangeDraft })
+
+    await userEvent.type(screen.getByLabelText('Original title'), 'A')
+    expect(onChangeDraft).toHaveBeenLastCalledWith({
+      relation: 'shadows',
+      draft: {
+        originalTitle: 'A',
+        sourceIdentifier: '',
+        source: '',
+        kind: EndeavorKind.task,
+        group: '',
+      },
+    })
+
+    await userEvent.selectOptions(screen.getByLabelText('Kind'), 'habit')
+    expect(onChangeDraft).toHaveBeenLastCalledWith({
+      relation: 'shadows',
+      draft: expect.objectContaining({ kind: 'habit' }),
+    })
+  })
+
+  it('removes a mirror by its position', async () => {
+    const onRemoveEntry = vi.fn()
+    mount(detailEndeavorMocks.event, EndeavorRelation.shadows, { onRemoveEntry })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remove Team sync' }),
+    )
+
+    expect(onRemoveEntry).toHaveBeenCalledWith(0)
+  })
+})
+
+describe('the performance form collects the user-meaningful subset', () => {
+  it('reports the duration in seconds, though it is typed in minutes', async () => {
+    const onChangeDraft = vi.fn()
+    mount(detailEndeavorMocks.task, EndeavorRelation.performances, {
+      onChangeDraft,
+    })
+
+    // `fireEvent.change` rather than typing: the draft is the store's, so an
+    // uncontrolled keystroke-by-keystroke type would re-read the same seed on
+    // every character and only the last one would survive.
+    fireEvent.change(screen.getByLabelText('Duration (minutes)'), {
+      target: { value: '4' },
+    })
+
+    expect(onChangeDraft).toHaveBeenLastCalledWith({
+      relation: 'performances',
+      draft: expect.objectContaining({ durationSeconds: 240 }),
+    })
+  })
+
+  it('reports the resolution the user picked', async () => {
+    const onChangeDraft = vi.fn()
+    mount(detailEndeavorMocks.task, EndeavorRelation.performances, {
+      onChangeDraft,
+    })
+
+    await userEvent.selectOptions(screen.getByLabelText('Resolution'), 'aborted')
+
+    expect(onChangeDraft).toHaveBeenLastCalledWith({
+      relation: 'performances',
+      draft: expect.objectContaining({ resolution: PerformResolution.aborted }),
+    })
+  })
+
+  it('only claims a whole focus session when the user says so', async () => {
+    const onChangeDraft = vi.fn()
+    mount(detailEndeavorMocks.task, EndeavorRelation.performances, {
+      onChangeDraft,
+    })
+
+    await userEvent.click(
+      screen.getByLabelText('This was a whole focus session'),
+    )
+
+    expect(onChangeDraft).toHaveBeenLastCalledWith({
+      relation: 'performances',
+      draft: expect.objectContaining({ wasCompletedInSession: true }),
+    })
+  })
+
+  it('carries the notes and the reward points into the draft', async () => {
+    const onChangeDraft = vi.fn()
+    mount(detailEndeavorMocks.task, EndeavorRelation.performances, {
+      onChangeDraft,
+    })
+
+    await userEvent.type(screen.getByLabelText('Notes (optional)'), 'n')
+    expect(onChangeDraft).toHaveBeenLastCalledWith({
+      relation: 'performances',
+      draft: expect.objectContaining({ notes: 'n' }),
+    })
+
+    fireEvent.change(screen.getByLabelText('Reward points'), {
+      target: { value: '15' },
+    })
+    expect(onChangeDraft).toHaveBeenLastCalledWith({
+      relation: 'performances',
+      draft: expect.objectContaining({ rewardPoints: 15 }),
+    })
+  })
+
+  it('prints the notes a recorded performance carries', () => {
+    const first = detailEndeavorMocks.taskWithSessions.performances[0]
+    if (first === undefined) throw new Error('no seeded performance')
+    mount(
+      {
+        ...detailEndeavorMocks.task,
+        performances: [{ ...first, notes: 'Made good progress' }],
+      },
+      EndeavorRelation.performances,
+    )
+
+    expect(screen.getByText('Made good progress')).toBeTruthy()
+  })
+
+  it('announces a write in flight and disables the controls with it', () => {
+    mount(detailEndeavorMocks.taskWithSessions, EndeavorRelation.performances, {
+      isSaving: true,
+    })
+
+    expect(screen.getByRole('status').textContent).toBe('Saving…')
+    for (const button of screen.getAllByRole('button', {
+      name: /^Remove performance/,
+    })) {
+      expect(button.hasAttribute('disabled')).toBe(true)
+    }
+  })
+})
+
+describe('the defer list', () => {
+  it('leads each row with the date it was pushed TO, and states why', () => {
+    mount(
+      {
+        ...detailEndeavorMocks.task,
+        defers: [
+          {
+            made: new Date(2026, 5, 18, 9),
+            reason: 'Waiting on finance',
+            target: new Date(2026, 5, 20, 9),
+          },
+        ],
+      },
+      EndeavorRelation.defers,
+    )
+
+    expect(screen.getByText('Waiting on finance')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /^Remove defer to/ })).toBeTruthy()
+  })
+})

--- a/packages/app/src/features/endeavorDetail/pages/EndeavorRelationFragment.tsx
+++ b/packages/app/src/features/endeavorDetail/pages/EndeavorRelationFragment.tsx
@@ -1,0 +1,1007 @@
+'use client'
+
+/**
+ * The four relation screens, on one shared layout — the port of
+ * `EndeavorPerformancesView`, `EndeavorDefersView`, `EndeavorHostsView` and
+ * `EndeavorShadowsView` (`RC-15`).
+ *
+ * Canon ships four files with the **same** four parts in the same order: a
+ * titled intro, an error banner, a grouped list (or its empty state), and
+ * either an add form or an info banner saying why there is none. Four copies of
+ * one layout is exactly the duplication `RC-32` names, so the layout is written
+ * once here and the four screens differ only in the list row and the form —
+ * which is genuinely all they differ in.
+ *
+ * ## The read-only copy is `#29`'s, never invented here
+ *
+ * `relationReadOnlyReason` and `relationEmptyState` are the merged logic tier's
+ * strings, keyed by relation **and** by editability, and its own header states
+ * why: *"'log one below by hand' is a lie on a surface that has no form."* This
+ * Fragment prints what it is handed and mints no message of its own.
+ *
+ * ## Hosts cannot be attached in this build, and the screen says so per row
+ *
+ * `hostAttachCandidatesOf` reports `isAttachable: false` with a reason for
+ * every provider (`#29`, and `attachHostThunk` refuses with the same string).
+ * The Attach control is therefore rendered **disabled with its reason beside
+ * it** rather than hidden: a hidden control makes the gap invisible, and canon
+ * never disables an affordance silently.
+ *
+ * ## No `ScreenIntroHeader`
+ *
+ * Canon's intro is `KroUI/Components/ScreenIntroHeader.swift`, which the merged
+ * component kit did not port (it is not in `#14`'s declared surface). The intro
+ * below is that shape — glyph, title, subtitle, optional summary chips — built
+ * from the kit's own primitives. Porting the component properly belongs to
+ * whichever child next opens `design/endeavor/`.
+ */
+import {
+  type Defer,
+  type Endeavor,
+  type EndeavorHost,
+  EndeavorKind,
+  EndeavorRelation,
+  type Perform,
+  PerformResolution,
+  type Shadow,
+  assertNever,
+  endeavorHostDisplayName,
+  endeavorKindDisplayName,
+  endeavorKinds,
+  makeDefer,
+  makePerform,
+  makeShadow,
+  performResolutions,
+} from '@kro/core'
+import { EmptyStateCard } from '../../../design/endeavor/EmptyStateCard'
+import { InlineBanner } from '../../../design/endeavor/InlineBanner'
+import { ChipFlow, KroChip } from '../../../design/endeavor/KroChip'
+import { CardRowStack, SectionCard } from '../../../design/endeavor/SurfaceCard'
+import { endeavorIcon } from '../../../design/endeavor/endeavorIcons'
+import {
+  localInputValue,
+  parseLocalInput,
+} from '../../../design/endeavor/endeavorPopovers'
+import { Input } from '../../../design/system/primitives/input'
+import { colorVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import type { EndeavorDetailException } from '../EndeavorDetailException'
+import type {
+  HostAttachCandidate,
+  RelationDraft,
+  RelationEmptyState,
+} from '../EndeavorRelations'
+import { HIDDEN_SCROLLBAR_STYLE } from './EndeavorDetailFragment'
+import {
+  deferTitle,
+  detailDateTime,
+  hostChip,
+  performanceChips,
+  performanceSummaryChips,
+  relationIcon,
+  relationLabel,
+  relationSubtitle,
+  shadowChips,
+  shadowTitle,
+} from './endeavorDetailDisplay'
+
+const Trash = endeavorIcon('trash')
+// Canon detaches with `minus`; neither symbol map carries it, so the
+// nearest mapped neighbour stands in and says so here.
+const Detach = endeavorIcon('xmark')
+
+export interface EndeavorRelationFragmentProps {
+  readonly relation: EndeavorRelation
+  readonly endeavor: Endeavor
+  /** `null` when the relation is editable for this kind; the reason otherwise. */
+  readonly readOnlyReason: string | null
+  readonly emptyState: RelationEmptyState
+  readonly isSaving: boolean
+  readonly exception: EndeavorDetailException | null
+  readonly draft: RelationDraft | null
+  readonly isDraftCommittable: boolean
+  readonly attachedHosts: readonly EndeavorHost[]
+  readonly hostCandidates: readonly HostAttachCandidate[]
+  /** The instant an unopened draft seeds itself from (`RC-5`: never a clock). */
+  readonly now: Date
+  readonly locale?: string
+  readonly onChangeDraft: (draft: RelationDraft | null) => void
+  readonly onCommitDraft: () => void
+  readonly onRemoveEntry: (index: number) => void
+  readonly onAttachHost: (host: EndeavorHost) => void
+  readonly onDetachHost: (host: EndeavorHost) => void
+}
+
+export function EndeavorRelationFragment(props: EndeavorRelationFragmentProps) {
+  const {
+    relation,
+    endeavor,
+    readOnlyReason,
+    emptyState,
+    isSaving,
+    exception,
+    locale,
+  } = props
+  const isEditable = readOnlyReason === null
+  const Glyph = endeavorIcon(relationIcon(relation))
+
+  return (
+    <div
+      data-testid="endeavor-relation"
+      data-relation={relation}
+      className="flex min-h-0 flex-1 flex-col gap-kro-large overflow-y-auto pb-kro-x-large [&>*]:shrink-0 [&::-webkit-scrollbar]:hidden"
+      style={HIDDEN_SCROLLBAR_STYLE}
+    >
+      <header className="flex flex-col gap-kro-small">
+        <div className="flex items-center gap-kro-small">
+          <Glyph size={22} aria-hidden style={{ color: colorVar('accent') }} />
+          <h2
+            className="m-0 font-bold text-xl"
+            style={{ color: colorVar('fore') }}
+          >
+            {relationLabel(relation)}
+          </h2>
+        </div>
+        <p className="m-0 text-sm" style={{ color: colorVar('foreSecondary') }}>
+          {relationSubtitle(relation)}
+        </p>
+        {relation === EndeavorRelation.performances &&
+        endeavor.performances.length > 0 ? (
+          <ChipFlow>
+            {performanceSummaryChips(endeavor.performances).map((chip) => (
+              <KroChip
+                key={chip.id}
+                title={chip.title}
+                icon={chip.icon}
+                tint={chip.tint}
+                size="small"
+              />
+            ))}
+          </ChipFlow>
+        ) : null}
+      </header>
+
+      {exception === null ? null : <InlineBanner message={exception.message} />}
+
+      <RelationList
+        {...props}
+        isEditable={isEditable}
+        emptyState={emptyState}
+        locale={locale}
+      />
+
+      {isEditable ? (
+        <RelationForm {...props} />
+      ) : (
+        <InlineBanner kind="info" message={readOnlyReason} />
+      )}
+
+      {isSaving ? (
+        <p
+          role="status"
+          className="m-0 text-sm"
+          style={{ color: colorVar('foreSecondary') }}
+        >
+          Saving…
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* The list                                                                  */
+/* ------------------------------------------------------------------------ */
+
+function RelationList(
+  props: EndeavorRelationFragmentProps & {
+    readonly isEditable: boolean
+  },
+) {
+  const {
+    relation,
+    endeavor,
+    isEditable,
+    emptyState,
+    isSaving,
+    attachedHosts,
+    locale,
+    onRemoveEntry,
+    onDetachHost,
+  } = props
+
+  switch (relation) {
+    case EndeavorRelation.performances:
+      return (
+        <SectionCard
+          title="Recorded"
+          icon="checkmark.circle"
+          count={endeavor.performances.length || undefined}
+          padding={endeavor.performances.length === 0 ? undefined : null}
+        >
+          {endeavor.performances.length === 0 ? (
+            <EmptyStateCard
+              icon="questionmark.circle"
+              title={emptyState.title}
+              message={emptyState.message}
+            />
+          ) : (
+            <CardRowStack>
+              {endeavor.performances.map((entry, index) => (
+                <PerformanceRow
+                  key={`${entry.date.getTime()}-${index}`}
+                  entry={entry}
+                  index={index}
+                  isEditable={isEditable}
+                  isSaving={isSaving}
+                  locale={locale}
+                  onRemove={onRemoveEntry}
+                />
+              ))}
+            </CardRowStack>
+          )}
+        </SectionCard>
+      )
+
+    case EndeavorRelation.defers:
+      return (
+        <SectionCard
+          title="History"
+          icon="clock.arrow.circlepath"
+          count={endeavor.defers.length || undefined}
+          padding={endeavor.defers.length === 0 ? undefined : null}
+        >
+          {endeavor.defers.length === 0 ? (
+            <EmptyStateCard
+              icon="checkmark.circle"
+              title={emptyState.title}
+              message={emptyState.message}
+            />
+          ) : (
+            <CardRowStack>
+              {endeavor.defers.map((entry, index) => (
+                <DeferRow
+                  key={`${entry.made.getTime()}-${index}`}
+                  entry={entry}
+                  index={index}
+                  isEditable={isEditable}
+                  isSaving={isSaving}
+                  locale={locale}
+                  onRemove={onRemoveEntry}
+                />
+              ))}
+            </CardRowStack>
+          )}
+        </SectionCard>
+      )
+
+    case EndeavorRelation.hosts:
+      return (
+        <SectionCard
+          title="Attached"
+          icon="network"
+          count={attachedHosts.length || undefined}
+          padding={attachedHosts.length === 0 ? undefined : null}
+        >
+          {attachedHosts.length === 0 ? (
+            <EmptyStateCard
+              icon="network"
+              title={emptyState.title}
+              message={emptyState.message}
+            />
+          ) : (
+            <CardRowStack>
+              {attachedHosts.map((host) => (
+                <div
+                  key={host}
+                  data-attached-host={host}
+                  className="flex items-center gap-kro-small px-kro-medium py-2.5"
+                >
+                  <KroChip {...chipProps(host)} size="small" />
+                  <span className="flex-1" />
+                  {isEditable ? (
+                    <IconButton
+                      label={`Detach ${endeavorHostDisplayName(host)}`}
+                      isDestructive
+                      disabled={isSaving}
+                      onPress={() => onDetachHost(host)}
+                    >
+                      <Detach size={14} aria-hidden />
+                    </IconButton>
+                  ) : null}
+                </div>
+              ))}
+            </CardRowStack>
+          )}
+        </SectionCard>
+      )
+
+    case EndeavorRelation.shadows: {
+      const shadows = endeavor.shadows ?? []
+      return (
+        <SectionCard
+          title="Current"
+          icon="square.and.arrow.down"
+          count={shadows.length || undefined}
+          padding={shadows.length === 0 ? undefined : null}
+        >
+          {shadows.length === 0 ? (
+            <EmptyStateCard
+              icon="square.and.arrow.down"
+              title={emptyState.title}
+              message={emptyState.message}
+            />
+          ) : (
+            <CardRowStack>
+              {shadows.map((shadow, index) => (
+                <ShadowRow
+                  key={`${shadow.sourceIdentifier}-${index}`}
+                  shadow={shadow}
+                  index={index}
+                  isEditable={isEditable}
+                  isSaving={isSaving}
+                  onRemove={onRemoveEntry}
+                />
+              ))}
+            </CardRowStack>
+          )}
+        </SectionCard>
+      )
+    }
+
+    default:
+      return assertNever(relation)
+  }
+}
+
+const chipProps = (host: EndeavorHost) => {
+  const chip = hostChip(host)
+  return { title: chip.title, icon: chip.icon, tint: chip.tint }
+}
+
+function PerformanceRow({
+  entry,
+  index,
+  isEditable,
+  isSaving,
+  locale,
+  onRemove,
+}: {
+  readonly entry: Perform
+  readonly index: number
+  readonly isEditable: boolean
+  readonly isSaving: boolean
+  readonly locale?: string
+  readonly onRemove: (index: number) => void
+}) {
+  const when = detailDateTime(entry.date, locale)
+  return (
+    <div className="flex items-start gap-kro-small px-kro-medium py-2.5">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="m-0 font-semibold text-sm" style={{ color: colorVar('fore') }}>
+          {when}
+        </p>
+        <ChipFlow>
+          {performanceChips(entry).map((chip) => (
+            <KroChip
+              key={chip.id}
+              title={chip.title}
+              icon={chip.icon}
+              tint={chip.tint}
+              size="small"
+            />
+          ))}
+        </ChipFlow>
+        {entry.notes === null || entry.notes.length === 0 ? null : (
+          <p className="m-0 text-xs" style={{ color: colorVar('foreSecondary') }}>
+            {entry.notes}
+          </p>
+        )}
+      </div>
+      {isEditable ? (
+        <IconButton
+          label={`Remove performance on ${when}`}
+          isDestructive
+          disabled={isSaving}
+          onPress={() => onRemove(index)}
+        >
+          <Trash size={14} aria-hidden />
+        </IconButton>
+      ) : null}
+    </div>
+  )
+}
+
+function DeferRow({
+  entry,
+  index,
+  isEditable,
+  isSaving,
+  locale,
+  onRemove,
+}: {
+  readonly entry: Defer
+  readonly index: number
+  readonly isEditable: boolean
+  readonly isSaving: boolean
+  readonly locale?: string
+  readonly onRemove: (index: number) => void
+}) {
+  const target = deferTitle(entry, locale)
+  return (
+    <div className="flex items-start gap-kro-small px-kro-medium py-2.5">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="m-0 font-semibold text-sm" style={{ color: colorVar('fore') }}>
+          {target}
+        </p>
+        <p className="m-0 text-xs" style={{ color: colorVar('foreSecondary') }}>
+          {`Deferred ${detailDateTime(entry.made, locale)}`}
+        </p>
+        {entry.reason === null || entry.reason.length === 0 ? null : (
+          <p className="m-0 text-xs" style={{ color: colorVar('foreSecondary') }}>
+            {entry.reason}
+          </p>
+        )}
+      </div>
+      {isEditable ? (
+        <IconButton
+          label={`Remove defer to ${target}`}
+          isDestructive
+          disabled={isSaving}
+          onPress={() => onRemove(index)}
+        >
+          <Trash size={14} aria-hidden />
+        </IconButton>
+      ) : null}
+    </div>
+  )
+}
+
+function ShadowRow({
+  shadow,
+  index,
+  isEditable,
+  isSaving,
+  onRemove,
+}: {
+  readonly shadow: Shadow
+  readonly index: number
+  readonly isEditable: boolean
+  readonly isSaving: boolean
+  readonly onRemove: (index: number) => void
+}) {
+  const title = shadowTitle(shadow)
+  return (
+    <div className="flex items-start gap-kro-small px-kro-medium py-2.5">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="m-0 font-semibold text-sm" style={{ color: colorVar('fore') }}>
+          {title}
+        </p>
+        <ChipFlow>
+          {shadowChips(shadow).map((chip) => (
+            <KroChip
+              key={chip.id}
+              title={chip.title}
+              icon={chip.icon}
+              tint={chip.tint}
+              size="small"
+            />
+          ))}
+        </ChipFlow>
+      </div>
+      {isEditable ? (
+        <IconButton
+          label={`Remove ${title}`}
+          isDestructive
+          disabled={isSaving}
+          onPress={() => onRemove(index)}
+        >
+          <Trash size={14} aria-hidden />
+        </IconButton>
+      ) : null}
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* The add form                                                              */
+/* ------------------------------------------------------------------------ */
+
+function RelationForm(props: EndeavorRelationFragmentProps) {
+  const {
+    relation,
+    draft,
+    isDraftCommittable,
+    isSaving,
+    hostCandidates,
+    now,
+    onChangeDraft,
+    onCommitDraft,
+    onAttachHost,
+  } = props
+
+  if (relation === EndeavorRelation.hosts) {
+    return (
+      <SectionCard title="Available" icon="plus.circle.fill">
+        {hostCandidates.length === 0 ? (
+          <EmptyStateCard
+            icon="checkmark.circle"
+            title="All set"
+            message="Every provider is already attached."
+          />
+        ) : (
+          <div className="flex flex-col gap-kro-small">
+            {hostCandidates.map((candidate) => (
+              <div
+                key={candidate.host}
+                data-host-candidate={candidate.host}
+                className="flex flex-col gap-kro-tiny"
+              >
+                <div className="flex items-center gap-kro-small">
+                  <KroChip {...chipProps(candidate.host)} size="small" />
+                  <span className="flex-1" />
+                  <button
+                    type="button"
+                    disabled={isSaving || !candidate.isAttachable}
+                    onClick={() => onAttachHost(candidate.host)}
+                    className="rounded-kro-small px-kro-small text-sm font-semibold outline-none focus-visible:shadow-[var(--kro-ring)] disabled:opacity-[var(--kro-opacity-disabled)]"
+                    style={{
+                      color: colorVar('accent'),
+                      minHeight: 'var(--kro-size-min-touch-target)',
+                    }}
+                  >
+                    {`Attach ${candidate.label}`}
+                  </button>
+                </div>
+                {candidate.unavailableReason === null ? null : (
+                  <p
+                    className="m-0 text-xs"
+                    style={{ color: colorVar('foreSecondary') }}
+                  >
+                    {candidate.unavailableReason}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </SectionCard>
+    )
+  }
+
+  const title =
+    relation === EndeavorRelation.performances
+      ? 'Add Performance'
+      : relation === EndeavorRelation.defers
+        ? 'Add Defer'
+        : 'Add Shadow'
+
+  return (
+    <SectionCard title={title} icon="plus">
+      <form
+        className="flex flex-col gap-kro-medium"
+        onSubmit={(event) => {
+          event.preventDefault()
+          if (isDraftCommittable && !isSaving) onCommitDraft()
+        }}
+      >
+        {relation === EndeavorRelation.performances ? (
+          <PerformanceForm
+            draft={draft}
+            now={now}
+            isSaving={isSaving}
+            onChangeDraft={onChangeDraft}
+          />
+        ) : relation === EndeavorRelation.defers ? (
+          <DeferForm
+            draft={draft}
+            now={now}
+            isSaving={isSaving}
+            onChangeDraft={onChangeDraft}
+          />
+        ) : (
+          <ShadowForm draft={draft} isSaving={isSaving} onChangeDraft={onChangeDraft} />
+        )}
+
+        <button
+          type="submit"
+          disabled={!isDraftCommittable || isSaving}
+          className={cn(
+            'inline-flex items-center justify-center rounded-kro-pill px-4',
+            'text-sm font-semibold outline-none focus-visible:shadow-[var(--kro-ring)]',
+            'disabled:opacity-[var(--kro-opacity-disabled)]',
+          )}
+          style={{
+            minHeight: 'var(--kro-size-min-touch-target)',
+            backgroundColor: colorVar('accent'),
+            color: colorVar('onAccent'),
+          }}
+        >
+          {title}
+        </button>
+      </form>
+    </SectionCard>
+  )
+}
+
+/** The draft each form starts from when nothing is open yet. */
+const emptyPerformanceDraft = (now: Date) => ({
+  relation: 'performances' as const,
+  draft: {
+    date: now,
+    durationSeconds: 25 * 60,
+    resolution: PerformResolution.complete,
+    notes: '',
+    rewardPoints: 0,
+    wasCompletedInSession: false,
+    editingIndex: null,
+  },
+})
+
+function PerformanceForm({
+  draft,
+  now,
+  isSaving,
+  onChangeDraft,
+}: {
+  readonly draft: RelationDraft | null
+  readonly now: Date
+  readonly isSaving: boolean
+  readonly onChangeDraft: (draft: RelationDraft | null) => void
+}) {
+  const current =
+    draft !== null && draft.relation === 'performances'
+      ? draft
+      : emptyPerformanceDraft(now)
+  const value = current.draft
+
+  const patch = (next: Partial<typeof value>) =>
+    onChangeDraft({ relation: 'performances', draft: { ...value, ...next } })
+
+  return (
+    <>
+      <Field label="Date" htmlFor="performance-date">
+        <Input
+          id="performance-date"
+          type="datetime-local"
+          disabled={isSaving}
+          value={localInputValue(value.date)}
+          onChange={(event) => {
+            const parsed = parseLocalInput(event.target.value)
+            if (parsed !== null) patch({ date: parsed })
+          }}
+        />
+      </Field>
+      <Field label="Duration (minutes)" htmlFor="performance-duration">
+        <Input
+          id="performance-duration"
+          type="number"
+          min={0}
+          step={5}
+          disabled={isSaving}
+          value={String(Math.round(value.durationSeconds / 60))}
+          onChange={(event) =>
+            patch({ durationSeconds: Number(event.target.value) * 60 })
+          }
+        />
+      </Field>
+      <Field label="Resolution" htmlFor="performance-resolution">
+        <NativeSelect
+          id="performance-resolution"
+          value={value.resolution}
+          disabled={isSaving}
+          onChange={(next) =>
+            patch({ resolution: next as PerformResolution })
+          }
+          options={performResolutions.map((resolution) => ({
+            value: resolution,
+            label: resolution,
+          }))}
+        />
+      </Field>
+      <Field label="Notes (optional)" htmlFor="performance-notes">
+        <textarea
+          id="performance-notes"
+          rows={3}
+          disabled={isSaving}
+          value={value.notes}
+          onChange={(event) => patch({ notes: event.target.value })}
+          className="w-full rounded-kro-field p-kro-small text-sm outline-none focus-visible:shadow-[var(--kro-ring)]"
+          style={{
+            backgroundColor: colorVar('backInner'),
+            color: colorVar('fore'),
+          }}
+        />
+      </Field>
+      <Field label="Reward points" htmlFor="performance-points">
+        <Input
+          id="performance-points"
+          type="number"
+          min={0}
+          step={5}
+          disabled={isSaving}
+          value={String(value.rewardPoints)}
+          onChange={(event) => patch({ rewardPoints: Number(event.target.value) })}
+        />
+      </Field>
+      <label
+        className="flex items-center gap-kro-small text-sm"
+        style={{ color: colorVar('fore') }}
+      >
+        <input
+          type="checkbox"
+          disabled={isSaving}
+          checked={value.wasCompletedInSession}
+          onChange={(event) =>
+            patch({ wasCompletedInSession: event.target.checked })
+          }
+          className="size-5 accent-[var(--kro-color-accent)]"
+        />
+        This was a whole focus session
+      </label>
+    </>
+  )
+}
+
+function DeferForm({
+  draft,
+  now,
+  isSaving,
+  onChangeDraft,
+}: {
+  readonly draft: RelationDraft | null
+  readonly now: Date
+  readonly isSaving: boolean
+  readonly onChangeDraft: (draft: RelationDraft | null) => void
+}) {
+  const value =
+    draft !== null && draft.relation === 'defers'
+      ? draft.draft
+      : { target: now, reason: '' }
+
+  const patch = (next: Partial<typeof value>) =>
+    onChangeDraft({ relation: 'defers', draft: { ...value, ...next } })
+
+  return (
+    <>
+      <Field label="Defer to" htmlFor="defer-target">
+        <Input
+          id="defer-target"
+          type="datetime-local"
+          disabled={isSaving}
+          value={localInputValue(value.target)}
+          onChange={(event) => {
+            const parsed = parseLocalInput(event.target.value)
+            if (parsed !== null) patch({ target: parsed })
+          }}
+        />
+      </Field>
+      <Field label="Reason (optional)" htmlFor="defer-reason">
+        <Input
+          id="defer-reason"
+          disabled={isSaving}
+          value={value.reason}
+          onChange={(event) => patch({ reason: event.target.value })}
+        />
+      </Field>
+    </>
+  )
+}
+
+function ShadowForm({
+  draft,
+  isSaving,
+  onChangeDraft,
+}: {
+  readonly draft: RelationDraft | null
+  readonly isSaving: boolean
+  readonly onChangeDraft: (draft: RelationDraft | null) => void
+}) {
+  const value =
+    draft !== null && draft.relation === 'shadows'
+      ? draft.draft
+      : {
+          originalTitle: '',
+          sourceIdentifier: '',
+          source: '',
+          kind: EndeavorKind.task,
+          group: '',
+        }
+
+  const patch = (next: Partial<typeof value>) =>
+    onChangeDraft({ relation: 'shadows', draft: { ...value, ...next } })
+
+  return (
+    <>
+      <Field label="Original title" htmlFor="shadow-title">
+        <Input
+          id="shadow-title"
+          disabled={isSaving}
+          value={value.originalTitle}
+          onChange={(event) => patch({ originalTitle: event.target.value })}
+        />
+      </Field>
+      <Field label="Source identifier" htmlFor="shadow-identifier">
+        <Input
+          id="shadow-identifier"
+          disabled={isSaving}
+          value={value.sourceIdentifier}
+          onChange={(event) => patch({ sourceIdentifier: event.target.value })}
+        />
+      </Field>
+      <Field label="Source" htmlFor="shadow-source">
+        <Input
+          id="shadow-source"
+          disabled={isSaving}
+          value={value.source}
+          onChange={(event) => patch({ source: event.target.value })}
+        />
+      </Field>
+      <Field label="Kind" htmlFor="shadow-kind">
+        <NativeSelect
+          id="shadow-kind"
+          value={value.kind}
+          disabled={isSaving}
+          onChange={(next) => patch({ kind: next as EndeavorKind })}
+          options={endeavorKinds.map((kind) => ({
+            value: kind,
+            label: endeavorKindDisplayName(kind),
+          }))}
+        />
+      </Field>
+      <Field label="Group (optional)" htmlFor="shadow-group">
+        <Input
+          id="shadow-group"
+          disabled={isSaving}
+          value={value.group}
+          onChange={(event) => patch({ group: event.target.value })}
+        />
+      </Field>
+    </>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* Draft → domain                                                            */
+/* ------------------------------------------------------------------------ */
+
+/**
+ * The domain value a committed draft becomes.
+ *
+ * Exported and pure, so the Page's commit path is one call and the mapping is
+ * unit-tested rather than asserted through a rendered form. `null` for `hosts`,
+ * which commits by attaching rather than by adding a row.
+ */
+export const relationEntryFromDraft = (
+  draft: RelationDraft,
+  now: Date,
+): Perform | Defer | Shadow | null => {
+  switch (draft.relation) {
+    case 'performances': {
+      const notes = draft.draft.notes.trim()
+      return makePerform({
+        date: draft.draft.date,
+        duration: draft.draft.durationSeconds,
+        notes: notes.length === 0 ? null : notes,
+        resolution: draft.draft.resolution,
+        rewardPoints: draft.draft.rewardPoints,
+        wasCompletedInSession: draft.draft.wasCompletedInSession,
+      })
+    }
+    case 'defers': {
+      const reason = draft.draft.reason.trim()
+      return makeDefer({
+        made: now,
+        reason: reason.length === 0 ? null : reason,
+        target: draft.draft.target,
+      })
+    }
+    case 'shadows': {
+      const group = draft.draft.group.trim()
+      return makeShadow({
+        originalTitle: draft.draft.originalTitle.trim(),
+        sourceIdentifier: draft.draft.sourceIdentifier.trim(),
+        kind: draft.draft.kind,
+        source: draft.draft.source.trim(),
+        group: group.length === 0 ? null : group,
+      })
+    }
+    default:
+      return null
+  }
+}
+
+/* ------------------------------------------------------------------------ */
+/* Small controls                                                            */
+/* ------------------------------------------------------------------------ */
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  readonly label: string
+  readonly htmlFor: string
+  readonly children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-kro-tiny">
+      <label
+        htmlFor={htmlFor}
+        className="text-sm"
+        style={{ color: colorVar('foreSecondary') }}
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  )
+}
+
+function NativeSelect({
+  id,
+  value,
+  options,
+  disabled,
+  onChange,
+}: {
+  readonly id: string
+  readonly value: string
+  readonly options: readonly { readonly value: string; readonly label: string }[]
+  readonly disabled: boolean
+  readonly onChange: (value: string) => void
+}) {
+  return (
+    <select
+      id={id}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+      className="w-full rounded-kro-field px-kro-small text-sm outline-none focus-visible:shadow-[var(--kro-ring)] disabled:opacity-[var(--kro-opacity-disabled)]"
+      style={{
+        backgroundColor: colorVar('backInner'),
+        color: colorVar('fore'),
+        minHeight: 'var(--kro-size-min-touch-target)',
+      }}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function IconButton({
+  label,
+  isDestructive,
+  disabled,
+  onPress,
+  children,
+}: {
+  readonly label: string
+  readonly isDestructive?: boolean
+  readonly disabled: boolean
+  readonly onPress: () => void
+  readonly children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      disabled={disabled}
+      onClick={onPress}
+      className="inline-flex shrink-0 items-center justify-center rounded-kro-pill outline-none focus-visible:shadow-[var(--kro-ring)] disabled:opacity-[var(--kro-opacity-disabled)]"
+      style={{
+        minWidth: 'var(--kro-size-min-touch-target)',
+        minHeight: 'var(--kro-size-min-touch-target)',
+        color: isDestructive === true
+          ? colorVar('bannerDanger')
+          : colorVar('foreSecondary'),
+      }}
+    >
+      {children}
+    </button>
+  )
+}

--- a/packages/app/src/features/endeavorDetail/pages/__tests__/DetailOverlaySelectors.test.ts
+++ b/packages/app/src/features/endeavorDetail/pages/__tests__/DetailOverlaySelectors.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The intent→endeavor join, against a hand-built root state slice (`RC-55`).
+ *
+ * The three cases that matter are the two REFUSALS: an intent that belongs to
+ * another feature must stay in the queue, and an intent naming a row this
+ * surface no longer holds must not present Detail on a ghost.
+ */
+import { describe, expect, it } from 'vitest'
+import type { RootState } from '../../../../library/store'
+import {
+  FIND_REFERENCE_NOW,
+  findEndeavorMocks,
+  findStateMocks,
+} from '../../../find/FindMocks'
+import type { EndeavorIntent } from '../../../find/FindOperations'
+import type { FindState } from '../../../find/FindState'
+import { selectDetailIntentRequest } from '../DetailOverlaySelectors'
+
+const rootWith = (find: FindState): RootState =>
+  ({ find }) as unknown as RootState
+
+const withIntent = (intent: EndeavorIntent): FindState => ({
+  ...findStateMocks.loaded,
+  intents: [intent],
+  nextIntentId: intent.id + 1,
+})
+
+const viewDetail: EndeavorIntent = {
+  id: 7,
+  operation: 'viewDetail',
+  endeavorId: findEndeavorMocks.morningTask.id,
+  surface: 'find',
+}
+
+describe('selectDetailIntentRequest', () => {
+  it('resolves a viewDetail intent to the endeavor the row was showing', () => {
+    const request = selectDetailIntentRequest(rootWith(withIntent(viewDetail)))
+
+    expect(request).not.toBeNull()
+    expect(request?.intentId).toBe(7)
+    expect(request?.endeavor.id).toBe(findEndeavorMocks.morningTask.id)
+    // The anchor is the fixture's own, so this is a pure read.
+    expect(findStateMocks.loaded.find.clockAnchor).toEqual(FIND_REFERENCE_NOW)
+  })
+
+  it('resolves an edit intent too — canon\'s second entry point into the editor', () => {
+    const request = selectDetailIntentRequest(
+      rootWith(withIntent({ ...viewDetail, operation: 'edit' })),
+    )
+
+    expect(request?.operation).toBe('edit')
+  })
+
+  it('leaves another feature\'s intent alone, so the session surface still gets it', () => {
+    const request = selectDetailIntentRequest(
+      rootWith(withIntent({ ...viewDetail, operation: 'startSession' })),
+    )
+
+    expect(request).toBeNull()
+  })
+
+  it('resolves nothing when the queue is empty', () => {
+    expect(selectDetailIntentRequest(rootWith(findStateMocks.loaded))).toBeNull()
+  })
+
+  it('refuses an intent whose row is no longer on the surface — a stale tap', () => {
+    const request = selectDetailIntentRequest(
+      rootWith(withIntent({ ...viewDetail, endeavorId: 'deleted-row' })),
+    )
+
+    expect(request).toBeNull()
+  })
+
+  it('reads the All Tasks pool when the intent came from that surface', () => {
+    const state: FindState = {
+      ...findStateMocks.tasksMixed,
+      intents: [
+        {
+          ...viewDetail,
+          surface: 'tasks',
+          endeavorId: findEndeavorMocks.morningTask.id,
+        },
+      ],
+      nextIntentId: 8,
+    }
+
+    expect(selectDetailIntentRequest(rootWith(state))?.endeavor.id).toBe(
+      findEndeavorMocks.morningTask.id,
+    )
+  })
+})

--- a/packages/app/src/features/endeavorDetail/pages/__tests__/endeavorDetailDisplay.test.ts
+++ b/packages/app/src/features/endeavorDetail/pages/__tests__/endeavorDetailDisplay.test.ts
@@ -1,0 +1,288 @@
+/**
+ * The display mapping, asserted against `#29`'s own fixtures.
+ *
+ * The point of these is the **placeholders**: canon says "No due date", not an
+ * em dash, and a Detail row that prints nothing is indistinguishable from a row
+ * whose value happens to be blank — which is the defect `PropertyRow`'s empty
+ * case exists to prevent.
+ */
+import {
+  EndeavorField,
+  EndeavorKind,
+  EndeavorRelation,
+  EndeavorStatus,
+  Month,
+  PerformResolution,
+  WeekDay,
+  endeavorFields,
+  makeEndeavor,
+  makePerform,
+  makeRepeatConfig,
+  makeShadow,
+  monthlyBase,
+  weeklyBase,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { detailEndeavorMocks } from '../../EndeavorDetailMocks'
+import {
+  deferTitle,
+  detailDateTime,
+  fieldIcon,
+  fieldLabel,
+  fieldValue,
+  headerChips,
+  normalizedHex,
+  performanceChips,
+  performanceSummaryChips,
+  relationIcon,
+  relationLabel,
+  relationSubtitle,
+  relationSummary,
+  repeatSummary,
+  resolutionLabel,
+  shadowChips,
+  shadowTitle,
+  tagLabel,
+} from '../endeavorDetailDisplay'
+
+const LOCALE = 'en-US'
+
+describe('every field earns a label and a glyph', () => {
+  it('names all thirteen fields, so a new one cannot render unlabelled', () => {
+    for (const field of endeavorFields) {
+      expect(fieldLabel(field).length).toBeGreaterThan(0)
+      expect(fieldIcon(field).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('uses canon\'s own words where they differ from the domain name', () => {
+    expect(fieldLabel(EndeavorField.sessionPoints)).toBe('Reward')
+    expect(fieldLabel(EndeavorField.expiry)).toBe('Expires')
+  })
+
+  it('labels every tag with its human name rather than its wire letter', () => {
+    expect(tagLabel('O')).toBe('On Desk')
+    expect(tagLabel('E')).toBe('Engaging')
+  })
+})
+
+describe('an unset field says WHY it is blank', () => {
+  const sparse = makeEndeavor({
+    id: 'sparse',
+    title: 'Sparse',
+    kind: EndeavorKind.task,
+    status: EndeavorStatus.pending,
+  })
+
+  it('prints "No due date" rather than an em dash on an undated task', () => {
+    expect(fieldValue(sparse, EndeavorField.due, LOCALE)).toEqual({
+      kind: 'empty',
+      placeholder: 'No due date',
+    })
+  })
+
+  it('prints "Not rated" for an unscored value, not a zero-star rating', () => {
+    expect(fieldValue(sparse, EndeavorField.effort, LOCALE)).toEqual({
+      kind: 'empty',
+      placeholder: 'Not rated',
+    })
+  })
+
+  it('prints "Does not repeat" rather than an empty recurrence summary', () => {
+    expect(fieldValue(sparse, EndeavorField.repeatConfig, LOCALE)).toEqual({
+      kind: 'empty',
+      placeholder: 'Does not repeat',
+    })
+  })
+})
+
+describe('a set field is formatted, not dumped', () => {
+  it('renders status as a tinted, glyph-bearing chip — never bare text', () => {
+    const value = fieldValue(detailEndeavorMocks.task, EndeavorField.status, LOCALE)
+    expect(value.kind).toBe('chip')
+  })
+
+  it('renders a duration in the app\'s own "30m" spelling', () => {
+    expect(
+      fieldValue(detailEndeavorMocks.task, EndeavorField.duration, LOCALE),
+    ).toEqual({ kind: 'emphasis', text: '30m' })
+  })
+
+  it('renders a reward with its unit, so a bare 8 cannot read as an hour', () => {
+    expect(
+      fieldValue(detailEndeavorMocks.task, EndeavorField.sessionPoints, LOCALE),
+    ).toEqual({ kind: 'emphasis', text: '8 pts' })
+  })
+
+  it('formats a date through the reader\'s locale, not a pinned one', () => {
+    const value = fieldValue(detailEndeavorMocks.task, EndeavorField.due, 'de-DE')
+    expect(value).toMatchObject({ kind: 'text' })
+    if (value.kind === 'text') {
+      expect(value.text).toBe(detailDateTime(detailEndeavorMocks.task.due!, 'de-DE'))
+    }
+  })
+})
+
+describe('the associated colour', () => {
+  it('accepts a six-digit hex and prints it uppercased', () => {
+    const coloured = { ...detailEndeavorMocks.task, associatedColor: '#2a9d8f' }
+    expect(fieldValue(coloured, EndeavorField.associatedColor, LOCALE)).toEqual({
+      kind: 'text',
+      text: '#2A9D8F',
+    })
+  })
+
+  it('expands a three-digit shorthand the way canon does', () => {
+    expect(normalizedHex('#0f8')).toBe('#00ff88')
+  })
+
+  it('refuses a malformed value rather than painting a black swatch', () => {
+    expect(normalizedHex('nope')).toBeNull()
+    const broken = { ...detailEndeavorMocks.task, associatedColor: 'nope' }
+    expect(
+      fieldValue(broken, EndeavorField.associatedColor, LOCALE),
+    ).toEqual({ kind: 'empty', placeholder: 'No color' })
+  })
+})
+
+describe('the recurrence summary reads as a sentence', () => {
+  it('names the weekdays in Monday-first order, whatever order they were set in', () => {
+    const config = makeRepeatConfig(
+      weeklyBase([WeekDay.friday, WeekDay.monday, WeekDay.wednesday]),
+    )
+    expect(repeatSummary(config)).toBe('Weekly on Mon, Wed, Fri')
+  })
+
+  it('appends the multiplier only when it is more than every occurrence', () => {
+    expect(repeatSummary(makeRepeatConfig(monthlyBase(1)))).toBe(
+      'Monthly on day 1',
+    )
+    expect(repeatSummary(makeRepeatConfig(monthlyBase(1), 2))).toBe(
+      'Monthly on day 1, every 2 months',
+    )
+  })
+
+  it('degrades a weekly rule with no days chosen to plain "Weekly"', () => {
+    expect(repeatSummary(makeRepeatConfig(weeklyBase([])))).toBe('Weekly')
+  })
+
+  it('spells a yearly rule with a short month name', () => {
+    expect(
+      repeatSummary(makeRepeatConfig({ type: 'yearly', day: 3, month: Month.july })),
+    ).toBe('Yearly on Jul 3')
+  })
+})
+
+describe('the relation cards', () => {
+  it('labels and subtitles all four relations', () => {
+    for (const relation of [
+      EndeavorRelation.performances,
+      EndeavorRelation.defers,
+      EndeavorRelation.hosts,
+      EndeavorRelation.shadows,
+    ]) {
+      expect(relationLabel(relation).length).toBeGreaterThan(0)
+      expect(relationSubtitle(relation).length).toBeGreaterThan(0)
+      expect(relationIcon(relation).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('counts sessions in words, singular included', () => {
+    const one = {
+      ...detailEndeavorMocks.task,
+      performances: [
+        makePerform({
+          date: new Date(2026, 5, 18, 9),
+          duration: 600,
+          resolution: PerformResolution.complete,
+        }),
+      ],
+    }
+    expect(relationSummary(one, EndeavorRelation.performances)).toEqual({
+      kind: 'text',
+      text: '1 session logged',
+    })
+  })
+
+  it('renders attached hosts as chips, so Detail and the Hosts screen agree', () => {
+    const value = relationSummary(detailEndeavorMocks.task, EndeavorRelation.hosts)
+    expect(value.kind).toBe('chips')
+  })
+
+  it('says "Never deferred" rather than showing an empty history', () => {
+    expect(relationSummary(detailEndeavorMocks.task, EndeavorRelation.defers)).toEqual(
+      { kind: 'empty', placeholder: 'Never deferred' },
+    )
+  })
+})
+
+describe('the header chips', () => {
+  it('always leads with the status, whatever else is set', () => {
+    expect(headerChips(detailEndeavorMocks.habit)[0]?.id).toBe('status')
+  })
+
+  it('adds duration, reward and repeats only when they are set', () => {
+    const ids = headerChips(detailEndeavorMocks.task).map((chip) => chip.id)
+    expect(ids).toContain('duration')
+    expect(ids).toContain('reward')
+    expect(ids).not.toContain('repeats')
+  })
+
+  it('stays compact on a sparse endeavor rather than showing placeholders', () => {
+    expect(headerChips(detailEndeavorMocks.blueprint)).toHaveLength(1)
+  })
+})
+
+describe('the relation row projections', () => {
+  const performance = makePerform({
+    date: new Date(2026, 5, 18, 9),
+    duration: 1500,
+    resolution: PerformResolution.aborted,
+    rewardPoints: 0,
+  })
+
+  it('leads a performance row with its resolution — the fact a log is scanned for', () => {
+    expect(performanceChips(performance)[0]).toMatchObject({
+      id: 'resolution',
+      title: 'Aborted',
+    })
+  })
+
+  it('totals the log so the header answers "how much" without adding up rows', () => {
+    const chips = performanceSummaryChips([performance, performance])
+    expect(chips.map((chip) => chip.title)).toEqual(['2 sessions', '50m', '0 pts'])
+  })
+
+  it('names every resolution in canon\'s words', () => {
+    expect(resolutionLabel(PerformResolution.finished)).toBe('Finished early')
+  })
+
+  it('falls back to the source identifier when a shadow has no title', () => {
+    const shadow = makeShadow({
+      originalTitle: '  ',
+      sourceIdentifier: 'gcal-9',
+      kind: EndeavorKind.calendarEvent,
+      source: 'googleCalendar',
+    })
+    expect(shadowTitle(shadow)).toBe('gcal-9')
+    expect(shadowChips(shadow).map((chip) => chip.id)).toEqual(['source', 'kind'])
+  })
+
+  it('adds the group chip only when the shadow carries one', () => {
+    const shadow = makeShadow({
+      originalTitle: 'Team sync',
+      sourceIdentifier: 'gcal-1',
+      kind: EndeavorKind.calendarEvent,
+      source: 'googleCalendar',
+      group: 'Work',
+    })
+    expect(shadowChips(shadow).map((chip) => chip.id)).toContain('group')
+  })
+
+  it('heads a defer row with the date it was pushed TO, not when it was made', () => {
+    const target = new Date(2026, 5, 20, 9)
+    expect(deferTitle({ made: new Date(2026, 5, 18), reason: null, target }, LOCALE)).toBe(
+      detailDateTime(target, LOCALE),
+    )
+  })
+})

--- a/packages/app/src/features/endeavorDetail/pages/__tests__/overlayCascade.test.ts
+++ b/packages/app/src/features/endeavorDetail/pages/__tests__/overlayCascade.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The one property the Detail overlay cannot assert from jsdom.
+ *
+ * `DetailOverlays` presents through the design system's `Sheet` and `Dialog`,
+ * both of which are `kro-glass` **and** ask for `fixed` positioning with a
+ * Tailwind utility. Unlayered CSS beats layered CSS, Tailwind emits every
+ * utility inside `@layer utilities`, and `.kro-glass` sets `position: relative`
+ * — so while `glass.css` was imported unlayered, every glass overlay in the app
+ * rendered **inline in the document flow** instead of over it.
+ *
+ * jsdom applies no stylesheets, so no render test could see that: the sheet
+ * mounted, announced itself as a dialog, and was still in the wrong place. It
+ * took a production build with a real browser to surface it, which is exactly
+ * the gap `UZF-26`'s visual evidence exists to close.
+ *
+ * The fix is one word in `styles.css` (`layer(components)`), and this is its
+ * regression guard — read from the stylesheet on disk, the same way the design
+ * system's own contrast suite reads `tokens.css`, because the property is a
+ * fact about the CSS rather than about any component.
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const STYLES = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../design/system/styles.css',
+)
+
+const source = readFileSync(STYLES, 'utf8')
+
+/** Only the `@import` lines — the header prose names the same files. */
+const imports = source
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line.startsWith('@import'))
+
+describe('the glass material must lose to a utility on the same element', () => {
+  it('imports glass.css into a cascade layer, so `fixed` can beat `relative`', () => {
+    const glass = imports.find((line) => line.includes('glass.css'))
+    expect(glass).toBeDefined()
+    expect(glass).toContain('layer(components)')
+  })
+
+  it('puts it in `components`, which Tailwind orders BEFORE `utilities`', () => {
+    const glass = imports.find((line) => line.includes('glass.css')) ?? ''
+    // `layer(utilities)` would tie with Tailwind's own utilities and resolve by
+    // source order — a coin flip. `components` is the layer Tailwind declares
+    // for exactly this: a default a utility may override.
+    expect(glass).toMatch(/layer\(components\)/)
+    expect(glass).not.toMatch(/layer\(utilities\)/)
+  })
+
+  it('leaves the token declarations unlayered — no utility competes with them', () => {
+    const tokens = imports.find((line) => line.includes('tokens.css'))
+    expect(tokens).toBeDefined()
+    expect(tokens).not.toContain('layer(')
+  })
+})
+
+describe('the glass rules this depends on are still there', () => {
+  const glassSource = readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      '../../../../design/system/glass/glass.css',
+    ),
+    'utf8',
+  )
+
+  it('still sets the position a `fixed` overlay has to override', () => {
+    // If this ever stops being true the layer is harmless; if it silently
+    // becomes `position: fixed` the overlays would break the other way, so the
+    // assertion names what the layering is FOR.
+    expect(glassSource).toMatch(/\.kro-glass\s*\{[^}]*position:\s*relative/)
+  })
+
+  it('still sets the radius a sheet overrides for its top-only corners', () => {
+    expect(glassSource).toMatch(/\.kro-glass\s*\{[^}]*border-radius:/)
+  })
+})

--- a/packages/app/src/features/endeavorDetail/pages/endeavorDetailDisplay.ts
+++ b/packages/app/src/features/endeavorDetail/pages/endeavorDetailDisplay.ts
@@ -1,0 +1,646 @@
+/**
+ * The Detail read surface's display mapping — the port of
+ * `KroUI/EndeavorDetail/Endeavor+DetailDisplay.swift`.
+ *
+ * One field, one label, one glyph, one `PropertyRowValue`. Canon keeps this
+ * local to the Detail surface rather than in a shared `Endeavor+UI`, and the
+ * reason transfers exactly: these are *this* surface's presentation choices —
+ * Edit formats the same properties as editable controls, and the two must be
+ * free to differ.
+ *
+ * Everything here is pure and React-free, so the whole mapping is unit-tested
+ * without mounting a surface. `#29`'s tier deliberately formats nothing ("a
+ * duration is seconds and a status is a status; turning either into a string is
+ * `#30`'s, because this tier has no locale"), which is precisely this file.
+ *
+ * ## Dates take their locale as an argument
+ *
+ * Canon pins `en_US_POSIX` on the formatter and leaves the time zone at the
+ * system default. The web can do better on the first half — `Intl` already
+ * knows the reader's locale — so `locale` is a parameter that defaults to the
+ * runtime's, which is the same call the merged kit's `formatting.ts` made and
+ * for the same reason: a `de-DE` browser printing "Jul 22, 2026" beside German
+ * chrome is a bug the iOS app cannot have.
+ *
+ * ## Five SF Symbols canon names that neither symbol map carries
+ *
+ * `textformat`, `circle.lefthalf.filled`, `star.fill`, `flame.fill` and
+ * `folder` are in neither `system/icons/icons.ts` nor the endeavor kit's map,
+ * and both are merged lanes this issue does not own. Each row below therefore
+ * carries the nearest mapped neighbour and names canon's own symbol beside it,
+ * exactly as `findPresentation` does for the two empty states. Folding the real
+ * rows upstream is a one-line-per-row follow-up.
+ */
+import {
+  type Defer,
+  type Endeavor,
+  EndeavorField,
+  type EndeavorHost,
+  EndeavorRelation,
+  type EndeavorTag,
+  type Perform,
+  PerformResolution,
+  type RepeatConfig,
+  type Shadow,
+  type WeekDay,
+  type Month,
+  assertNever,
+  endeavorHostDisplayName,
+  weekDays,
+} from '@kro/core'
+import type {
+  PropertyRowChip,
+  PropertyRowValue,
+} from '../../../design/endeavor/PropertyRow'
+import { type ChipTint, colorTint, semanticTint } from '../../../design/endeavor/KroChip'
+import type { KitSymbolName } from '../../../design/endeavor/endeavorIcons'
+import {
+  hostGlyph,
+  hostTint,
+  kindGlyph,
+  kindShortLabel,
+  kindTint,
+  statusGlyph,
+  statusShortLabel,
+  statusTint,
+} from '../../../design/endeavor/endeavorProjections'
+import { formatDuration } from '../../../design/endeavor/formatting'
+
+/* ------------------------------------------------------------------------ */
+/* Fields                                                                    */
+/* ------------------------------------------------------------------------ */
+
+/** `EndeavorField.detailLabel`, verbatim. */
+export const fieldLabel = (field: EndeavorField): string => {
+  switch (field) {
+    case EndeavorField.title:
+      return 'Title'
+    case EndeavorField.status:
+      return 'Status'
+    case EndeavorField.due:
+      return 'Due'
+    case EndeavorField.start:
+      return 'Start'
+    case EndeavorField.duration:
+      return 'Duration'
+    case EndeavorField.sessionPoints:
+      return 'Reward'
+    case EndeavorField.value:
+      return 'Value'
+    case EndeavorField.effort:
+      return 'Effort'
+    case EndeavorField.expiry:
+      return 'Expires'
+    case EndeavorField.tags:
+      return 'Tags'
+    case EndeavorField.associatedColor:
+      return 'Color'
+    case EndeavorField.project:
+      return 'Project'
+    case EndeavorField.repeatConfig:
+      return 'Repeats'
+    default:
+      return assertNever(field)
+  }
+}
+
+/**
+ * `EndeavorField.detailIcon`. Five rows carry a substitute; canon's own symbol
+ * is named in the comment beside each, per the header note.
+ */
+export const fieldIcon = (field: EndeavorField): KitSymbolName => {
+  switch (field) {
+    case EndeavorField.title:
+      return 'pencil' // canon: textformat
+    case EndeavorField.status:
+      return 'circle' // canon: circle.lefthalf.filled
+    case EndeavorField.due:
+      return 'calendar'
+    case EndeavorField.start:
+      return 'clock'
+    case EndeavorField.duration:
+      return 'timer'
+    case EndeavorField.sessionPoints:
+      return 'bolt.fill'
+    case EndeavorField.value:
+      return 'star' // canon: star.fill
+    case EndeavorField.effort:
+      return 'target' // canon: flame.fill
+    case EndeavorField.expiry:
+      return 'hourglass'
+    case EndeavorField.tags:
+      return 'tag'
+    case EndeavorField.associatedColor:
+      return 'paintpalette'
+    case EndeavorField.project:
+      return 'checklist' // canon: folder
+    case EndeavorField.repeatConfig:
+      return 'repeat'
+    default:
+      return assertNever(field)
+  }
+}
+
+/** `Endeavor.Tag.detailLabel`, verbatim. */
+export const tagLabel = (tag: EndeavorTag): string => {
+  switch (tag) {
+    case 'O':
+      return 'On Desk'
+    case 'D':
+      return 'During Performance'
+    case 'S':
+      return 'Session'
+    case 'R':
+      return 'Replica'
+    case 'P':
+      return 'Passive'
+    case 'E':
+      return 'Engaging'
+    default:
+      return assertNever(tag)
+  }
+}
+
+/**
+ * The medium-date/short-time string canon prints, in the reader's locale.
+ * Exported because both the Detail rows and the relation screens' row dates use
+ * it, and two copies of a date format drift.
+ */
+export const detailDateTime = (date: Date, locale?: string): string =>
+  new Intl.DateTimeFormat(locale, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+
+/** Canon's `WeekDay.detailShortName` — "Mon", "Tue", … Exported so the Edit
+ *  form's weekday toggles and the recurrence summary read the same three
+ *  letters; two spellings of a weekday is exactly the drift this avoids. */
+export const WEEKDAY_SHORT: Readonly<Record<WeekDay, string>> = {
+  monday: 'Mon',
+  tuesday: 'Tue',
+  wednesday: 'Wed',
+  thursday: 'Thu',
+  friday: 'Fri',
+  saturday: 'Sat',
+  sunday: 'Sun',
+}
+
+const MONTH_SHORT: Readonly<Record<Month, string>> = {
+  1: 'Jan',
+  2: 'Feb',
+  3: 'Mar',
+  4: 'Apr',
+  5: 'May',
+  6: 'Jun',
+  7: 'Jul',
+  8: 'Aug',
+  9: 'Sep',
+  10: 'Oct',
+  11: 'Nov',
+  12: 'Dec',
+}
+
+/**
+ * `RepeatConfig.detailSummary` — "Daily", "Weekly on Mon, Wed, Fri",
+ * "Monthly on day 1", plus the `every N units` suffix when `everyOther > 1`.
+ *
+ * Weekdays are ordered by `weekDays` (canon's Monday-first declaration order)
+ * rather than by the set's own iteration order, which is canon's `detailOrder`
+ * sort expressed as a lookup instead of a comparator.
+ */
+export const repeatSummary = (config: RepeatConfig): string => {
+  const base = config.base
+  let description: string
+  let unit: string
+  switch (base.type) {
+    case 'daily':
+      description = 'Daily'
+      unit = 'day'
+      break
+    case 'weekly': {
+      const names = weekDays
+        .filter((day) => base.weekdays.includes(day))
+        .map((day) => WEEKDAY_SHORT[day])
+      description =
+        names.length === 0 ? 'Weekly' : `Weekly on ${names.join(', ')}`
+      unit = 'week'
+      break
+    }
+    case 'monthly':
+      description = `Monthly on day ${base.day}`
+      unit = 'month'
+      break
+    case 'yearly':
+      description = `Yearly on ${MONTH_SHORT[base.month]} ${base.day}`
+      unit = 'year'
+      break
+    default:
+      return assertNever(base)
+  }
+  return config.everyOther > 1
+    ? `${description}, every ${config.everyOther} ${unit}s`
+    : description
+}
+
+/**
+ * `Endeavor.detailValue(for:)` — every case handled explicitly, no `default`,
+ * so a new field earns a deliberate display choice rather than a blank row.
+ */
+export const fieldValue = (
+  endeavor: Endeavor,
+  field: EndeavorField,
+  locale?: string,
+): PropertyRowValue => {
+  switch (field) {
+    case EndeavorField.title:
+      return { kind: 'text', text: endeavor.title }
+    case EndeavorField.status:
+      return {
+        kind: 'chip',
+        title: statusShortLabel(endeavor.status),
+        icon: statusGlyph(endeavor.status),
+        tint: semanticTint(statusTint(endeavor.status)),
+      }
+    case EndeavorField.due:
+      return endeavor.due === null
+        ? { kind: 'empty', placeholder: 'No due date' }
+        : { kind: 'text', text: detailDateTime(endeavor.due, locale) }
+    case EndeavorField.start:
+      return endeavor.start === null
+        ? { kind: 'empty', placeholder: 'No start time' }
+        : { kind: 'text', text: detailDateTime(endeavor.start, locale) }
+    case EndeavorField.duration:
+      return endeavor.duration === null
+        ? { kind: 'empty', placeholder: 'No duration set' }
+        : { kind: 'emphasis', text: formatDuration(endeavor.duration) }
+    case EndeavorField.sessionPoints:
+      return endeavor.sessionPoints === null
+        ? { kind: 'empty', placeholder: 'No reward set' }
+        : { kind: 'emphasis', text: `${endeavor.sessionPoints} pts` }
+    case EndeavorField.value:
+      return endeavor.value === null
+        ? { kind: 'empty', placeholder: 'Not rated' }
+        : { kind: 'rating', value: endeavor.value, outOf: 5, symbol: 'star' }
+    case EndeavorField.effort:
+      return endeavor.effort === null
+        ? { kind: 'empty', placeholder: 'Not rated' }
+        : { kind: 'rating', value: endeavor.effort, outOf: 5, symbol: 'target' }
+    case EndeavorField.expiry:
+      return endeavor.expiry === null
+        ? { kind: 'empty', placeholder: 'No expiry' }
+        : { kind: 'text', text: detailDateTime(endeavor.expiry, locale) }
+    case EndeavorField.tags:
+      return { kind: 'tags', tags: (endeavor.tags ?? []).map(tagLabel) }
+    case EndeavorField.associatedColor: {
+      const hex = normalizedHex(endeavor.associatedColor)
+      /*
+        Canon draws a bordered swatch filled with the endeavor's own stored
+        hex. `PropertyRowValue`'s `tint` case takes a `ChipTint`, which is a
+        design-system token ROLE by construction — deliberately, so no caller
+        can paint a colour that was never contrast-measured — and there is no
+        token for "whatever the user picked". Rather than fork `PropertyRow`
+        (a merged lane) or invent a second swatch, the row prints the
+        normalized hex and the Detail header still carries the endeavor's
+        identity through its kind chip. Named in the PR body as a cross-lane
+        follow-up for whichever child next opens `PropertyRow`.
+      */
+      return hex === null
+        ? { kind: 'empty', placeholder: 'No color' }
+        : { kind: 'text', text: hex.toUpperCase() }
+    }
+    case EndeavorField.project: {
+      const title = endeavor.list?.title.trim() ?? ''
+      return title.length === 0
+        ? { kind: 'empty', placeholder: 'No project' }
+        : { kind: 'text', text: title }
+    }
+    case EndeavorField.repeatConfig:
+      return endeavor.repeatConfig === null
+        ? { kind: 'empty', placeholder: 'Does not repeat' }
+        : { kind: 'text', text: repeatSummary(endeavor.repeatConfig) }
+    default:
+      return assertNever(field)
+  }
+}
+
+/**
+ * Canon's `Color(detailHex:)` guard, kept as a validity check: three or six hex
+ * digits with an optional `#`. `null` for anything else, so a malformed stored
+ * colour reads as "No color" rather than as a black swatch.
+ */
+export const normalizedHex = (raw: string | null): string | null => {
+  if (raw === null) return null
+  const value = raw.trim().replace(/^#+/, '')
+  const expanded =
+    value.length === 3
+      ? [...value].map((digit) => `${digit}${digit}`).join('')
+      : value
+  return /^[0-9a-fA-F]{6}$/.test(expanded) ? `#${expanded}` : null
+}
+
+/* ------------------------------------------------------------------------ */
+/* Relations                                                                 */
+/* ------------------------------------------------------------------------ */
+
+/** `EndeavorRelation.detailLabel`, verbatim. */
+export const relationLabel = (relation: EndeavorRelation): string => {
+  switch (relation) {
+    case EndeavorRelation.performances:
+      return 'Performances'
+    case EndeavorRelation.defers:
+      return 'Defers'
+    case EndeavorRelation.hosts:
+      return 'Hosts'
+    case EndeavorRelation.shadows:
+      return 'Shadows'
+    default:
+      return assertNever(relation)
+  }
+}
+
+/** `EndeavorRelation.detailIcon`, with the substitutions the header names. */
+export const relationIcon = (relation: EndeavorRelation): KitSymbolName => {
+  switch (relation) {
+    case EndeavorRelation.performances:
+      return 'clock.arrow.circlepath'
+    case EndeavorRelation.defers:
+      return 'arrow.uturn.forward.circle' // canon: arrow.uturn.right
+    case EndeavorRelation.hosts:
+      return 'network' // canon: antenna.radiowaves.left.and.right
+    case EndeavorRelation.shadows:
+      return 'square.and.arrow.down' // canon: square.on.square
+    default:
+      return assertNever(relation)
+  }
+}
+
+/** The relation screen's intro subtitle — canon's `ScreenIntroHeader` copy. */
+export const relationSubtitle = (relation: EndeavorRelation): string => {
+  switch (relation) {
+    case EndeavorRelation.performances:
+      return 'Every session logged against this endeavor.'
+    case EndeavorRelation.defers:
+      return "Every time this endeavor's due date was pushed back."
+    case EndeavorRelation.hosts:
+      return 'The external providers this endeavor is mirrored to.'
+    case EndeavorRelation.shadows:
+      return 'Where this endeavor was mirrored from an external source.'
+    default:
+      return assertNever(relation)
+  }
+}
+
+/** `Endeavor.detailSummary(for:)` — the one-line summary a Detail card shows. */
+export const relationSummary = (
+  endeavor: Endeavor,
+  relation: EndeavorRelation,
+): PropertyRowValue => {
+  switch (relation) {
+    case EndeavorRelation.performances: {
+      const count = endeavor.performances.length
+      return count === 0
+        ? { kind: 'empty', placeholder: 'No sessions logged' }
+        : {
+            kind: 'text',
+            text: count === 1 ? '1 session logged' : `${count} sessions logged`,
+          }
+    }
+    case EndeavorRelation.defers: {
+      const count = endeavor.defers.length
+      return count === 0
+        ? { kind: 'empty', placeholder: 'Never deferred' }
+        : {
+            kind: 'text',
+            text: count === 1 ? 'Deferred once' : `Deferred ${count} times`,
+          }
+    }
+    case EndeavorRelation.hosts:
+      return endeavor.hostedBy.length === 0
+        ? { kind: 'empty', placeholder: 'Not synced' }
+        : { kind: 'chips', chips: endeavor.hostedBy.map(hostChip) }
+    case EndeavorRelation.shadows: {
+      const count = endeavor.shadows?.length ?? 0
+      return count === 0
+        ? { kind: 'empty', placeholder: 'No external mirrors' }
+        : {
+            kind: 'text',
+            text:
+              count === 1 ? '1 external mirror' : `${count} external mirrors`,
+          }
+    }
+    default:
+      return assertNever(relation)
+  }
+}
+
+/** One host, as the tinted chip both Detail and the Hosts screen draw. */
+export const hostChip = (host: EndeavorHost): PropertyRowChip => ({
+  id: host,
+  title: endeavorHostDisplayName(host),
+  icon: hostGlyph(host),
+  tint: semanticTint(hostTint(host)),
+})
+
+/* ------------------------------------------------------------------------ */
+/* Header chips                                                              */
+/* ------------------------------------------------------------------------ */
+
+/**
+ * The header's at-a-glance facts, in canon's order and with canon's rule:
+ * status is always present, the rest only when set, so a sparse endeavor gets a
+ * compact header rather than a row of placeholders.
+ *
+ * The **kind** is not here — canon draws it above the title as a prominent
+ * chip, and `#29`'s `detailHeaderBadges` already leads with it. This is the
+ * second row.
+ */
+export const headerChips = (endeavor: Endeavor): readonly PropertyRowChip[] => {
+  const chips: PropertyRowChip[] = [
+    {
+      id: 'status',
+      title: statusShortLabel(endeavor.status),
+      icon: statusGlyph(endeavor.status),
+      tint: semanticTint(statusTint(endeavor.status)),
+    },
+  ]
+  if (endeavor.duration !== null) {
+    chips.push({
+      id: 'duration',
+      title: formatDuration(endeavor.duration),
+      icon: 'timer',
+      tint: semanticTint('chipNeutral'),
+    })
+  }
+  if (endeavor.sessionPoints !== null && endeavor.sessionPoints > 0) {
+    chips.push({
+      id: 'reward',
+      title: `${endeavor.sessionPoints} pts`,
+      icon: 'bolt.fill',
+      tint: colorTint('badgeOrange'),
+    })
+  }
+  if (endeavor.repeatConfig !== null) {
+    chips.push({
+      id: 'repeats',
+      title: 'Repeats',
+      icon: 'repeat',
+      tint: colorTint('badgePurple'),
+    })
+  }
+  return chips
+}
+
+/** The prominent kind chip canon leads the header with. */
+export const kindChip = (endeavor: Endeavor): PropertyRowChip => ({
+  id: 'kind',
+  title: kindShortLabel(endeavor.kind),
+  icon: kindGlyph(endeavor.kind),
+  tint: semanticTint(kindTint(endeavor.kind)),
+})
+
+/* ------------------------------------------------------------------------ */
+/* Relation rows                                                             */
+/* ------------------------------------------------------------------------ */
+
+/** Canon's `resolutionTitle`. */
+export const resolutionLabel = (resolution: PerformResolution): string => {
+  switch (resolution) {
+    case PerformResolution.complete:
+      return 'Complete'
+    case PerformResolution.aborted:
+      return 'Aborted'
+    case PerformResolution.finished:
+      return 'Finished early'
+    default:
+      return assertNever(resolution)
+  }
+}
+
+/** Canon's `resolutionGlyph`, with `xmark`/`flag` standing in for the two fills. */
+export const resolutionIcon = (
+  resolution: PerformResolution,
+): KitSymbolName => {
+  switch (resolution) {
+    case PerformResolution.complete:
+      return 'checkmark.circle.fill'
+    case PerformResolution.aborted:
+      return 'xmark' // canon: xmark.circle.fill
+    case PerformResolution.finished:
+      return 'flag' // canon: flag.checkered
+    default:
+      return assertNever(resolution)
+  }
+}
+
+/** Canon's `resolutionTint`, as contrast-verified badge roles. */
+export const resolutionTint = (resolution: PerformResolution): ChipTint => {
+  switch (resolution) {
+    case PerformResolution.complete:
+      return colorTint('badgeGreen')
+    case PerformResolution.aborted:
+      return colorTint('badgeRed')
+    case PerformResolution.finished:
+      return colorTint('badgeBlue')
+    default:
+      return assertNever(resolution)
+  }
+}
+
+/** Canon's `rowChips` — resolution, duration, reward, for one performance. */
+export const performanceChips = (
+  performance: Perform,
+): readonly PropertyRowChip[] => [
+  {
+    id: 'resolution',
+    title: resolutionLabel(performance.resolution),
+    icon: resolutionIcon(performance.resolution),
+    tint: resolutionTint(performance.resolution),
+  },
+  {
+    id: 'duration',
+    title: formatDuration(performance.duration),
+    icon: 'timer',
+    tint: semanticTint('chipNeutral'),
+  },
+  {
+    id: 'points',
+    title: `${performance.rewardPoints} pts`,
+    icon: 'bolt.fill',
+    tint: colorTint('badgeOrange'),
+  },
+]
+
+/** Canon's `summaryChips` — sessions, total time, total points. */
+export const performanceSummaryChips = (
+  performances: readonly Perform[],
+): readonly PropertyRowChip[] => {
+  const totalDuration = performances.reduce(
+    (total, entry) => total + entry.duration,
+    0,
+  )
+  const totalPoints = performances.reduce(
+    (total, entry) => total + entry.rewardPoints,
+    0,
+  )
+  return [
+    {
+      id: 'sessions',
+      title:
+        performances.length === 1
+          ? '1 session'
+          : `${performances.length} sessions`,
+      icon: 'checklist', // canon: list.bullet
+      tint: semanticTint('chipNeutral'),
+    },
+    {
+      id: 'time',
+      title: formatDuration(totalDuration),
+      icon: 'timer',
+      tint: colorTint('badgeTeal'),
+    },
+    {
+      id: 'points',
+      title: `${totalPoints} pts`,
+      icon: 'bolt.fill',
+      tint: colorTint('badgeOrange'),
+    },
+  ]
+}
+
+/** Canon's `shadowChips` — source, kind, and the group when it has one. */
+export const shadowChips = (shadow: Shadow): readonly PropertyRowChip[] => {
+  const chips: PropertyRowChip[] = [
+    {
+      id: 'source',
+      title: shadow.source,
+      icon: 'arrow.down.circle', // canon: arrow.down.left.circle
+      tint: colorTint('badgeTeal'),
+    },
+    {
+      id: 'kind',
+      title: kindShortLabel(shadow.kind),
+      icon: kindGlyph(shadow.kind),
+      tint: semanticTint(kindTint(shadow.kind)),
+    },
+  ]
+  const group = shadow.group
+  if (group !== null && group.length > 0) {
+    chips.push({
+      id: 'group',
+      title: group,
+      icon: 'checklist', // canon: folder
+      tint: semanticTint('chipNeutral'),
+    })
+  }
+  return chips
+}
+
+/** Canon's `shadowTitle` — the mirrored title, or its source identifier. */
+export const shadowTitle = (shadow: Shadow): string =>
+  shadow.originalTitle.trim().length === 0
+    ? shadow.sourceIdentifier
+    : shadow.originalTitle
+
+/** Canon's defer row heading: the date the endeavor was pushed to. */
+export const deferTitle = (entry: Defer, locale?: string): string =>
+  detailDateTime(entry.target, locale)

--- a/packages/app/src/features/endeavorDetail/pages/index.ts
+++ b/packages/app/src/features/endeavorDetail/pages/index.ts
@@ -1,0 +1,55 @@
+/**
+ * The Endeavor Detail render tier's public surface — a pure re-export barrel.
+ *
+ * `apps/web` imports exactly one name from here: `DetailOverlays`, which the
+ * shell mounts once beside its content.
+ */
+export {
+  DETAIL_INTENT_OPERATIONS,
+  type DetailIntentRequest,
+  selectDetailIntentRequest,
+} from './DetailOverlaySelectors'
+export { type DetailOverlaysProps, DetailOverlays } from './DetailOverlays'
+export {
+  HIDDEN_SCROLLBAR_STYLE,
+  type EndeavorDetailFragmentProps,
+  EndeavorDetailFragment,
+} from './EndeavorDetailFragment'
+export {
+  DURATION_MAX_SECONDS,
+  type EndeavorDurationFragmentProps,
+  EndeavorDurationFragment,
+} from './EndeavorDurationFragment'
+export {
+  type EndeavorEditFragmentProps,
+  EndeavorEditFragment,
+} from './EndeavorEditFragment'
+export {
+  type EndeavorRelationFragmentProps,
+  EndeavorRelationFragment,
+  relationEntryFromDraft,
+} from './EndeavorRelationFragment'
+export {
+  deferTitle,
+  detailDateTime,
+  fieldIcon,
+  fieldLabel,
+  fieldValue,
+  headerChips,
+  hostChip,
+  kindChip,
+  normalizedHex,
+  performanceChips,
+  performanceSummaryChips,
+  relationIcon,
+  relationLabel,
+  relationSubtitle,
+  relationSummary,
+  repeatSummary,
+  resolutionIcon,
+  resolutionLabel,
+  resolutionTint,
+  shadowChips,
+  shadowTitle,
+  tagLabel,
+} from './endeavorDetailDisplay'

--- a/packages/app/src/features/find/pages/FindCapabilitiesProducer.ts
+++ b/packages/app/src/features/find/pages/FindCapabilitiesProducer.ts
@@ -1,0 +1,73 @@
+/**
+ * The one Service read the two browsing surfaces need before they can install a
+ * vista: which feature flags are enabled (`RC-3`, `RC-6`, `RC-7`, `RC-25`).
+ *
+ * ## Why this exists at all
+ *
+ * `#29`'s `onViewLoaded` takes `enabledFlags` as an argument — deliberately, so
+ * capability gating stays a pure Selector read and no Selector ever reaches for
+ * a flag service. That leaves somebody to *supply* the list, and a Page cannot:
+ * a Service reaches a Producer through `extra` and nowhere else (`RC-6`). So
+ * this is that Producer. It reads `extra.featureFlags`, hands back the enabled
+ * names, and the Page dispatches the plain `onViewLoaded` event with them —
+ * the same "resolve through a Producer, then dispatch a named event" shape
+ * `MainShellPage` already uses for the capture route hand-off.
+ *
+ * ## No reducer arm, on purpose
+ *
+ * Nothing in `findSlice` handles this thunk's three lifecycle actions, because
+ * there is nothing for them to change: the value's only consumer is the
+ * `onViewLoaded` payload the Page assembles from it. Adding arms would put the
+ * flag list in `State` twice — once here and once inside the surface it was
+ * installed on — and the second copy is the one that goes stale.
+ *
+ * ## A flag read that fails resolves to "nothing enabled"
+ *
+ * A capability whose flag cannot be resolved is simply not offered, which is
+ * the safe direction: the surface renders without the dark-launched gesture
+ * rather than refusing to render. That mirrors `restoreFindLensThunk`'s own
+ * rule — a preference that cannot be read is not a reason to show an error over
+ * a screen that works.
+ */
+import {
+  FeatureFlags,
+  type Result,
+  ok,
+} from '@kro/core'
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import type { ThunkExtra } from '../../../library/store'
+import type { FindException } from '../FindException'
+
+/**
+ * The flags a vista binding can wait on.
+ *
+ * One entry today — `endeavorDetail`, the flag every `viewDetail` tap binding
+ * in the registry declares. It is a list rather than a single boolean because
+ * `EndeavorCapabilities.requires` is a flag *name*, so a second gated binding
+ * needs a row here and nothing else.
+ */
+export const CAPABILITY_FLAGS = [FeatureFlags.endeavorDetail] as const
+
+/**
+ * The names of the capability flags that are currently enabled.
+ *
+ * Exactly the shape `FindState.enabledFlags` holds and
+ * `selectFindCapabilities` tests membership against.
+ */
+export const resolveCapabilityFlagsThunk = createAsyncThunk<
+  Result<readonly string[], FindException>,
+  void,
+  { extra: ThunkExtra }
+>('find/onCapabilityFlagsResolved', async (_unused, { extra }) => {
+  try {
+    return ok(
+      CAPABILITY_FLAGS.filter((flag) => extra.featureFlags.isEnabled(flag)).map(
+        (flag) => flag.name,
+      ),
+    )
+  } catch {
+    // See the header: an unreadable flag hides its capability, it never breaks
+    // the surface that was going to offer it.
+    return ok([])
+  }
+})

--- a/packages/app/src/features/find/pages/FindFragment.stories.tsx
+++ b/packages/app/src/features/find/pages/FindFragment.stories.tsx
@@ -1,0 +1,146 @@
+/**
+ * Find's visual evidence (`RC-11`, `UZF-26`).
+ *
+ * Every scene is built from `#29`'s `findEndeavorMocks` through the same
+ * adapter the Selector uses, so a story cannot show a list the slice could not
+ * produce. The set mirrors `FindFragment.test.tsx` 1:1 — the loaded list, each
+ * of the four empty states, the two input grammars, and both schemes.
+ */
+import { allFindEndeavorMocks, findEndeavorMocks } from '../FindMocks'
+import { FindFragment } from './FindFragment'
+import { BothSchemes, Stage } from '../../../design/endeavor/storyStage'
+import { adaptedRows, findCapabilitiesWith } from './__tests__/pagesHarness'
+
+const NOW = new Date(2026, 5, 18, 9, 40)
+const noop = () => {}
+
+const capabilities = findCapabilitiesWith()
+const detailCapabilities = findCapabilitiesWith(['endeavorDetail'])
+
+const base = {
+  query: '',
+  rows: adaptedRows(allFindEndeavorMocks, capabilities),
+  capabilities,
+  emptyState: null,
+  selectedKinds: ['task', 'calendarEvent', 'habit'] as const,
+  selectedHosts: ['local', 'supabase', 'googleCalendar'] as const,
+  selectedStatuses: ['pending', 'planned', 'ongoing'] as const,
+  showArchived: false,
+  visibleCount: allFindEndeavorMocks.length,
+  isLoading: false,
+  exception: null,
+  now: NOW,
+  locale: 'en-US',
+  onChangeQuery: noop,
+  onToggleFilter: noop,
+  onToggleShowArchived: noop,
+  onOperation: noop,
+  onOpenDetail: noop,
+  onDeleteAllVisible: noop,
+  onArchiveAllVisible: noop,
+  onRetry: noop,
+} as const
+
+export default {
+  title: 'Find/Find',
+  component: FindFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+/** Mixed rows, chips active — the scene acceptance criterion 1 is read against. */
+export const MixedRowsWithChips = {
+  render: () => (
+    <Stage width={430}>
+      <FindFragment {...base} input="touch" />
+    </Stage>
+  ),
+}
+
+/** The same list on a pointer surface: hover strip and context menu, no swipe. */
+export const PointerGrammar = {
+  render: () => (
+    <Stage width={880}>
+      <FindFragment {...base} input="pointer" capabilities={detailCapabilities} />
+    </Stage>
+  ),
+}
+
+/** A live search that matched nothing — canon's "No Results". */
+export const NoResults = {
+  render: () => (
+    <Stage width={430}>
+      <FindFragment
+        {...base}
+        query="zzzz"
+        rows={[]}
+        visibleCount={0}
+        emptyState={{ kind: 'noResults', query: 'zzzz' }}
+        input="touch"
+      />
+    </Stage>
+  ),
+}
+
+/** Every chip off — canon's "No Filters Selected", which is not "No Results". */
+export const NoFiltersSelected = {
+  render: () => (
+    <Stage width={430}>
+      <FindFragment
+        {...base}
+        rows={[]}
+        visibleCount={0}
+        selectedKinds={[]}
+        selectedHosts={[]}
+        selectedStatuses={[]}
+        emptyState={{ kind: 'noFilters' }}
+        input="touch"
+      />
+    </Stage>
+  ),
+}
+
+/** A first run: nothing fetched at all. */
+export const NoEndeavorsYet = {
+  render: () => (
+    <Stage width={430}>
+      <FindFragment
+        {...base}
+        rows={[]}
+        visibleCount={0}
+        emptyState={{ kind: 'noData' }}
+        input="touch"
+      />
+    </Stage>
+  ),
+}
+
+/** A failed refresh over rows that are still good — canon keeps the list. */
+export const FailedRefresh = {
+  render: () => (
+    <Stage width={430}>
+      <FindFragment
+        {...base}
+        rows={adaptedRows(
+          [findEndeavorMocks.morningTask, findEndeavorMocks.teamSync],
+          capabilities,
+        )}
+        visibleCount={2}
+        exception={{
+          kind: 'fetchFailed',
+          message: "Couldn't load your endeavors: offline",
+          recoverable: true,
+        }}
+        input="touch"
+      />
+    </Stage>
+  ),
+}
+
+/** Both schemes, so the chips and rows are judged in dark too. */
+export const BothColorSchemes = {
+  render: () => (
+    <BothSchemes>
+      <FindFragment {...base} input="touch" />
+    </BothSchemes>
+  ),
+}

--- a/packages/app/src/features/find/pages/FindFragment.test.tsx
+++ b/packages/app/src/features/find/pages/FindFragment.test.tsx
@@ -1,0 +1,358 @@
+/**
+ * Find's render tests, mirroring `FindFragment.stories.tsx` 1:1 (`RC-11`).
+ *
+ * The interaction half is here too, because these are the flows the issue names
+ * and none of them can be judged from a screenshot: the swipe grammar on touch,
+ * the hover/context grammar on pointer, and the ellipsis menu's two irreversible
+ * bulk operations.
+ */
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installPointerEvents } from '../../../design/endeavor/__tests__/pointerEnvironment'
+import { allFindEndeavorMocks, findEndeavorMocks } from '../FindMocks'
+import { FindFragment, type FindFragmentProps } from './FindFragment'
+import { adaptedRows, findCapabilitiesWith } from './__tests__/pagesHarness'
+
+const NOW = new Date(2026, 5, 18, 9, 40)
+const capabilities = findCapabilitiesWith()
+
+let pointerEnvironment: () => void
+
+beforeEach(() => {
+  pointerEnvironment = installPointerEvents()
+})
+
+afterEach(() => {
+  cleanup()
+  pointerEnvironment()
+})
+
+const props = (
+  overrides: Partial<FindFragmentProps> = {},
+): FindFragmentProps => ({
+  query: '',
+  rows: adaptedRows(allFindEndeavorMocks, capabilities),
+  capabilities,
+  emptyState: null,
+  selectedKinds: ['task', 'calendarEvent', 'habit'],
+  selectedHosts: ['local', 'supabase', 'googleCalendar'],
+  selectedStatuses: ['pending', 'planned', 'ongoing'],
+  showArchived: false,
+  visibleCount: allFindEndeavorMocks.length,
+  isLoading: false,
+  exception: null,
+  now: NOW,
+  locale: 'en-US',
+  input: 'touch',
+  onChangeQuery: () => {},
+  onToggleFilter: () => {},
+  onToggleShowArchived: () => {},
+  onOperation: () => {},
+  onOpenDetail: () => {},
+  onDeleteAllVisible: () => {},
+  onArchiveAllVisible: () => {},
+  onRetry: () => {},
+  ...overrides,
+})
+
+describe('the loaded list — the scene acceptance criterion 1 is read against', () => {
+  it('lists every row the vista handed it, under canon\'s section heading', () => {
+    render(<FindFragment {...props()} />)
+
+    expect(screen.getByRole('heading', { name: 'All Endeavors' })).toBeTruthy()
+    expect(screen.getByText('Prepare quarterly slides')).toBeTruthy()
+    expect(screen.getByText('Team sync')).toBeTruthy()
+  })
+
+  it('offers all three chip rows, each named for a screen reader', () => {
+    render(<FindFragment {...props()} />)
+
+    expect(screen.getByRole('group', { name: 'Kinds' })).toBeTruthy()
+    expect(screen.getByRole('group', { name: 'Sources' })).toBeTruthy()
+    expect(screen.getByRole('group', { name: 'Statuses' })).toBeTruthy()
+  })
+
+  it('marks a chip pressed when the lens is NOT hiding it', () => {
+    render(<FindFragment {...props()} />)
+
+    const kinds = screen.getByRole('group', { name: 'Kinds' })
+    expect(
+      within(kinds).getByRole('button', { name: /Task/ }).getAttribute('aria-pressed'),
+    ).toBe('true')
+  })
+})
+
+describe('the four empty states are four different messages', () => {
+  it('says "No Endeavors Yet" when nothing was ever fetched', () => {
+    render(
+      <FindFragment
+        {...props({ rows: [], visibleCount: 0, emptyState: { kind: 'noData' } })}
+      />,
+    )
+    expect(screen.getByText('No Endeavors Yet')).toBeTruthy()
+  })
+
+  it('says "No Filters Selected" when the user turned every chip off', () => {
+    render(
+      <FindFragment
+        {...props({
+          rows: [],
+          visibleCount: 0,
+          selectedKinds: [],
+          selectedHosts: [],
+          selectedStatuses: [],
+          emptyState: { kind: 'noFilters' },
+        })}
+      />,
+    )
+    expect(screen.getByText('No Filters Selected')).toBeTruthy()
+    expect(screen.queryByText('No Endeavors Yet')).toBeNull()
+  })
+
+  it('quotes the query back on a search that matched nothing', () => {
+    render(
+      <FindFragment
+        {...props({
+          query: 'zzzz',
+          rows: [],
+          visibleCount: 0,
+          emptyState: { kind: 'noResults', query: 'zzzz' },
+        })}
+      />,
+    )
+    expect(
+      screen.getByText('No endeavors match "zzzz" with the current filters.'),
+    ).toBeTruthy()
+  })
+
+  it('keeps the previously loaded rows visible through a failed refresh', () => {
+    render(
+      <FindFragment
+        {...props({
+          exception: {
+            kind: 'fetchFailed',
+            message: "Couldn't load your endeavors: offline",
+            recoverable: true,
+          },
+        })}
+      />,
+    )
+    expect(screen.getByText("Couldn't load your endeavors: offline")).toBeTruthy()
+    expect(screen.getByText('Prepare quarterly slides')).toBeTruthy()
+  })
+})
+
+describe('the search field', () => {
+  it('reports every keystroke, so the lens narrows as the user types', async () => {
+    const onChangeQuery = vi.fn()
+    render(<FindFragment {...props({ onChangeQuery })} />)
+
+    await userEvent.type(
+      screen.getByRole('searchbox', { name: 'Search endeavors' }),
+      'q',
+    )
+
+    expect(onChangeQuery).toHaveBeenCalledWith('q')
+  })
+
+  it('offers a clear control only once there is something to clear', async () => {
+    const onChangeQuery = vi.fn()
+    const { rerender } = render(<FindFragment {...props({ onChangeQuery })} />)
+    expect(screen.queryByRole('button', { name: 'Clear search' })).toBeNull()
+
+    rerender(<FindFragment {...props({ query: 'tax', onChangeQuery })} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Clear search' }))
+
+    expect(onChangeQuery).toHaveBeenCalledWith('')
+  })
+})
+
+describe('the filter chips dispatch by axis', () => {
+  it('toggles a kind by its own axis, never by position', async () => {
+    const onToggleFilter = vi.fn()
+    render(<FindFragment {...props({ onToggleFilter })} />)
+
+    const kinds = screen.getByRole('group', { name: 'Kinds' })
+    await userEvent.click(within(kinds).getByRole('button', { name: /Habit/ }))
+
+    expect(onToggleFilter).toHaveBeenCalledWith({ axis: 'kind', value: 'habit' })
+  })
+
+  it('raises the Archived chip as its own event — it is a flag, not a status', async () => {
+    const onToggleShowArchived = vi.fn()
+    const onToggleFilter = vi.fn()
+    render(
+      <FindFragment {...props({ onToggleShowArchived, onToggleFilter })} />,
+    )
+
+    const statuses = screen.getByRole('group', { name: 'Statuses' })
+    await userEvent.click(
+      within(statuses).getByRole('button', { name: /Archived/ }),
+    )
+
+    expect(onToggleShowArchived).toHaveBeenCalledTimes(1)
+    expect(onToggleFilter).not.toHaveBeenCalled()
+  })
+})
+
+describe('row operations — one capability set, two input grammars', () => {
+  const oneRow = adaptedRows([findEndeavorMocks.morningTask], capabilities)
+
+  it('performs the leading swipe\'s FIRST binding on a full swipe (touch)', () => {
+    const onOperation = vi.fn()
+    render(
+      <FindFragment
+        {...props({ rows: oneRow, visibleCount: 1, input: 'touch', onOperation })}
+      />,
+    )
+
+    const content = document.querySelector(
+      '[data-slot="endeavor-action-content"]',
+    )
+    if (content === null) throw new Error('no action content')
+    fireEvent.pointerDown(content, { clientX: 0, pointerId: 1 })
+    fireEvent.pointerMove(content, { clientX: 200, pointerId: 1 })
+    fireEvent.pointerUp(content, { clientX: 200, pointerId: 1 })
+
+    // Find's leading swipe is Start, then Edit — declaration order is the order.
+    expect(onOperation).toHaveBeenCalledWith(
+      'startSession',
+      findEndeavorMocks.morningTask.id,
+    )
+  })
+
+  it('performs the trailing swipe\'s destructive binding the same way', () => {
+    const onOperation = vi.fn()
+    render(
+      <FindFragment
+        {...props({ rows: oneRow, visibleCount: 1, input: 'touch', onOperation })}
+      />,
+    )
+
+    const content = document.querySelector(
+      '[data-slot="endeavor-action-content"]',
+    )
+    if (content === null) throw new Error('no action content')
+    fireEvent.pointerDown(content, { clientX: 300, pointerId: 1 })
+    fireEvent.pointerMove(content, { clientX: 100, pointerId: 1 })
+    fireEvent.pointerUp(content, { clientX: 100, pointerId: 1 })
+
+    expect(onOperation).toHaveBeenCalledWith(
+      'delete',
+      findEndeavorMocks.morningTask.id,
+    )
+  })
+
+  it('offers the SAME bindings as hover buttons on a pointer surface', async () => {
+    const onOperation = vi.fn()
+    render(
+      <FindFragment
+        {...props({ rows: oneRow, visibleCount: 1, input: 'pointer', onOperation })}
+      />,
+    )
+
+    // The strip is opacity-0 until hover/focus; it is in the tree either way,
+    // which is what makes it reachable by keyboard.
+    await userEvent.click(screen.getByRole('button', { name: 'Start' }))
+
+    expect(onOperation).toHaveBeenCalledWith(
+      'startSession',
+      findEndeavorMocks.morningTask.id,
+    )
+  })
+
+  it('gives every row a named context-menu trigger, on both grammars', () => {
+    render(
+      <FindFragment {...props({ rows: oneRow, visibleCount: 1, input: 'pointer' })} />,
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: `Actions for ${findEndeavorMocks.morningTask.title}`,
+      }),
+    ).toBeTruthy()
+  })
+
+  it('opens Detail from a control OUTSIDE the action surface, on both grammars', async () => {
+    for (const input of ['touch', 'pointer'] as const) {
+      cleanup()
+      const onOpenDetail = vi.fn()
+      render(
+        <FindFragment
+          {...props({ rows: oneRow, visibleCount: 1, input, onOpenDetail })}
+        />,
+      )
+
+      const open = screen.getByTestId('find-row-open')
+      // Outside, so neither the pointer capture nor the hover strip can eat it.
+      expect(
+        open.closest('[data-slot="endeavor-action-surface"]'),
+      ).toBeNull()
+
+      await userEvent.click(open)
+      expect(onOpenDetail).toHaveBeenCalledWith(
+        findEndeavorMocks.morningTask.id,
+      )
+    }
+  })
+})
+
+describe('the ellipsis menu — two irreversible bulk operations', () => {
+  it('stays closed until asked, and says so through aria-expanded', () => {
+    render(<FindFragment {...props()} />)
+
+    const trigger = screen.getByRole('button', { name: 'Endeavor actions' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('counts the visible rows in both labels, as canon does', async () => {
+    render(<FindFragment {...props({ visibleCount: 4 })} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Endeavor actions' }))
+
+    expect(
+      screen.getByRole('menuitem', { name: 'Delete all visible (4)' }),
+    ).toBeTruthy()
+    expect(
+      screen.getByRole('menuitem', { name: 'Archive all visible (4)' }),
+    ).toBeTruthy()
+  })
+
+  it('deletes every visible endeavor and closes — canon has no confirm step', async () => {
+    const onDeleteAllVisible = vi.fn()
+    render(<FindFragment {...props({ visibleCount: 2, onDeleteAllVisible })} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Endeavor actions' }))
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: 'Delete all visible (2)' }),
+    )
+
+    expect(onDeleteAllVisible).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('archives every visible endeavor through the second entry', async () => {
+    const onArchiveAllVisible = vi.fn()
+    render(<FindFragment {...props({ visibleCount: 2, onArchiveAllVisible })} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Endeavor actions' }))
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: 'Archive all visible (2)' }),
+    )
+
+    expect(onArchiveAllVisible).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes on Escape and returns focus to its trigger', async () => {
+    render(<FindFragment {...props()} />)
+
+    const trigger = screen.getByRole('button', { name: 'Endeavor actions' })
+    await userEvent.click(trigger)
+    await userEvent.keyboard('{Escape}')
+
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/packages/app/src/features/find/pages/FindFragment.tsx
+++ b/packages/app/src/features/find/pages/FindFragment.tsx
@@ -1,0 +1,573 @@
+'use client'
+
+/**
+ * Find — the port of `KroUI/Find/FindView.swift` (`RC-15`).
+ *
+ * The user's all-endeavors browser: a search field, three rows of filter chips,
+ * one bulk menu, and a list whose rows carry the vista's own operations. Pure:
+ * it reads no store and dispatches nothing; every value arrives as a prop and
+ * every intent leaves as a callback.
+ *
+ * ## The rows get their gestures from the CAPABILITIES, once
+ *
+ * `EndeavorRow` is handed `capabilities` + `onOperation` and the merged kit's
+ * `EndeavorActionSurface` does the rest: on touch the vista's leading and
+ * trailing swipe bindings become swipe surfaces; on pointer the same bindings
+ * become a hover strip **and** context-menu entries. This surface therefore
+ * declares no gesture of its own — canon's `endeavorOperations(_:on:…)`
+ * modifier is exactly that single bridge, and building a second one here is the
+ * duplication `FindAdapters`' own header refuses.
+ *
+ * ## The row's Open control, and the flag it works around
+ *
+ * Canon's Find row opens Detail with a whole-row tap, and the registry binds
+ * that tap `requires: 'endeavorDetail'` — a flag `statusQuoSet` ships **off**,
+ * because iOS is dark-launching Detail while its epic lands. This issue builds
+ * that surface for the web, so with the tap alone it would be unreachable in a
+ * shipping build and the issue's own acceptance criterion ("opens from any
+ * endeavor row") could not be met at all.
+ *
+ * So the row carries a labelled `Open <title>` control of its own, and the
+ * vista's tap keeps its flag untouched — the gate is not weakened, a second,
+ * unflagged affordance is added beside it. That is a deliberate divergence from
+ * canon's shipped Find, it is named in the PR body, and it is the human's to
+ * keep or gate at G2.
+ *
+ * ## The ellipsis menu is a hand-built disclosure, not the kit's dropdown
+ *
+ * Every other menu in the kit is a Radix dropdown. This one is not, and the
+ * reason is written up in `system/primitives/__tests__/radixEnvironment.tsx`:
+ * mounting a Radix popper under jsdom costs 5–12 seconds, so those panels are
+ * asserted only by a Storybook runner that this repo has not executed yet.
+ * *Delete all visible* is irreversible and unconfirmed (canon's own choice, see
+ * `findOverflowEntries`), which makes "covered by a runner nobody has run" the
+ * wrong bar for it. So the menu is the same disclosure shape the chrome kit's
+ * `LiquidGlassFABMenu` already ships — an `aria-expanded` trigger over a
+ * labelled group of ordinary buttons, Escape to close, focus returned — and its
+ * whole flow is exercised by an ordinary interaction test.
+ *
+ * ## Where the menu is drawn
+ *
+ * Canon puts it in the navigation bar (`.topBarTrailing`). The shell owns those
+ * bars here and lends them out through `ToolbarSlot`, so the menu is portalled
+ * into whichever placement the current shell renders — `primary` on the sidebar
+ * shell, `trailing` on the tab-bar shell — and falls back to the surface's own
+ * header when neither outlet exists, which is the case in a story, in a test,
+ * and on any host that mounts this Fragment outside the shell.
+ */
+import type {
+  EndeavorCapabilities,
+  EndeavorComputedState,
+  EndeavorHost,
+  EndeavorKind,
+  EndeavorStatus,
+} from '@kro/core'
+import {
+  type KeyboardEvent,
+  useCallback,
+  useId,
+  useRef,
+  useState,
+} from 'react'
+import { EmptyStateCard } from '../../../design/endeavor/EmptyStateCard'
+import { EndeavorRow } from '../../../design/endeavor/EndeavorRow'
+import { InlineBanner } from '../../../design/endeavor/InlineBanner'
+import { KroChip } from '../../../design/endeavor/KroChip'
+import { endeavorIcon } from '../../../design/endeavor/endeavorIcons'
+import type { OnEndeavorOperation } from '../../../design/endeavor/rowActions'
+import type { InputCapability } from '../../../design/endeavor/useInputCapability'
+import { colorVar, radiusVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import {
+  ToolbarSlot,
+  useToolbarOutletPresent,
+} from '../../main/ToolbarSlots'
+import type { EndeavorRowAdapter } from '../FindAdapters'
+import type { FindException } from '../FindException'
+import type { FindEmptyState, FindFilterToggle } from '../FindState'
+import {
+  type FindFilterChip,
+  findEmptyCopy,
+  findFilterRows,
+  findOverflowEntries,
+  findRowBadges,
+  findRowSymbol,
+  findRowTimeInfo,
+  isFilterChipSelected,
+} from './findPresentation'
+
+const Search = endeavorIcon('magnifyingglass')
+const Ellipsis = endeavorIcon('ellipsis')
+const Clear = endeavorIcon('xmark')
+const ChevronRight = endeavorIcon('chevron.right')
+
+export interface FindFragmentProps {
+  readonly query: string
+  readonly rows: readonly EndeavorRowAdapter[]
+  /** The flag-resolved capability set every row is adapted against. */
+  readonly capabilities: EndeavorCapabilities
+  /** `null` while the list has rows to show. */
+  readonly emptyState: FindEmptyState | null
+  readonly selectedKinds: readonly EndeavorKind[]
+  readonly selectedHosts: readonly EndeavorHost[]
+  readonly selectedStatuses: readonly EndeavorStatus[]
+  readonly selectedComputedStates?: readonly EndeavorComputedState[]
+  readonly showArchived: boolean
+  /** Exactly the number the bulk menu's counted labels print. */
+  readonly visibleCount: number
+  readonly isLoading: boolean
+  readonly exception: FindException | null
+  /** The instant every relative caption is written against (`RC-5`). */
+  readonly now: Date
+  /** Forces an input grammar. Stories and tests set it; production detects. */
+  readonly input?: InputCapability
+  readonly locale?: string
+  readonly onChangeQuery: (query: string) => void
+  readonly onToggleFilter: (toggle: FindFilterToggle) => void
+  readonly onToggleShowArchived: () => void
+  readonly onOperation: OnEndeavorOperation
+  /**
+   * The row's Detail affordance.
+   *
+   * Canon's Find row opens Detail with a whole-row TAP, and the registry
+   * declares that binding `requires: 'endeavorDetail'` — a flag that is OFF in
+   * the shipping baseline. So on the web the row carries a labelled control of
+   * its own, outside the action surface, and the vista's tap keeps its flag.
+   * See the header note on the divergence.
+   */
+  readonly onOpenDetail: (endeavorId: string) => void
+  readonly onDeleteAllVisible: () => void
+  readonly onArchiveAllVisible: () => void
+  readonly onRetry: () => void
+}
+
+export function FindFragment(props: FindFragmentProps) {
+  const {
+    query,
+    rows,
+    capabilities,
+    emptyState,
+    selectedKinds,
+    selectedHosts,
+    selectedStatuses,
+    selectedComputedStates,
+    showArchived,
+    visibleCount,
+    isLoading,
+    exception,
+    now,
+    input,
+    locale,
+    onChangeQuery,
+    onToggleFilter,
+    onToggleShowArchived,
+    onOperation,
+    onOpenDetail,
+    onDeleteAllVisible,
+    onArchiveAllVisible,
+    onRetry,
+  } = props
+
+  const hasPrimaryOutlet = useToolbarOutletPresent('primary')
+  const hasTrailingOutlet = useToolbarOutletPresent('trailing')
+  const placement = hasPrimaryOutlet
+    ? 'primary'
+    : hasTrailingOutlet
+      ? 'trailing'
+      : null
+
+  const menu = (
+    <FindOverflowMenu
+      visibleCount={visibleCount}
+      onDeleteAllVisible={onDeleteAllVisible}
+      onArchiveAllVisible={onArchiveAllVisible}
+    />
+  )
+
+  return (
+    <section
+      data-testid="find-surface"
+      aria-label="Find"
+      className="flex h-full min-h-0 flex-col"
+    >
+      {placement === null ? null : (
+        <ToolbarSlot placement={placement}>{menu}</ToolbarSlot>
+      )}
+
+      <div className="flex flex-col gap-kro-small px-kro-medium pt-kro-medium">
+        <div className="flex items-center gap-kro-small">
+          <FindSearchField
+            query={query}
+            onChangeQuery={onChangeQuery}
+            className="flex-1"
+          />
+          {placement === null ? menu : null}
+        </div>
+
+        <FindFilterBar
+          selectedKinds={selectedKinds}
+          selectedHosts={selectedHosts}
+          selectedStatuses={selectedStatuses}
+          selectedComputedStates={selectedComputedStates}
+          showArchived={showArchived}
+          onToggleFilter={onToggleFilter}
+          onToggleShowArchived={onToggleShowArchived}
+        />
+
+        {exception === null ? null : (
+          <InlineBanner
+            message={exception.message}
+            actionTitle={exception.recoverable ? 'Try again' : undefined}
+            onAction={exception.recoverable ? onRetry : undefined}
+          />
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-kro-medium pt-kro-small pb-kro-x-large">
+        {emptyState !== null ? (
+          <FindEmptyView state={emptyState} />
+        ) : (
+          <>
+            <h2
+              className="sticky top-0 z-1 m-0 py-kro-small font-bold text-base"
+              style={{
+                color: colorVar('fore'),
+                backgroundColor: colorVar('back'),
+              }}
+            >
+              All Endeavors
+            </h2>
+            <ul
+              aria-busy={isLoading}
+              className="m-0 flex list-none flex-col gap-kro-small p-0"
+            >
+              {rows.map((adapter) => {
+                const lead = findRowSymbol(adapter.endeavor.title)
+                const name = lead.title.length === 0 ? 'Untitled' : lead.title
+                return (
+                  <li
+                    key={adapter.id}
+                    className="flex items-center gap-kro-small"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <EndeavorRow
+                        config="find"
+                        endeavorId={adapter.id}
+                        capabilities={capabilities}
+                        onOperation={onOperation}
+                        input={input}
+                        symbol={lead.symbol}
+                        isGenericSymbol={lead.isGeneric}
+                        title={lead.title}
+                        timeInfo={findRowTimeInfo(adapter.endeavor)}
+                        badges={findRowBadges(adapter.endeavor)}
+                        now={now}
+                        locale={locale}
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      aria-label={`Open ${name}`}
+                      data-testid="find-row-open"
+                      onClick={() => onOpenDetail(adapter.id)}
+                      className="inline-flex shrink-0 items-center justify-center rounded-kro-pill outline-none focus-visible:shadow-[var(--kro-ring)]"
+                      style={{
+                        minWidth: 'var(--kro-size-min-touch-target)',
+                        minHeight: 'var(--kro-size-min-touch-target)',
+                        color: colorVar('foreSecondary'),
+                      }}
+                    >
+                      <ChevronRight size={16} aria-hidden />
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </>
+        )}
+      </div>
+    </section>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* Search field                                                              */
+/* ------------------------------------------------------------------------ */
+
+/**
+ * The surface's own search field.
+ *
+ * Canon has none: iOS attaches `.searchable` to the navigation stack and hands
+ * the binding down. The web's two shells answer differently — the sidebar shell
+ * already carries a field (the shell's, which routes *to* this destination) and
+ * the tab-bar shell carries none at all — so the destination owns one, which is
+ * also what makes the surface usable when it is opened by URL rather than by
+ * typing into the sidebar.
+ */
+function FindSearchField({
+  query,
+  onChangeQuery,
+  className,
+}: {
+  readonly query: string
+  readonly onChangeQuery: (query: string) => void
+  readonly className?: string
+}) {
+  return (
+    <form
+      role="search"
+      onSubmit={(event) => event.preventDefault()}
+      className={cn(
+        'flex items-center gap-kro-small rounded-kro-field px-kro-small',
+        className,
+      )}
+      style={{
+        backgroundColor: colorVar('backInner'),
+        minHeight: 'var(--kro-size-min-touch-target)',
+      }}
+    >
+      <Search
+        size={16}
+        aria-hidden
+        className="shrink-0"
+        style={{ color: colorVar('foreSecondary') }}
+      />
+      <input
+        type="search"
+        aria-label="Search endeavors"
+        placeholder="Search endeavors"
+        value={query}
+        onChange={(event) => onChangeQuery(event.target.value)}
+        className="w-full bg-transparent text-sm outline-none"
+        style={{ color: colorVar('fore') }}
+      />
+      {query.length === 0 ? null : (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={() => onChangeQuery('')}
+          className="inline-flex size-7 shrink-0 items-center justify-center rounded-kro-pill outline-none focus-visible:shadow-[var(--kro-ring)]"
+          style={{ color: colorVar('foreSecondary') }}
+        >
+          <Clear size={12} strokeWidth={3} aria-hidden />
+        </button>
+      )}
+    </form>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* Filter chips                                                              */
+/* ------------------------------------------------------------------------ */
+
+/**
+ * Canon's three horizontal chip scrollers.
+ *
+ * Each row is a `group` with an accessible name, because canon's rows are
+ * visually unlabelled and a screen reader would otherwise read twenty-one
+ * unrelated toggles in a run. The chips themselves are `aria-pressed` buttons —
+ * a filter chip is a toggle, not a link, and canon's selected/unselected fill
+ * is exactly that state.
+ */
+function FindFilterBar({
+  selectedKinds,
+  selectedHosts,
+  selectedStatuses,
+  selectedComputedStates,
+  showArchived,
+  onToggleFilter,
+  onToggleShowArchived,
+}: {
+  readonly selectedKinds: readonly EndeavorKind[]
+  readonly selectedHosts: readonly EndeavorHost[]
+  readonly selectedStatuses: readonly EndeavorStatus[]
+  readonly selectedComputedStates?: readonly EndeavorComputedState[]
+  readonly showArchived: boolean
+  readonly onToggleFilter: (toggle: FindFilterToggle) => void
+  readonly onToggleShowArchived: () => void
+}) {
+  const selected = {
+    kinds: selectedKinds,
+    hosts: selectedHosts,
+    statuses: selectedStatuses,
+    computedStates: selectedComputedStates,
+    showArchived,
+  }
+
+  return (
+    <div className="flex flex-col gap-kro-tiny">
+      {findFilterRows.map((row) => (
+        <div
+          key={row.id}
+          role="group"
+          aria-label={row.label}
+          data-filter-row={row.id}
+          className="flex gap-kro-small overflow-x-auto pb-kro-tiny"
+        >
+          {row.chips.map((chip) => (
+            <FilterChipButton
+              key={chip.id}
+              chip={chip}
+              isSelected={isFilterChipSelected(chip, selected)}
+              onPress={() =>
+                chip.toggle === null
+                  ? onToggleShowArchived()
+                  : onToggleFilter(chip.toggle)
+              }
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function FilterChipButton({
+  chip,
+  isSelected,
+  onPress,
+}: {
+  readonly chip: FindFilterChip
+  readonly isSelected: boolean
+  readonly onPress: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={isSelected}
+      onClick={onPress}
+      data-filter-chip={chip.id}
+      className={cn(
+        'inline-flex shrink-0 items-center rounded-kro-pill',
+        'outline-none focus-visible:shadow-[var(--kro-ring)]',
+      )}
+      style={{ minHeight: 'var(--kro-size-min-touch-target)' }}
+    >
+      <KroChip
+        title={chip.label}
+        icon={chip.icon}
+        tint={chip.tint}
+        emphasis={isSelected ? 'prominent' : 'outline'}
+        size="small"
+      />
+    </button>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* Empty states                                                              */
+/* ------------------------------------------------------------------------ */
+
+function FindEmptyView({ state }: { readonly state: FindEmptyState }) {
+  const copy = findEmptyCopy(state)
+  return (
+    <div
+      data-testid="find-empty-state"
+      data-empty-kind={state.kind}
+      className="flex h-full items-center justify-center py-kro-x-large"
+    >
+      <EmptyStateCard
+        icon={copy.icon}
+        title={copy.title}
+        message={copy.message}
+      />
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* The bulk menu                                                             */
+/* ------------------------------------------------------------------------ */
+
+function FindOverflowMenu({
+  visibleCount,
+  onDeleteAllVisible,
+  onArchiveAllVisible,
+}: {
+  readonly visibleCount: number
+  readonly onDeleteAllVisible: () => void
+  readonly onArchiveAllVisible: () => void
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const menuId = useId()
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+    triggerRef.current?.focus()
+  }, [])
+
+  const choose = useCallback(
+    (id: 'deleteAllVisible' | 'archiveAllVisible') => {
+      if (id === 'deleteAllVisible') onDeleteAllVisible()
+      else onArchiveAllVisible()
+      close()
+    },
+    [close, onArchiveAllVisible, onDeleteAllVisible],
+  )
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== 'Escape' || !isOpen) return
+      event.stopPropagation()
+      close()
+    },
+    [close, isOpen],
+  )
+
+  return (
+    <div className="relative" onKeyDown={onKeyDown}>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="Endeavor actions"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-controls={menuId}
+        onClick={() => setIsOpen(!isOpen)}
+        className="inline-flex items-center justify-center rounded-kro-small outline-none focus-visible:shadow-[var(--kro-ring)]"
+        style={{
+          minWidth: 'var(--kro-size-min-touch-target)',
+          minHeight: 'var(--kro-size-min-touch-target)',
+          color: colorVar('fore'),
+        }}
+      >
+        <Ellipsis size={18} aria-hidden />
+      </button>
+
+      {isOpen ? (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label="Endeavor actions"
+          className="kro-glass absolute top-full right-0 z-50 mt-kro-tiny flex min-w-60 flex-col p-kro-tiny"
+          style={{ borderRadius: radiusVar('field') }}
+        >
+          {findOverflowEntries(visibleCount).map((entry) => {
+            const Icon = endeavorIcon(entry.icon)
+            return (
+              <button
+                key={entry.id}
+                type="button"
+                role="menuitem"
+                onClick={() => choose(entry.id)}
+                className={cn(
+                  'flex h-11 items-center gap-kro-small rounded-kro-small px-kro-small',
+                  'text-left text-base outline-none focus-visible:shadow-[var(--kro-ring)]',
+                )}
+                style={{
+                  color: entry.isDestructive
+                    ? colorVar('bannerDanger')
+                    : colorVar('fore'),
+                }}
+              >
+                <Icon size={18} aria-hidden />
+                {entry.label}
+              </button>
+            )
+          })}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/app/src/features/find/pages/FindPage.stories.tsx
+++ b/packages/app/src/features/find/pages/FindPage.stories.tsx
@@ -1,0 +1,73 @@
+/**
+ * Find, mounted on a real store (`RC-11`).
+ *
+ * Every scene seeds the in-memory database and lets the surface's own fetch
+ * run, so what is drawn is what the Producer, the Shifter and the reconcile
+ * pass actually produce — see `__tests__/pagesHarness.tsx` for why that is the
+ * stronger claim than a preloaded slice.
+ */
+import { Stage } from '../../../design/endeavor/storyStage'
+import { allFindEndeavorMocks, findEndeavorMocks } from '../FindMocks'
+import { FindPage } from './FindPage'
+import {
+  Harness,
+  detailEnabledFlags,
+  makeSeededStore,
+} from './__tests__/pagesHarness'
+
+export default {
+  title: 'Find/Find page',
+  component: FindPage,
+  parameters: { layout: 'fullscreen' },
+}
+
+/** The seeded, mixed list — the story the screenshots are taken from. */
+export const Loaded = {
+  render: () => (
+    <Stage width={430}>
+      <Harness store={makeSeededStore({ endeavors: allFindEndeavorMocks })}>
+        <FindPage input="touch" locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}
+
+/** A pointer surface with the dark-launched Detail tap resolved on. */
+export const PointerWithDetailEnabled = {
+  render: () => (
+    <Stage width={900}>
+      <Harness
+        store={makeSeededStore({
+          endeavors: allFindEndeavorMocks,
+          featureFlags: detailEnabledFlags,
+        })}
+      >
+        <FindPage input="pointer" locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}
+
+/** A first run: the database is empty, so canon's "No Endeavors Yet" shows. */
+export const FirstRun = {
+  render: () => (
+    <Stage width={430}>
+      <Harness store={makeSeededStore()}>
+        <FindPage input="touch" locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}
+
+/** One endeavor, to judge the row's own geometry rather than the list's. */
+export const SingleRow = {
+  render: () => (
+    <Stage width={430}>
+      <Harness
+        store={makeSeededStore({ endeavors: [findEndeavorMocks.teamSync] })}
+      >
+        <FindPage input="touch" locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}

--- a/packages/app/src/features/find/pages/FindPage.test.tsx
+++ b/packages/app/src/features/find/pages/FindPage.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * Find's container, against a real store built with `makeStore(stubbedThunkExtra)`
+ * over a seeded in-memory database (`RC-22`, `RC-35`) — never a hand-assembled
+ * second store, never the live services.
+ */
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+import { userDidChangeSearchQuery } from '../../main/MainFeature'
+import { allFindEndeavorMocks, findEndeavorMocks } from '../FindMocks'
+import { FindPage } from './FindPage'
+import {
+  Harness,
+  detailEnabledFlags,
+  makeSeededStore,
+} from './__tests__/pagesHarness'
+
+afterEach(cleanup)
+
+const mount = (
+  store = makeSeededStore({ endeavors: allFindEndeavorMocks }),
+) => {
+  render(
+    <Harness store={store}>
+      <FindPage input="touch" locale="en-US" />
+    </Harness>,
+  )
+  return store
+}
+
+describe('mount', () => {
+  it('fetches through the real Producer and lists what the database held', async () => {
+    mount()
+
+    await waitFor(() => {
+      expect(screen.getByText('Prepare quarterly slides')).toBeTruthy()
+    })
+    expect(screen.getByText('Team sync')).toBeTruthy()
+  })
+
+  it('installs the surface with the resolved capability flags, not a guess', async () => {
+    const store = mount(
+      makeSeededStore({
+        endeavors: allFindEndeavorMocks,
+        featureFlags: detailEnabledFlags,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(store.getState().find.find.enabledFlags).toEqual(['endeavorDetail'])
+    })
+  })
+
+  it('leaves the dark-launched tap unresolved on the shipping baseline', async () => {
+    const store = mount()
+
+    await waitFor(() => {
+      expect(store.getState().find.find.load.kind).toBe('loaded')
+    })
+    expect(store.getState().find.find.enabledFlags).toEqual([])
+  })
+
+  it('tells the shell which destination the URL landed on', async () => {
+    const store = mount()
+
+    await waitFor(() => {
+      expect(store.getState().main.selected.kind).toBe('search')
+    })
+  })
+})
+
+describe('the sidebar\'s query seeds this surface', () => {
+  it('narrows the lens to what the shell\'s field was submitted with', async () => {
+    const store = makeSeededStore({ endeavors: allFindEndeavorMocks })
+    store.dispatch(userDidChangeSearchQuery({ query: 'slides' }))
+
+    mount(store)
+
+    await waitFor(() => {
+      expect(store.getState().find.find.lens.searchQuery).toBe('slides')
+    })
+    expect(screen.getByText('Prepare quarterly slides')).toBeTruthy()
+    expect(screen.queryByText('Team sync')).toBeNull()
+  })
+})
+
+describe('filters and search write the lens', () => {
+  it('hides a kind when its chip is pressed, and the row goes with it', async () => {
+    const store = mount()
+    await waitFor(() => {
+      expect(screen.getByText('Team sync')).toBeTruthy()
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /Event/, pressed: true }),
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Team sync')).toBeNull()
+    })
+    expect(store.getState().find.find.lens.hiddenKinds).toContain(
+      'calendarEvent',
+    )
+  })
+
+  it('reveals the archived row only once Show Archived is on', async () => {
+    const store = mount()
+    await waitFor(() => {
+      expect(screen.getByText('Prepare quarterly slides')).toBeTruthy()
+    })
+    expect(screen.queryByText('Renew the domain')).toBeNull()
+
+    await userEvent.click(screen.getByRole('button', { name: /Archived/ }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Renew the domain')).toBeTruthy()
+    })
+    expect(store.getState().find.find.lens.showArchived).toBe(true)
+  })
+})
+
+describe('Detail is reachable from a Find row', () => {
+  it('parks a viewDetail request the global overlay can serve', async () => {
+    const store = mount(
+      makeSeededStore({ endeavors: [findEndeavorMocks.teamSync] }),
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('find-row-open')).toBeTruthy()
+    })
+
+    await userEvent.click(screen.getByTestId('find-row-open'))
+
+    await waitFor(() => {
+      expect(store.getState().find.intents).toEqual([
+        {
+          id: 1,
+          operation: 'viewDetail',
+          endeavorId: findEndeavorMocks.teamSync.id,
+          surface: 'find',
+        },
+      ])
+    })
+  })
+})
+
+describe('the bulk operations act on exactly the visible rows', () => {
+  it('deletes every visible endeavor and empties the surface', async () => {
+    const store = mount(
+      makeSeededStore({
+        endeavors: [findEndeavorMocks.morningTask, findEndeavorMocks.teamSync],
+      }),
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Team sync')).toBeTruthy()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Endeavor actions' }))
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: 'Delete all visible (2)' }),
+    )
+
+    await waitFor(() => {
+      expect(store.getState().find.find.endeavors).toHaveLength(0)
+    })
+    expect(screen.getByText('No Endeavors Yet')).toBeTruthy()
+  })
+
+  it('archives the visible rows, which closes them rather than removing them', async () => {
+    const store = mount(
+      makeSeededStore({ endeavors: [findEndeavorMocks.morningTask] }),
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Prepare quarterly slides')).toBeTruthy()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Endeavor actions' }))
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: 'Archive all visible (1)' }),
+    )
+
+    await waitFor(() => {
+      expect(store.getState().find.find.endeavors[0]?.status).toBe('closed')
+    })
+  })
+
+  it('applies a bulk delete only to what the filters left visible', async () => {
+    const store = mount()
+    await waitFor(() => {
+      expect(screen.getByText('Team sync')).toBeTruthy()
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /Event/, pressed: true }),
+    )
+    await waitFor(() => {
+      expect(screen.queryByText('Team sync')).toBeNull()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Endeavor actions' }))
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /^Delete all visible/ }),
+    )
+
+    await waitFor(() => {
+      expect(
+        store
+          .getState()
+          .find.find.endeavors.map((endeavor) => endeavor.id),
+      ).toContain(findEndeavorMocks.teamSync.id)
+    })
+  })
+})

--- a/packages/app/src/features/find/pages/FindPage.test.tsx
+++ b/packages/app/src/features/find/pages/FindPage.test.tsx
@@ -3,11 +3,20 @@
  * over a seeded in-memory database (`RC-22`, `RC-35`) — never a hand-assembled
  * second store, never the live services.
  */
+import { EndeavorsVistas, makeEndeavorsLensSnapshot } from '@kro/core'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it } from 'vitest'
+import {
+  type ThunkExtra,
+  makeStore,
+  stubbedThunkExtra,
+} from '../../../library/store'
+import { makeInMemoryLocalStore } from '../../../services/localStore/InMemoryLocalStore'
 import { userDidChangeSearchQuery } from '../../main/MainFeature'
 import { allFindEndeavorMocks, findEndeavorMocks } from '../FindMocks'
+import { selectIsFindLensLoading } from '../FindSelectors'
+import { initialFindLens } from '../FindState'
 import { FindPage } from './FindPage'
 import {
   Harness,
@@ -66,6 +75,67 @@ describe('mount', () => {
     await waitFor(() => {
       expect(store.getState().main.selected.kind).toBe('search')
     })
+  })
+})
+
+describe('the saved lens survives the mount that reads it', () => {
+  it('restores the user\'s filters instead of the vista\'s defaults', async () => {
+    const store = mount(
+      makeSeededStore({
+        endeavors: allFindEndeavorMocks,
+        lensSnapshots: {
+          [EndeavorsVistas.find.id]: makeEndeavorsLensSnapshot({
+            ...initialFindLens,
+            hiddenKinds: ['calendarEvent'],
+            showArchived: true,
+          }),
+        },
+      }),
+    )
+
+    await waitFor(() => {
+      expect(store.getState().find.find.lens.showArchived).toBe(true)
+    })
+    expect(store.getState().find.find.lens.hiddenKinds).toEqual([
+      'calendarEvent',
+    ])
+  })
+
+  it('settles the restore flag, so the surface never reports it as loading forever', async () => {
+    const store = mount()
+
+    await waitFor(() => {
+      expect(store.getState().find.find.isLensRestored).toBe(true)
+    })
+    expect(selectIsFindLensLoading(store.getState())).toBe(false)
+  })
+
+  it('never writes the defaults back over the snapshot it is about to read', async () => {
+    const saved = makeEndeavorsLensSnapshot({
+      ...initialFindLens,
+      hiddenKinds: ['calendarEvent'],
+    })
+    const extra: ThunkExtra = {
+      ...stubbedThunkExtra,
+      localStore: makeInMemoryLocalStore({
+        lensSnapshots: { [EndeavorsVistas.find.id]: saved },
+      }),
+    }
+    const store = makeStore(extra)
+
+    render(
+      <Harness store={store}>
+        <FindPage input="touch" locale="en-US" />
+      </Harness>,
+    )
+
+    await waitFor(() => {
+      expect(store.getState().find.find.isLensRestored).toBe(true)
+    })
+    const onDisk = await extra.localStore.lensSnapshots.read(
+      EndeavorsVistas.find.id,
+    )
+    expect([...(onDisk?.hiddenKinds ?? [])]).toEqual(['calendarEvent'])
   })
 })
 

--- a/packages/app/src/features/find/pages/FindPage.tsx
+++ b/packages/app/src/features/find/pages/FindPage.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+/**
+ * Find's stateful container (`RC-37`) — canon's `FindScreen`.
+ *
+ * The only artifact on this surface that calls both `useAppSelector` and
+ * `useAppDispatch`. It selects through named Selectors, dispatches intents, and
+ * renders exactly one Fragment.
+ *
+ * ## Mount is three dispatches, in this order
+ *
+ * 1. **the capability flags** — resolved through a Producer, because a Service
+ *    reaches a Producer and nothing else (`RC-6`), then handed to
+ *    `onViewLoaded` so `selectFindCapabilities` can gate the vista's bindings
+ *    without a Selector ever seeing a flag;
+ * 2. **the persisted lens** — restored before the first paint is judged, which
+ *    is what `isLensRestored` exists to let the surface wait for;
+ * 3. **the fetch**.
+ *
+ * `onViewLoaded` is dispatched *after* the flag read resolves rather than
+ * optimistically with an empty list, because installing the surface twice would
+ * reset `clockAnchor` and re-stamp the lens mid-restore.
+ *
+ * ## The shell's sidebar field seeds this surface, once per value
+ *
+ * The desktop shell carries its own search field (`MainShellPage` →
+ * `SidebarFragment`), and submitting it navigates here. That field writes the
+ * **main** slice; this surface's field writes the **find lens**. They are
+ * deliberately two values — a sidebar query is a navigation intent, a lens
+ * query is a saved filter — so the seed runs on the shell value changing and
+ * never the other way, which is what keeps typing here from fighting the
+ * sidebar.
+ *
+ * ## The route bookkeeping is this Page's now
+ *
+ * `/search` used to mount the shell's `DestinationPage`, whose only job was to
+ * dispatch `onDestinationRouteMounted` so the sidebar highlight follows the
+ * URL. Replacing the placeholder means inheriting that dispatch — a Page is the
+ * one artifact allowed to dispatch across slices (`RC-37`), and the alternative
+ * (a route file that dispatches) is exactly what `RC-38` forbids.
+ */
+import { type EndeavorOperation, EndeavorsVistas } from '@kro/core'
+import { useCallback, useEffect } from 'react'
+import { useAppDispatch, useAppSelector } from '../../../library/hooks'
+import { onDestinationRouteMounted } from '../../main/MainFeature'
+import { selectSearchQuery } from '../../main/MainSelectors'
+import { DestinationKind } from '../../main/SidebarDestination'
+import {
+  onViewLoaded,
+  userDidChangeSearchQuery,
+  userDidToggleFilter,
+  userDidToggleShowArchived,
+} from '../FindFeature'
+import { FindSurface } from '../FindOperations'
+import {
+  fetchFindEndeavorsThunk,
+  performBulkOperationThunk,
+  performEndeavorOperationThunk,
+  persistFindLensThunk,
+  restoreFindLensThunk,
+} from '../FindProducer'
+import {
+  selectFindCapabilities,
+  selectFindEmptyState,
+  selectFindException,
+  selectFindRowAdapters,
+  selectFindSearchQuery,
+  selectFindSelectedHosts,
+  selectFindSelectedKinds,
+  selectFindSelectedStatuses,
+  selectFindShowArchived,
+  selectFindVisibleCount,
+  selectFindVisibleIds,
+  selectIsFindLoading,
+} from '../FindSelectors'
+import type { FindFilterToggle } from '../FindState'
+import { resolveCapabilityFlagsThunk } from './FindCapabilitiesProducer'
+import { FindFragment } from './FindFragment'
+import type { InputCapability } from '../../../design/endeavor/useInputCapability'
+
+/**
+ * The stand-in anchor before the first install, matching `FindSelectors`'
+ * own `anchorOf` fallback exactly. Nothing renders a caption against it: the
+ * pool is empty until the fetch lands, so no row exists to date.
+ */
+const EPOCH = new Date(0)
+
+export interface FindPageProps {
+  /** Stories and tests pin the input grammar; production detects it. */
+  readonly input?: InputCapability
+  readonly locale?: string
+}
+
+export function FindPage({ input, locale }: FindPageProps) {
+  const dispatch = useAppDispatch()
+
+  const query = useAppSelector(selectFindSearchQuery)
+  const rows = useAppSelector(selectFindRowAdapters)
+  const capabilities = useAppSelector(selectFindCapabilities)
+  const emptyState = useAppSelector(selectFindEmptyState)
+  const selectedKinds = useAppSelector(selectFindSelectedKinds)
+  const selectedHosts = useAppSelector(selectFindSelectedHosts)
+  const selectedStatuses = useAppSelector(selectFindSelectedStatuses)
+  const showArchived = useAppSelector(selectFindShowArchived)
+  const visibleCount = useAppSelector(selectFindVisibleCount)
+  const visibleIds = useAppSelector(selectFindVisibleIds)
+  const isLoading = useAppSelector(selectIsFindLoading)
+  const exception = useAppSelector(selectFindException)
+  const shellQuery = useAppSelector(selectSearchQuery)
+  // Two O(1) field reads, which is all `RC-5` allows here — the lens is stored
+  // flat precisely so persisting it needs no derivation, and the anchor is the
+  // instant the Selectors already classify against, so a row's "2 hours ago"
+  // caption and the filter that let it through agree by construction.
+  const lens = useAppSelector((state) => state.find.find.lens)
+  const clockAnchor = useAppSelector((state) => state.find.find.clockAnchor)
+
+  // The URL is the authority for the shell's selection (`RC-63`).
+  useEffect(() => {
+    dispatch(
+      onDestinationRouteMounted({ destination: { kind: DestinationKind.search } }),
+    )
+  }, [dispatch])
+
+  useEffect(() => {
+    let cancelled = false
+    const flags = dispatch(resolveCapabilityFlagsThunk())
+    const lensRestore = dispatch(
+      restoreFindLensThunk({
+        surface: FindSurface.find,
+        vistaId: EndeavorsVistas.find.id,
+      }),
+    )
+    const fetch = dispatch(
+      fetchFindEndeavorsThunk({ surface: FindSurface.find, now: new Date() }),
+    )
+
+    void flags.then((action) => {
+      if (cancelled) return
+      const result = resolveCapabilityFlagsThunk.fulfilled.match(action)
+        ? action.payload
+        : null
+      dispatch(
+        onViewLoaded({
+          surface: FindSurface.find,
+          now: new Date(),
+          enabledFlags: result !== null && result.ok ? result.value : [],
+        }),
+      )
+    })
+
+    return () => {
+      cancelled = true
+      flags.abort()
+      lensRestore.abort()
+      fetch.abort()
+    }
+  }, [dispatch])
+
+  // Seeded by the shell's own field, and only when that value changes.
+  useEffect(() => {
+    if (shellQuery.length === 0) return
+    dispatch(
+      userDidChangeSearchQuery({
+        surface: FindSurface.find,
+        query: shellQuery,
+      }),
+    )
+  }, [dispatch, shellQuery])
+
+  // Canon persists the lens whenever it changes; a failure is swallowed by the
+  // Producer, so this never needs a result.
+  useEffect(() => {
+    const effect = dispatch(
+      persistFindLensThunk({
+        surface: FindSurface.find,
+        vistaId: EndeavorsVistas.find.id,
+        lens,
+      }),
+    )
+    return () => effect.abort()
+  }, [dispatch, lens])
+
+  const onChangeQuery = useCallback(
+    (next: string) => {
+      dispatch(
+        userDidChangeSearchQuery({ surface: FindSurface.find, query: next }),
+      )
+    },
+    [dispatch],
+  )
+
+  const onToggleFilter = useCallback(
+    (toggle: FindFilterToggle) => {
+      dispatch(userDidToggleFilter({ surface: FindSurface.find, toggle }))
+    },
+    [dispatch],
+  )
+
+  const onOperation = useCallback(
+    (operation: EndeavorOperation, endeavorId: string) => {
+      void dispatch(
+        performEndeavorOperationThunk({
+          surface: FindSurface.find,
+          operation,
+          endeavorId,
+          now: new Date(),
+        }),
+      )
+    },
+    [dispatch],
+  )
+
+  const onBulk = useCallback(
+    (operation: 'delete' | 'archive') => {
+      void dispatch(
+        performBulkOperationThunk({
+          surface: FindSurface.find,
+          operation,
+          endeavorIds: visibleIds,
+          now: new Date(),
+        }),
+      )
+    },
+    [dispatch, visibleIds],
+  )
+
+  /**
+   * The row's Open control, raised through the SAME Producer the vista's tap
+   * would use — so there is one path to Detail from every surface, and the
+   * global overlay has one intent shape to drain.
+   */
+  const onOpenDetail = useCallback(
+    (endeavorId: string) => {
+      void dispatch(
+        performEndeavorOperationThunk({
+          surface: FindSurface.find,
+          operation: 'viewDetail',
+          endeavorId,
+          now: new Date(),
+        }),
+      )
+    },
+    [dispatch],
+  )
+
+  const onRetry = useCallback(() => {
+    void dispatch(
+      fetchFindEndeavorsThunk({ surface: FindSurface.find, now: new Date() }),
+    )
+  }, [dispatch])
+
+  return (
+    <FindFragment
+      query={query}
+      rows={rows}
+      capabilities={capabilities}
+      emptyState={emptyState}
+      selectedKinds={selectedKinds}
+      selectedHosts={selectedHosts}
+      selectedStatuses={selectedStatuses}
+      showArchived={showArchived}
+      visibleCount={visibleCount}
+      isLoading={isLoading}
+      exception={exception}
+      now={clockAnchor ?? EPOCH}
+      input={input}
+      locale={locale}
+      onChangeQuery={onChangeQuery}
+      onToggleFilter={onToggleFilter}
+      onToggleShowArchived={() =>
+        dispatch(userDidToggleShowArchived({ surface: FindSurface.find }))
+      }
+      onOperation={onOperation}
+      onOpenDetail={onOpenDetail}
+      onDeleteAllVisible={() => onBulk('delete')}
+      onArchiveAllVisible={() => onBulk('archive')}
+      onRetry={onRetry}
+    />
+  )
+}

--- a/packages/app/src/features/find/pages/FindPage.tsx
+++ b/packages/app/src/features/find/pages/FindPage.tsx
@@ -7,19 +7,26 @@
  * `useAppDispatch`. It selects through named Selectors, dispatches intents, and
  * renders exactly one Fragment.
  *
- * ## Mount is three dispatches, in this order
+ * ## Mount is three dispatches, and the ORDER is load-bearing
  *
- * 1. **the capability flags** — resolved through a Producer, because a Service
+ * 1. **the capability flags**, resolved through a Producer because a Service
  *    reaches a Producer and nothing else (`RC-6`), then handed to
  *    `onViewLoaded` so `selectFindCapabilities` can gate the vista's bindings
  *    without a Selector ever seeing a flag;
- * 2. **the persisted lens** — restored before the first paint is judged, which
- *    is what `isLensRestored` exists to let the surface wait for;
+ * 2. **the persisted lens**, restored once the surface is installed;
  * 3. **the fetch**.
  *
- * `onViewLoaded` is dispatched *after* the flag read resolves rather than
- * optimistically with an empty list, because installing the surface twice would
- * reset `clockAnchor` and re-stamp the lens mid-restore.
+ * The restore and the fetch wait for `onViewLoaded` rather than racing it, and
+ * both failure modes are real. `withFindViewLoaded` sets `isLensRestored` back
+ * to `false` and re-stamps `clockAnchor`; `withLensSnapshotRestored` refuses to
+ * run twice. So a restore that landed FIRST would be un-flagged by the install
+ * and never re-run — `selectIsFindLensLoading` would stay true forever — and an
+ * install landing after the fetch would move the anchor the rows were already
+ * classified against.
+ *
+ * The lens is likewise persisted only **after** the restore has landed: writing
+ * before then saves the vista's defaults over the user's own filters, which
+ * destroys the snapshot the mount was about to read.
  *
  * ## The shell's sidebar field seeds this surface, once per value
  *
@@ -113,6 +120,9 @@ export function FindPage({ input, locale }: FindPageProps) {
   // caption and the filter that let it through agree by construction.
   const lens = useAppSelector((state) => state.find.find.lens)
   const clockAnchor = useAppSelector((state) => state.find.find.clockAnchor)
+  const isLensRestored = useAppSelector(
+    (state) => state.find.find.isLensRestored,
+  )
 
   // The URL is the authority for the shell's selection (`RC-63`).
   useEffect(() => {
@@ -124,15 +134,9 @@ export function FindPage({ input, locale }: FindPageProps) {
   useEffect(() => {
     let cancelled = false
     const flags = dispatch(resolveCapabilityFlagsThunk())
-    const lensRestore = dispatch(
-      restoreFindLensThunk({
-        surface: FindSurface.find,
-        vistaId: EndeavorsVistas.find.id,
-      }),
-    )
-    const fetch = dispatch(
-      fetchFindEndeavorsThunk({ surface: FindSurface.find, now: new Date() }),
-    )
+    // The two effects the flag read starts, so unmount can cancel them —
+    // cancellation is the one silent exit (`UZF-14`).
+    const started: { abort: () => void }[] = []
 
     void flags.then((action) => {
       if (cancelled) return
@@ -146,13 +150,26 @@ export function FindPage({ input, locale }: FindPageProps) {
           enabledFlags: result !== null && result.ok ? result.value : [],
         }),
       )
+      started.push(
+        dispatch(
+          restoreFindLensThunk({
+            surface: FindSurface.find,
+            vistaId: EndeavorsVistas.find.id,
+          }),
+        ),
+        dispatch(
+          fetchFindEndeavorsThunk({
+            surface: FindSurface.find,
+            now: new Date(),
+          }),
+        ),
+      )
     })
 
     return () => {
       cancelled = true
       flags.abort()
-      lensRestore.abort()
-      fetch.abort()
+      for (const effect of started) effect.abort()
     }
   }, [dispatch])
 
@@ -167,9 +184,16 @@ export function FindPage({ input, locale }: FindPageProps) {
     )
   }, [dispatch, shellQuery])
 
-  // Canon persists the lens whenever it changes; a failure is swallowed by the
-  // Producer, so this never needs a result.
+  /*
+    Canon persists the lens whenever it changes; a failure is swallowed by the
+    Producer, so this never needs a result.
+
+    It is GATED on the restore having landed. Writing before then would save the
+    vista's defaults over the user's own saved filters — the snapshot would be
+    destroyed by the very mount that was about to read it.
+  */
   useEffect(() => {
+    if (!isLensRestored) return
     const effect = dispatch(
       persistFindLensThunk({
         surface: FindSurface.find,
@@ -178,7 +202,7 @@ export function FindPage({ input, locale }: FindPageProps) {
       }),
     )
     return () => effect.abort()
-  }, [dispatch, lens])
+  }, [dispatch, isLensRestored, lens])
 
   const onChangeQuery = useCallback(
     (next: string) => {

--- a/packages/app/src/features/find/pages/TasksFragment.stories.tsx
+++ b/packages/app/src/features/find/pages/TasksFragment.stories.tsx
@@ -1,0 +1,117 @@
+/**
+ * All Tasks' visual evidence (`RC-11`, `UZF-26`).
+ *
+ * The grouped list at each of its three group states — clipped (every group
+ * trimmed to seven), expanded (one group in full, its siblings collapsed), and
+ * empty — plus the two other groupings the lens exposes, and both schemes.
+ */
+import { EndeavorGroupingCriteria } from '@kro/core'
+import { BothSchemes, Stage } from '../../../design/endeavor/storyStage'
+import { allFindEndeavorMocks, nineOpenTasks } from '../FindMocks'
+import { TasksFragment } from './TasksFragment'
+import { adaptedGroups, tasksCapabilitiesWith } from './__tests__/pagesHarness'
+
+const NOW = new Date(2026, 5, 18, 9, 40)
+const noop = () => {}
+const capabilities = tasksCapabilitiesWith()
+
+const base = {
+  heading: 'Tasks',
+  subtitle: '',
+  query: '',
+  grouping: EndeavorGroupingCriteria.status,
+  groups: adaptedGroups(nineOpenTasks, capabilities),
+  expandedGroupKey: null,
+  capabilities,
+  emptyState: null,
+  isLoading: false,
+  exception: null,
+  now: NOW,
+  locale: 'en-US',
+  input: 'touch',
+  onChangeQuery: noop,
+  onSelectGrouping: noop,
+  onExpandGroup: noop,
+  onCollapseGroups: noop,
+  onOperation: noop,
+  onSelectEndeavor: noop,
+  onRetry: noop,
+} as const
+
+export default {
+  title: 'Find/All Tasks',
+  component: TasksFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+/** Nine tasks in one status: seven shown, "Show more…" for the rest. */
+export const ClippedToSeven = {
+  render: () => (
+    <Stage width={430}>
+      <TasksFragment {...base} />
+    </Stage>
+  ),
+}
+
+/** The same group expanded — the limit lifts and the siblings collapse. */
+export const OneGroupExpanded = {
+  render: () => (
+    <Stage width={430}>
+      <TasksFragment
+        {...base}
+        groups={adaptedGroups(allFindEndeavorMocks, capabilities, {
+          expandedGroupKey: 'pending',
+        })}
+        expandedGroupKey="pending"
+      />
+    </Stage>
+  ),
+}
+
+/** Grouped by kind instead of status — the control the lens exposes. */
+export const GroupedByKind = {
+  render: () => (
+    <Stage width={430}>
+      <TasksFragment
+        {...base}
+        grouping={EndeavorGroupingCriteria.kind}
+        groups={adaptedGroups(allFindEndeavorMocks, capabilities, {
+          grouping: EndeavorGroupingCriteria.kind,
+        })}
+      />
+    </Stage>
+  ),
+}
+
+/** A list destination: the heading is the list's own title. */
+export const ListDestination = {
+  render: () => (
+    <Stage width={900}>
+      <TasksFragment
+        {...base}
+        heading="Household"
+        subtitle="List"
+        input="pointer"
+        groups={adaptedGroups(allFindEndeavorMocks, capabilities)}
+      />
+    </Stage>
+  ),
+}
+
+/** Nothing stored yet. */
+export const Empty = {
+  render: () => (
+    <Stage width={430}>
+      <TasksFragment {...base} groups={[]} emptyState={{ kind: 'noData' }} />
+    </Stage>
+  ),
+}
+
+/** Both schemes, so the group headers and footlines are judged in dark too. */
+export const BothColorSchemes = {
+  render: () => (
+    <BothSchemes>
+      <TasksFragment {...base} />
+    </BothSchemes>
+  ),
+}

--- a/packages/app/src/features/find/pages/TasksFragment.test.tsx
+++ b/packages/app/src/features/find/pages/TasksFragment.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * All Tasks' render tests, mirroring `TasksFragment.stories.tsx` (`RC-11`).
+ *
+ * The display limit and its three group states are the behaviour worth
+ * asserting here: seven rows and a "Show more…", then one group in full with
+ * its siblings collapsed, and the affordance changing wording with the state.
+ */
+import { EndeavorGroupingCriteria } from '@kro/core'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installPointerEvents } from '../../../design/endeavor/__tests__/pointerEnvironment'
+import { allFindEndeavorMocks, nineOpenTasks } from '../FindMocks'
+import { TasksFragment, type TasksFragmentProps } from './TasksFragment'
+import { adaptedGroups, tasksCapabilitiesWith } from './__tests__/pagesHarness'
+
+const NOW = new Date(2026, 5, 18, 9, 40)
+const capabilities = tasksCapabilitiesWith()
+
+let pointerEnvironment: () => void
+
+beforeEach(() => {
+  pointerEnvironment = installPointerEvents()
+})
+
+afterEach(() => {
+  cleanup()
+  pointerEnvironment()
+})
+
+const props = (
+  overrides: Partial<TasksFragmentProps> = {},
+): TasksFragmentProps => ({
+  heading: 'Tasks',
+  subtitle: '',
+  query: '',
+  grouping: EndeavorGroupingCriteria.status,
+  groups: adaptedGroups(nineOpenTasks, capabilities),
+  expandedGroupKey: null,
+  capabilities,
+  emptyState: null,
+  isLoading: false,
+  exception: null,
+  now: NOW,
+  locale: 'en-US',
+  input: 'touch',
+  onChangeQuery: () => {},
+  onSelectGrouping: () => {},
+  onExpandGroup: () => {},
+  onCollapseGroups: () => {},
+  onOperation: () => {},
+  onSelectEndeavor: () => {},
+  onRetry: () => {},
+  ...overrides,
+})
+
+describe('the grouped list', () => {
+  it('shows seven rows of a nine-row group and offers the rest', () => {
+    render(<TasksFragment {...props()} />)
+
+    const group = screen.getByTestId('tasks-group')
+    expect(within(group).getAllByTestId('tasks-row-open')).toHaveLength(7)
+    expect(within(group).getByRole('button', { name: 'Show more…' })).toBeTruthy()
+  })
+
+  it('states the group\'s TOTAL count in its header, not the clipped one', () => {
+    render(<TasksFragment {...props()} />)
+
+    expect(screen.getByRole('heading', { name: 'Pending (9)' })).toBeTruthy()
+  })
+
+  it('lists every row and states the count once a group is expanded', () => {
+    render(
+      <TasksFragment
+        {...props({
+          groups: adaptedGroups(nineOpenTasks, capabilities, {
+            expandedGroupKey: 'pending',
+          }),
+          expandedGroupKey: 'pending',
+        })}
+      />,
+    )
+
+    const group = screen.getByTestId('tasks-group')
+    expect(within(group).getAllByTestId('tasks-row-open')).toHaveLength(9)
+    expect(within(group).getByText('9 tasks listed')).toBeTruthy()
+  })
+
+  it('collapses the siblings of the expanded group, as canon does', () => {
+    render(
+      <TasksFragment
+        {...props({
+          groups: adaptedGroups(allFindEndeavorMocks, capabilities, {
+            expandedGroupKey: 'pending',
+          }),
+          expandedGroupKey: 'pending',
+        })}
+      />,
+    )
+
+    const collapsed = screen
+      .getAllByTestId('tasks-group')
+      .filter((group) => group.dataset.groupState === 'collapsed')
+    expect(collapsed.length).toBeGreaterThan(0)
+    for (const group of collapsed) {
+      expect(within(group).queryAllByTestId('tasks-row-open')).toHaveLength(0)
+    }
+  })
+})
+
+describe('the group affordance says what it will do', () => {
+  it('offers "Show All" while every group is clipped', async () => {
+    const onExpandGroup = vi.fn()
+    render(<TasksFragment {...props({ onExpandGroup })} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show All' }))
+
+    expect(onExpandGroup).toHaveBeenCalledWith('pending')
+  })
+
+  it('offers "Collapse" on the group that is open', async () => {
+    const onCollapseGroups = vi.fn()
+    render(
+      <TasksFragment
+        {...props({
+          groups: adaptedGroups(nineOpenTasks, capabilities, {
+            expandedGroupKey: 'pending',
+          }),
+          expandedGroupKey: 'pending',
+          onCollapseGroups,
+        })}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Collapse' }))
+
+    expect(onCollapseGroups).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers "Show" on a sibling the expansion collapsed', () => {
+    render(
+      <TasksFragment
+        {...props({
+          groups: adaptedGroups(allFindEndeavorMocks, capabilities, {
+            expandedGroupKey: 'pending',
+          }),
+          expandedGroupKey: 'pending',
+        })}
+      />,
+    )
+
+    expect(screen.getAllByRole('button', { name: 'Show' }).length).toBeGreaterThan(0)
+  })
+})
+
+describe('the grouping control', () => {
+  it('states the four criteria as one exclusive choice', () => {
+    render(<TasksFragment {...props()} />)
+
+    const control = screen.getByRole('radiogroup', { name: 'Group by' })
+    expect(within(control).getAllByRole('radio')).toHaveLength(4)
+    expect(
+      within(control).getByRole('radio', { name: 'Status' }).getAttribute('aria-checked'),
+    ).toBe('true')
+  })
+
+  it('reports the criterion the user picked', async () => {
+    const onSelectGrouping = vi.fn()
+    render(<TasksFragment {...props({ onSelectGrouping })} />)
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Kind' }))
+
+    expect(onSelectGrouping).toHaveBeenCalledWith(EndeavorGroupingCriteria.kind)
+  })
+})
+
+describe('rows', () => {
+  it('opens Detail from a row\'s own named control — not by wrapping the row', async () => {
+    const onSelectEndeavor = vi.fn()
+    render(<TasksFragment {...props({ onSelectEndeavor })} />)
+
+    await userEvent.click(screen.getAllByTestId('tasks-row-open')[0] as HTMLElement)
+
+    expect(onSelectEndeavor).toHaveBeenCalledWith(nineOpenTasks[0]?.id)
+  })
+
+  it('keeps that control OUTSIDE the action surface, so neither grammar eats it', () => {
+    render(<TasksFragment {...props({ input: 'pointer' })} />)
+
+    for (const open of screen.getAllByTestId('tasks-row-open')) {
+      // The kit's hover strip is an overlay on the row's trailing edge, and its
+      // touch counterpart takes a pointer capture; a control inside the surface
+      // would be unclickable under either.
+      expect(open.closest('[data-slot="endeavor-action-surface"]')).toBeNull()
+    }
+  })
+
+  it('still carries the vista\'s row operations beside that control', () => {
+    render(<TasksFragment {...props({ input: 'pointer' })} />)
+
+    expect(screen.getAllByRole('button', { name: 'Complete' }).length).toBe(7)
+  })
+
+  it('names the heading and, on a list destination, its subtitle', () => {
+    render(<TasksFragment {...props({ heading: 'Household', subtitle: 'List' })} />)
+
+    expect(screen.getByRole('heading', { name: 'Household' })).toBeTruthy()
+    expect(screen.getByText('List')).toBeTruthy()
+  })
+})
+
+describe('empty and failed states', () => {
+  it('shows canon\'s first-run message when nothing is stored', () => {
+    render(
+      <TasksFragment {...props({ groups: [], emptyState: { kind: 'noData' } })} />,
+    )
+
+    expect(screen.getByText('No Endeavors Yet')).toBeTruthy()
+  })
+
+  it('surfaces a recoverable failure with its retry', async () => {
+    const onRetry = vi.fn()
+    render(
+      <TasksFragment
+        {...props({
+          exception: {
+            kind: 'fetchFailed',
+            message: "Couldn't load your endeavors: offline",
+            recoverable: true,
+          },
+          onRetry,
+        })}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports every keystroke of its own search field', async () => {
+    const onChangeQuery = vi.fn()
+    render(<TasksFragment {...props({ onChangeQuery })} />)
+
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search tasks' }), 'a')
+
+    expect(onChangeQuery).toHaveBeenCalledWith('a')
+  })
+})

--- a/packages/app/src/features/find/pages/TasksFragment.tsx
+++ b/packages/app/src/features/find/pages/TasksFragment.tsx
@@ -1,0 +1,466 @@
+'use client'
+
+/**
+ * All Tasks — the port of `KroUI/Tasks/TasksView.swift` (`RC-15`).
+ *
+ * The grouped task list behind the sidebar's All Tasks row and behind every
+ * Lists destination. Pure: no store read, no dispatch; every value is a prop.
+ *
+ * ## The three parts canon's macOS body has, in canon's order
+ *
+ * A heading with its glyph, a grouping control, then one block per group: a
+ * header carrying the group's name and its **total** count, the group's rows,
+ * and a footline that either offers "Show more…" or states how many are listed.
+ * `GroupForTasks.state` is what the header's affordance keys on — *Show All*
+ * while every group is clipped, *Collapse* on the one that is open, *Show* on
+ * its siblings — and `EndeavorGroupDisplayState` is that same value, computed
+ * by `#29`'s `groupDisplayState`.
+ *
+ * ## What canon has here and this port does not
+ *
+ * **The new-task box.** Canon's macOS body opens with a "Write a new task…"
+ * field, and its iOS body with an "ADD NEW TASK" section. Creating an endeavor
+ * is the capture feature's (KC-IS-#23 logic, KC-IS-#24 UI), and `findSlice`
+ * declares no create event at all — so a field here would either dispatch
+ * nothing or reach into a sibling slice (`RC-20`). Named in the PR body rather
+ * than faked.
+ *
+ * **The Reminders banner.** Canon offers "Connect to Reminders"; Apple
+ * Reminders has no web equivalent at all, which the epic states as out of
+ * scope. There is nothing to connect to, so there is no banner.
+ *
+ * ## Selecting a row opens Detail
+ *
+ * Canon's macOS `TaskRow` raises `onSelected`, and the Tasks screen answers it
+ * with a trailing detail panel. This build has no trailing panel — the epic
+ * maps that content onto a sheet — so the row's selection raises
+ * `onSelectEndeavor`, which the Page turns into the same Detail presentation
+ * the `viewDetail` capability raises. That keeps Detail reachable from a
+ * surface whose vista declares no `viewDetail` binding, which is exactly the
+ * "opens from any endeavor row" contract, and it is the only reason a reader
+ * will find a selection affordance here that canon's iOS body does not have.
+ */
+import {
+  type EndeavorCapabilities,
+  type EndeavorGroupingCriteria,
+  endeavorGroupingCriteriaCases,
+  endeavorGroupingCriteriaDisplayName,
+} from '@kro/core'
+import { EmptyStateCard } from '../../../design/endeavor/EmptyStateCard'
+import { EndeavorRow } from '../../../design/endeavor/EndeavorRow'
+import { InlineBanner } from '../../../design/endeavor/InlineBanner'
+import { KroChip, semanticTint } from '../../../design/endeavor/KroChip'
+import { endeavorIcon } from '../../../design/endeavor/endeavorIcons'
+import type { OnEndeavorOperation } from '../../../design/endeavor/rowActions'
+import type { InputCapability } from '../../../design/endeavor/useInputCapability'
+import { colorVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import type { EndeavorRowAdapter } from '../FindAdapters'
+import type { FindException } from '../FindException'
+import {
+  EndeavorGroupDisplayState,
+  type EndeavorRowGroup,
+  groupDisplayState,
+} from '../FindGrouping'
+import type { FindEmptyState } from '../FindState'
+import {
+  findEmptyCopy,
+  findRowBadges,
+  findRowSymbol,
+  findRowTimeInfo,
+} from './findPresentation'
+
+const Search = endeavorIcon('magnifyingglass')
+const Checklist = endeavorIcon('checklist')
+const ChevronRight = endeavorIcon('chevron.right')
+
+/** One group, already adapted — the shape `selectTasksGroupAdapters` returns. */
+export interface TasksGroupModel {
+  readonly group: EndeavorRowGroup
+  readonly rows: readonly EndeavorRowAdapter[]
+}
+
+export interface TasksFragmentProps {
+  /** Canon's `expectedHeading` — the caller's override, the list, or "Tasks". */
+  readonly heading: string
+  /** Canon's `expectedTitle` — the macOS subtitle. Empty means none. */
+  readonly subtitle: string
+  readonly query: string
+  readonly grouping: EndeavorGroupingCriteria
+  readonly groups: readonly TasksGroupModel[]
+  readonly expandedGroupKey: string | null
+  readonly capabilities: EndeavorCapabilities
+  readonly emptyState: FindEmptyState | null
+  readonly isLoading: boolean
+  readonly exception: FindException | null
+  readonly now: Date
+  readonly input?: InputCapability
+  readonly locale?: string
+  readonly onChangeQuery: (query: string) => void
+  readonly onSelectGrouping: (grouping: EndeavorGroupingCriteria) => void
+  readonly onExpandGroup: (groupKey: string) => void
+  readonly onCollapseGroups: () => void
+  readonly onOperation: OnEndeavorOperation
+  readonly onSelectEndeavor: (endeavorId: string) => void
+  readonly onRetry: () => void
+}
+
+export function TasksFragment(props: TasksFragmentProps) {
+  const {
+    heading,
+    subtitle,
+    query,
+    grouping,
+    groups,
+    expandedGroupKey,
+    capabilities,
+    emptyState,
+    isLoading,
+    exception,
+    now,
+    input,
+    locale,
+    onChangeQuery,
+    onSelectGrouping,
+    onExpandGroup,
+    onCollapseGroups,
+    onOperation,
+    onSelectEndeavor,
+    onRetry,
+  } = props
+
+  return (
+    <section
+      data-testid="tasks-surface"
+      aria-label={heading}
+      className="flex h-full min-h-0 flex-col"
+    >
+      <div className="flex flex-col gap-kro-small px-kro-medium pt-kro-medium">
+        <div className="flex items-center gap-kro-small">
+          <Checklist
+            size={26}
+            aria-hidden
+            style={{ color: colorVar('accent') }}
+          />
+          <div className="flex min-w-0 flex-col">
+            <h2
+              className="m-0 truncate font-bold text-2xl"
+              style={{ color: colorVar('fore') }}
+            >
+              {heading}
+            </h2>
+            {subtitle.length === 0 ? null : (
+              <p
+                className="m-0 truncate text-sm"
+                style={{ color: colorVar('foreSecondary') }}
+              >
+                {subtitle}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <form
+          role="search"
+          onSubmit={(event) => event.preventDefault()}
+          className="flex items-center gap-kro-small rounded-kro-field px-kro-small"
+          style={{
+            backgroundColor: colorVar('backInner'),
+            minHeight: 'var(--kro-size-min-touch-target)',
+          }}
+        >
+          <Search
+            size={16}
+            aria-hidden
+            className="shrink-0"
+            style={{ color: colorVar('foreSecondary') }}
+          />
+          <input
+            type="search"
+            aria-label="Search tasks"
+            placeholder="Search tasks"
+            value={query}
+            onChange={(event) => onChangeQuery(event.target.value)}
+            className="w-full bg-transparent text-sm outline-none"
+            style={{ color: colorVar('fore') }}
+          />
+        </form>
+
+        <GroupingControl grouping={grouping} onSelectGrouping={onSelectGrouping} />
+
+        {exception === null ? null : (
+          <InlineBanner
+            message={exception.message}
+            actionTitle={exception.recoverable ? 'Try again' : undefined}
+            onAction={exception.recoverable ? onRetry : undefined}
+          />
+        )}
+      </div>
+
+      <div
+        aria-busy={isLoading}
+        className="min-h-0 flex-1 overflow-y-auto px-kro-medium pt-kro-small pb-kro-x-large"
+      >
+        {emptyState !== null ? (
+          <div
+            data-testid="tasks-empty-state"
+            data-empty-kind={emptyState.kind}
+            className="flex h-full items-center justify-center py-kro-x-large"
+          >
+            <EmptyStateCard {...findEmptyCopy(emptyState)} />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-kro-medium">
+            {groups.map((model) => (
+              <TasksGroupBlock
+                key={model.group.key}
+                model={model}
+                state={groupDisplayState(model.group, expandedGroupKey)}
+                capabilities={capabilities}
+                now={now}
+                input={input}
+                locale={locale}
+                onExpandGroup={onExpandGroup}
+                onCollapseGroups={onCollapseGroups}
+                onOperation={onOperation}
+                onSelectEndeavor={onSelectEndeavor}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* Grouping control                                                          */
+/* ------------------------------------------------------------------------ */
+
+/**
+ * The lens's `grouping` toggle — the control canon exposes through
+ * `UserFilter.grouping` on every `.tasks*` vista.
+ *
+ * A `radiogroup` rather than a menu: the four criteria are mutually exclusive
+ * and all four fit, so a segmented control states the whole choice at a glance,
+ * which a menu hides behind a tap.
+ */
+function GroupingControl({
+  grouping,
+  onSelectGrouping,
+}: {
+  readonly grouping: EndeavorGroupingCriteria
+  readonly onSelectGrouping: (grouping: EndeavorGroupingCriteria) => void
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Group by"
+      data-testid="tasks-grouping-control"
+      className="flex gap-kro-small overflow-x-auto pb-kro-tiny"
+    >
+      {endeavorGroupingCriteriaCases.map((criteria) => {
+        const isSelected = criteria === grouping
+        return (
+          <button
+            key={criteria}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            onClick={() => onSelectGrouping(criteria)}
+            data-grouping-option={criteria}
+            className="inline-flex shrink-0 items-center rounded-kro-pill outline-none focus-visible:shadow-[var(--kro-ring)]"
+            style={{ minHeight: 'var(--kro-size-min-touch-target)' }}
+          >
+            <KroChip
+              title={endeavorGroupingCriteriaDisplayName(criteria)}
+              tint={semanticTint('chipNeutral')}
+              emphasis={isSelected ? 'prominent' : 'outline'}
+              size="small"
+            />
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------------ */
+/* One group                                                                 */
+/* ------------------------------------------------------------------------ */
+
+function TasksGroupBlock({
+  model,
+  state,
+  capabilities,
+  now,
+  input,
+  locale,
+  onExpandGroup,
+  onCollapseGroups,
+  onOperation,
+  onSelectEndeavor,
+}: {
+  readonly model: TasksGroupModel
+  readonly state: EndeavorGroupDisplayState
+  readonly capabilities: EndeavorCapabilities
+  readonly now: Date
+  readonly input?: InputCapability
+  readonly locale?: string
+  readonly onExpandGroup: (groupKey: string) => void
+  readonly onCollapseGroups: () => void
+  readonly onOperation: OnEndeavorOperation
+  readonly onSelectEndeavor: (endeavorId: string) => void
+}) {
+  const { group, rows } = model
+  const isCollapsed = state === EndeavorGroupDisplayState.collapsed
+
+  return (
+    <section
+      data-testid="tasks-group"
+      data-group-key={group.key}
+      data-group-state={state}
+      className="flex flex-col gap-kro-small"
+    >
+      <header className="flex items-center gap-kro-small px-kro-tiny">
+        <h3
+          className="m-0 font-semibold text-base"
+          style={{ color: colorVar('fore') }}
+        >
+          {group.title} ({group.totalCount})
+        </h3>
+        <span className="flex-1" />
+        <GroupAffordance
+          state={state}
+          groupKey={group.key}
+          onExpandGroup={onExpandGroup}
+          onCollapseGroups={onCollapseGroups}
+        />
+      </header>
+
+      {isCollapsed ? null : (
+        <>
+          <ul className="m-0 flex list-none flex-col gap-kro-small p-0">
+            {rows.map((adapter) => {
+              const lead = findRowSymbol(adapter.endeavor.title)
+              const name = lead.title.length === 0 ? 'Untitled' : lead.title
+              return (
+                /*
+                  The Open control is a SIBLING of the row, not its `trailing`
+                  slot and not a wrapper around it. Three real reasons, all of
+                  which only show up in a browser:
+
+                  · a `<button>` may hold only phrasing content, so wrapping the
+                    row would be invalid markup;
+                  · on POINTER the kit's hover strip is an absolutely-positioned
+                    overlay on the row's trailing edge with `pointer-events` on
+                    while hovered — anything inside the row underneath it is
+                    unclickable, which is exactly what a mouse hovering the row
+                    would find;
+                  · on TOUCH the action surface takes a POINTER CAPTURE on
+                    `pointerdown` so a swipe cannot be lost mid-gesture; a
+                    control inside the captured element therefore never sees its
+                    click.
+
+                  Outside the surface, the control is reachable by both input
+                  types and the swipe still owns the row itself.
+                */
+                <li key={adapter.id} className="flex items-center gap-kro-small">
+                  <div className="min-w-0 flex-1">
+                    <EndeavorRow
+                      endeavorId={adapter.id}
+                      capabilities={capabilities}
+                      onOperation={onOperation}
+                      input={input}
+                      symbol={lead.symbol}
+                      isGenericSymbol={lead.isGeneric}
+                      title={lead.title}
+                      timeInfo={findRowTimeInfo(adapter.endeavor)}
+                      badges={findRowBadges(adapter.endeavor)}
+                      now={now}
+                      locale={locale}
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    aria-label={`Open ${name}`}
+                    data-testid="tasks-row-open"
+                    onClick={() => onSelectEndeavor(adapter.id)}
+                    className="inline-flex shrink-0 items-center justify-center rounded-kro-pill outline-none focus-visible:shadow-[var(--kro-ring)]"
+                    style={{
+                      minWidth: 'var(--kro-size-min-touch-target)',
+                      minHeight: 'var(--kro-size-min-touch-target)',
+                      color: colorVar('foreSecondary'),
+                    }}
+                  >
+                    <ChevronRight size={16} aria-hidden />
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+          <p
+            data-testid="tasks-group-footline"
+            className="m-0 px-kro-tiny text-sm"
+            style={{ color: colorVar('foreSecondary') }}
+          >
+            {group.isTrimmed ? (
+              <button
+                type="button"
+                onClick={() => onExpandGroup(group.key)}
+                className="underline underline-offset-2 outline-none focus-visible:shadow-[var(--kro-ring)]"
+                style={{ color: colorVar('accent') }}
+              >
+                Show more…
+              </button>
+            ) : (
+              `${rows.length} tasks listed`
+            )}
+          </p>
+        </>
+      )}
+    </section>
+  )
+}
+
+/**
+ * Canon's `sectionHeader` link, one affordance per state: *Show All* while
+ * every group is clipped, *Collapse* on the group that is open, *Show* on the
+ * siblings it collapsed.
+ */
+function GroupAffordance({
+  state,
+  groupKey,
+  onExpandGroup,
+  onCollapseGroups,
+}: {
+  readonly state: EndeavorGroupDisplayState
+  readonly groupKey: string
+  readonly onExpandGroup: (groupKey: string) => void
+  readonly onCollapseGroups: () => void
+}) {
+  const label =
+    state === EndeavorGroupDisplayState.expanded
+      ? 'Collapse'
+      : state === EndeavorGroupDisplayState.collapsed
+        ? 'Show'
+        : 'Show All'
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        state === EndeavorGroupDisplayState.expanded
+          ? onCollapseGroups()
+          : onExpandGroup(groupKey)
+      }
+      className="inline-flex items-center rounded-kro-small px-kro-tiny text-xs font-semibold outline-none focus-visible:shadow-[var(--kro-ring)]"
+      style={{
+        color: colorVar('accent'),
+        minHeight: 'var(--kro-size-min-touch-target)',
+      }}
+    >
+      {label}
+    </button>
+  )
+}

--- a/packages/app/src/features/find/pages/TasksPage.stories.tsx
+++ b/packages/app/src/features/find/pages/TasksPage.stories.tsx
@@ -1,0 +1,69 @@
+/**
+ * All Tasks, mounted on a real store (`RC-11`).
+ *
+ * The three destinations one Page serves — `/tasks`, a Lists destination, and a
+ * seeded search — plus the empty case, all fetching through the real Producer
+ * over a seeded database.
+ */
+import { Stage } from '../../../design/endeavor/storyStage'
+import { allFindEndeavorMocks, nineOpenTasks } from '../FindMocks'
+import { TasksPage } from './TasksPage'
+import { Harness, makeSeededStore } from './__tests__/pagesHarness'
+
+export default {
+  title: 'Find/All Tasks page',
+  component: TasksPage,
+  parameters: { layout: 'fullscreen' },
+}
+
+/** `/tasks` — the default vista, nine tasks in one status, clipped to seven. */
+export const AllTasks = {
+  render: () => (
+    <Stage width={430}>
+      <Harness store={makeSeededStore({ endeavors: nineOpenTasks })}>
+        <TasksPage selection={{ kind: 'default' }} input="touch" locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}
+
+/** A Lists destination — the same surface over `tasksForList(id)`. */
+export const ListDestination = {
+  render: () => (
+    <Stage width={900}>
+      <Harness store={makeSeededStore({ endeavors: allFindEndeavorMocks })}>
+        <TasksPage
+          selection={{ kind: 'list', listId: 'proj-1', listTitle: 'Household' }}
+          input="pointer"
+          locale="en-US"
+        />
+      </Harness>
+    </Stage>
+  ),
+}
+
+/** A seeded search — `tasksForSearch(query)`, with its own saved lens. */
+export const SeededSearch = {
+  render: () => (
+    <Stage width={430}>
+      <Harness store={makeSeededStore({ endeavors: allFindEndeavorMocks })}>
+        <TasksPage
+          selection={{ kind: 'search', query: 'report' }}
+          input="touch"
+          locale="en-US"
+        />
+      </Harness>
+    </Stage>
+  ),
+}
+
+/** Nothing stored yet. */
+export const Empty = {
+  render: () => (
+    <Stage width={430}>
+      <Harness store={makeSeededStore()}>
+        <TasksPage selection={{ kind: 'default' }} input="touch" locale="en-US" />
+      </Harness>
+    </Stage>
+  ),
+}

--- a/packages/app/src/features/find/pages/TasksPage.test.tsx
+++ b/packages/app/src/features/find/pages/TasksPage.test.tsx
@@ -7,13 +7,18 @@
  * lens rather than carrying the previous list's grouping onto the next one's
  * rows.
  */
-import { EndeavorGroupingCriteria, makeProject } from '@kro/core'
+import {
+  EndeavorGroupingCriteria,
+  EndeavorsVistas,
+  makeEndeavorsLensSnapshot,
+  makeProject,
+} from '@kro/core'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it } from 'vitest'
 import { loadShellThunk } from '../../main/MainProducer'
 import { allFindEndeavorMocks, findEndeavorMocks, nineOpenTasks } from '../FindMocks'
-import type { TasksVistaSelection } from '../FindState'
+import { type TasksVistaSelection, initialTasksLens } from '../FindState'
 import { TasksPage } from './TasksPage'
 import { Harness, makeSeededStore } from './__tests__/pagesHarness'
 
@@ -114,6 +119,29 @@ describe('mount', () => {
         listId: 'proj-2',
       })
     })
+  })
+})
+
+describe('the saved lens survives the mount that reads it', () => {
+  it('restores the list\'s own saved grouping rather than the vista default', async () => {
+    const store = makeSeededStore({
+      endeavors: nineOpenTasks,
+      lensSnapshots: {
+        [EndeavorsVistas.tasksDefault.id]: makeEndeavorsLensSnapshot({
+          ...initialTasksLens,
+          grouping: EndeavorGroupingCriteria.dueSection,
+        }),
+      },
+    })
+
+    mount({ kind: 'default' }, store)
+
+    await waitFor(() => {
+      expect(store.getState().find.tasks.lens.grouping).toBe(
+        EndeavorGroupingCriteria.dueSection,
+      )
+    })
+    expect(store.getState().find.tasks.isLensRestored).toBe(true)
   })
 })
 

--- a/packages/app/src/features/find/pages/TasksPage.test.tsx
+++ b/packages/app/src/features/find/pages/TasksPage.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * All Tasks' container, against a real store over a seeded database
+ * (`RC-22`, `RC-35`).
+ *
+ * The behaviour worth proving here is the one the three destinations share: the
+ * SELECTION decides which vista is installed, and re-declaring it reseeds the
+ * lens rather than carrying the previous list's grouping onto the next one's
+ * rows.
+ */
+import { EndeavorGroupingCriteria, makeProject } from '@kro/core'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+import { loadShellThunk } from '../../main/MainProducer'
+import { allFindEndeavorMocks, findEndeavorMocks, nineOpenTasks } from '../FindMocks'
+import type { TasksVistaSelection } from '../FindState'
+import { TasksPage } from './TasksPage'
+import { Harness, makeSeededStore } from './__tests__/pagesHarness'
+
+afterEach(cleanup)
+
+const mount = (
+  selection: TasksVistaSelection = { kind: 'default' },
+  store = makeSeededStore({ endeavors: nineOpenTasks }),
+) => {
+  const view = render(
+    <Harness store={store}>
+      <TasksPage selection={selection} input="touch" locale="en-US" />
+    </Harness>,
+  )
+  return { store, view }
+}
+
+describe('mount', () => {
+  it('fetches through the real Producer and groups what the database held', async () => {
+    mount()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Pending (9)' })).toBeTruthy()
+    })
+    expect(screen.getAllByTestId('tasks-row-open')).toHaveLength(7)
+  })
+
+  it('installs the vista the selection names', async () => {
+    const { store } = mount({
+      kind: 'list',
+      listId: 'proj-1',
+      listTitle: 'Household',
+    })
+
+    await waitFor(() => {
+      expect(store.getState().find.tasksSelection).toEqual({
+        kind: 'list',
+        listId: 'proj-1',
+        listTitle: 'Household',
+      })
+    })
+  })
+
+  it('heads a list destination with the list\'s own title', async () => {
+    mount(
+      { kind: 'list', listId: 'proj-1', listTitle: 'Household' },
+      makeSeededStore({ endeavors: allFindEndeavorMocks }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Household' })).toBeTruthy()
+    })
+  })
+
+  it('looks the title up from the shell\'s Lists when the route carries only an id', async () => {
+    const store = makeSeededStore({
+      endeavors: allFindEndeavorMocks,
+      projects: [makeProject({ id: 'proj-1', title: 'Household' })],
+    })
+    await store.dispatch(loadShellThunk())
+
+    mount({ kind: 'list', listId: 'proj-1', listTitle: null }, store)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Household' })).toBeTruthy()
+    })
+  })
+
+  it('falls back to the generic heading rather than guessing an unknown list\'s name', async () => {
+    mount(
+      { kind: 'list', listId: 'never-loaded', listTitle: null },
+      makeSeededStore({ endeavors: allFindEndeavorMocks }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Tasks' })).toBeTruthy()
+    })
+  })
+
+  it('tells the shell which destination the URL landed on', async () => {
+    const { store } = mount()
+
+    await waitFor(() => {
+      expect(store.getState().main.selected.kind).toBe('allTasks')
+    })
+  })
+
+  it('selects the Lists destination when the route carries a list id', async () => {
+    const { store } = mount({
+      kind: 'list',
+      listId: 'proj-2',
+      listTitle: 'Work',
+    })
+
+    await waitFor(() => {
+      expect(store.getState().main.selected).toMatchObject({
+        kind: 'list',
+        listId: 'proj-2',
+      })
+    })
+  })
+})
+
+describe('the grouping control writes the lens', () => {
+  it('regroups the list by the criterion the user picked', async () => {
+    const { store } = mount(
+      { kind: 'default' },
+      makeSeededStore({ endeavors: allFindEndeavorMocks }),
+    )
+    await waitFor(() => {
+      expect(screen.getByRole('radiogroup', { name: 'Group by' })).toBeTruthy()
+    })
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Kind' }))
+
+    await waitFor(() => {
+      expect(store.getState().find.tasks.lens.grouping).toBe(
+        EndeavorGroupingCriteria.kind,
+      )
+    })
+  })
+})
+
+describe('the display limit', () => {
+  it('lifts the limit for the group the user expanded', async () => {
+    const { store } = mount()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Show All' })).toBeTruthy()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show All' }))
+
+    await waitFor(() => {
+      expect(store.getState().find.tasks.expandedGroupKey).toBe('pending')
+    })
+    expect(screen.getAllByTestId('tasks-row-open')).toHaveLength(9)
+  })
+})
+
+describe('selecting a row raises the Detail intent', () => {
+  it('parks a viewDetail request the global overlay can serve', async () => {
+    const { store } = mount(
+      { kind: 'default' },
+      makeSeededStore({ endeavors: [findEndeavorMocks.morningTask] }),
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('tasks-row-open')).toBeTruthy()
+    })
+
+    await userEvent.click(screen.getByTestId('tasks-row-open'))
+
+    await waitFor(() => {
+      expect(store.getState().find.intents).toEqual([
+        {
+          id: 1,
+          operation: 'viewDetail',
+          endeavorId: findEndeavorMocks.morningTask.id,
+          surface: 'tasks',
+        },
+      ])
+    })
+  })
+})

--- a/packages/app/src/features/find/pages/TasksPage.tsx
+++ b/packages/app/src/features/find/pages/TasksPage.tsx
@@ -11,6 +11,13 @@
  * three near-copies — which is the same argument `FindState`'s own header makes
  * for one slice carrying two surfaces.
  *
+ * ## Mount order, and the two races it avoids
+ *
+ * The restore and the fetch wait for `onViewLoaded`, and the lens is persisted
+ * only once the restore has landed. Both are `FindPage`'s reasoning verbatim —
+ * see its header — and both matter more here, because a Lists destination
+ * re-runs this whole sequence every time the route's identity changes.
+ *
  * ## The selection is re-declared whenever the route's identity changes
  *
  * `userDidSelectTasksVista` reseeds the lens from the new vista's defaults and
@@ -95,6 +102,9 @@ export function TasksPage({
   // O(1) field reads, exactly as `FindPage` does and for the same two reasons.
   const lens = useAppSelector((state) => state.find.tasks.lens)
   const clockAnchor = useAppSelector((state) => state.find.tasks.clockAnchor)
+  const isLensRestored = useAppSelector(
+    (state) => state.find.tasks.isLensRestored,
+  )
 
   const listId = selection.kind === 'list' ? selection.listId : null
   const seededQuery = selection.kind === 'search' ? selection.query : null
@@ -155,12 +165,9 @@ export function TasksPage({
   useEffect(() => {
     let cancelled = false
     const flags = dispatch(resolveCapabilityFlagsThunk())
-    const lensRestore = dispatch(
-      restoreFindLensThunk({ surface: FindSurface.tasks, vistaId }),
-    )
-    const fetch = dispatch(
-      fetchFindEndeavorsThunk({ surface: FindSurface.tasks, now: new Date() }),
-    )
+    // The two effects the flag read starts, so unmount can cancel them —
+    // cancellation is the one silent exit (`UZF-14`).
+    const started: { abort: () => void }[] = []
 
     void flags.then((action) => {
       if (cancelled) return
@@ -174,22 +181,33 @@ export function TasksPage({
           enabledFlags: result !== null && result.ok ? result.value : [],
         }),
       )
+      started.push(
+        dispatch(restoreFindLensThunk({ surface: FindSurface.tasks, vistaId })),
+        dispatch(
+          fetchFindEndeavorsThunk({
+            surface: FindSurface.tasks,
+            now: new Date(),
+          }),
+        ),
+      )
     })
 
     return () => {
       cancelled = true
       flags.abort()
-      lensRestore.abort()
-      fetch.abort()
+      for (const effect of started) effect.abort()
     }
   }, [dispatch, vistaId])
 
+  // Gated on the restore, exactly as `FindPage` is and for the same reason:
+  // an ungated write saves the vista's defaults over the user's own filters.
   useEffect(() => {
+    if (!isLensRestored) return
     const effect = dispatch(
       persistFindLensThunk({ surface: FindSurface.tasks, vistaId, lens }),
     )
     return () => effect.abort()
-  }, [dispatch, vistaId, lens])
+  }, [dispatch, isLensRestored, vistaId, lens])
 
   const onOperation = useCallback(
     (operation: EndeavorOperation, endeavorId: string) => {

--- a/packages/app/src/features/find/pages/TasksPage.tsx
+++ b/packages/app/src/features/find/pages/TasksPage.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+/**
+ * All Tasks' stateful container (`RC-37`) — canon's `TasksScreen`.
+ *
+ * One Page serves **three** destinations, because after the vista migration
+ * they differ only in which `.tasks*` vista is installed: `/tasks` installs
+ * `tasksDefault`, a Lists destination installs `tasksForList(id)`, and a seeded
+ * search installs `tasksForSearch(query)`. `#29` modelled that as one surface
+ * over a `TasksVistaSelection`, so the render tier gets one Page rather than
+ * three near-copies — which is the same argument `FindState`'s own header makes
+ * for one slice carrying two surfaces.
+ *
+ * ## The selection is re-declared whenever the route's identity changes
+ *
+ * `userDidSelectTasksVista` reseeds the lens from the new vista's defaults and
+ * clears the expanded group, so navigating between two lists cannot leave the
+ * previous list's grouping applied to the next one's rows. That is why the
+ * effect is keyed on the selection's identity fields rather than the object.
+ */
+import {
+  type EndeavorGroupingCriteria,
+  type EndeavorOperation,
+} from '@kro/core'
+import { useCallback, useEffect, useMemo } from 'react'
+import type { InputCapability } from '../../../design/endeavor/useInputCapability'
+import { useAppDispatch, useAppSelector } from '../../../library/hooks'
+import { onDestinationRouteMounted } from '../../main/MainFeature'
+import { selectProjects } from '../../main/MainSelectors'
+import { DestinationKind } from '../../main/SidebarDestination'
+import {
+  onViewLoaded,
+  userDidChangeSearchQuery,
+  userDidSelectGrouping,
+  userDidSelectTasksVista,
+  userDidTapCollapseGroups,
+  userDidTapExpandGroup,
+} from '../FindFeature'
+import { FindSurface } from '../FindOperations'
+import {
+  fetchFindEndeavorsThunk,
+  performEndeavorOperationThunk,
+  persistFindLensThunk,
+  restoreFindLensThunk,
+} from '../FindProducer'
+import {
+  selectTasksCapabilities,
+  selectTasksEmptyState,
+  selectTasksException,
+  selectTasksExpandedGroupKey,
+  selectTasksGroupAdapters,
+  selectTasksGrouping,
+  selectTasksHeading,
+  selectTasksSearchQuery,
+  selectTasksTitle,
+  selectIsTasksLoading,
+} from '../FindSelectors'
+import { type TasksVistaSelection, tasksVistaIdFor } from '../FindState'
+import { resolveCapabilityFlagsThunk } from './FindCapabilitiesProducer'
+import { TasksFragment } from './TasksFragment'
+
+/** The anchor before the first install — `FindSelectors`' own fallback. */
+const EPOCH = new Date(0)
+
+export interface TasksPageProps {
+  /**
+   * Which `.tasks*` vista to install. `/tasks` passes the default; a Lists
+   * destination passes its own id and title.
+   */
+  readonly selection: TasksVistaSelection
+  /** Canon's `TasksFeature.State.customTitle` — a caller-supplied heading. */
+  readonly customTitle?: string | null
+  readonly input?: InputCapability
+  readonly locale?: string
+}
+
+export function TasksPage({
+  selection,
+  customTitle = null,
+  input,
+  locale,
+}: TasksPageProps) {
+  const dispatch = useAppDispatch()
+
+  const heading = useAppSelector(selectTasksHeading)
+  const subtitle = useAppSelector(selectTasksTitle)
+  const query = useAppSelector(selectTasksSearchQuery)
+  const grouping = useAppSelector(selectTasksGrouping)
+  const groups = useAppSelector(selectTasksGroupAdapters)
+  const expandedGroupKey = useAppSelector(selectTasksExpandedGroupKey)
+  const capabilities = useAppSelector(selectTasksCapabilities)
+  const emptyState = useAppSelector(selectTasksEmptyState)
+  const isLoading = useAppSelector(selectIsTasksLoading)
+  const exception = useAppSelector(selectTasksException)
+  // O(1) field reads, exactly as `FindPage` does and for the same two reasons.
+  const lens = useAppSelector((state) => state.find.tasks.lens)
+  const clockAnchor = useAppSelector((state) => state.find.tasks.clockAnchor)
+
+  const listId = selection.kind === 'list' ? selection.listId : null
+  const seededQuery = selection.kind === 'search' ? selection.query : null
+
+  /*
+    A list destination's route carries the id, never the name — the id is the
+    identity and the title is presentation, which is the same split the shell's
+    own `DestinationPage` made. So the title is looked up from the projects the
+    shell already loaded, and an unresolved one stays `null` rather than being
+    guessed: `selectTasksHeading` then falls through to "Tasks" instead of
+    printing a name that would change under the reader a moment later.
+  */
+  const projects = useAppSelector(selectProjects)
+  const listTitle =
+    selection.kind !== 'list'
+      ? null
+      : (selection.listTitle ??
+        projects.find((project) => project.id === selection.listId)?.title ??
+        null)
+
+  const resolvedSelection = useMemo<TasksVistaSelection>(
+    () =>
+      listId === null ? selection : { kind: 'list', listId, listTitle },
+    // The object is rebuilt on every render; its identity fields are the deps.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: `selection` is
+    // derived — `kind`, `listId`, `listTitle` and the seeded query are its
+    // identity.
+    [selection.kind, listId, listTitle, seededQuery],
+  )
+
+  const vistaId = useMemo(
+    () => tasksVistaIdFor(resolvedSelection),
+    [resolvedSelection],
+  )
+
+  // The URL is the authority for the shell's selection (`RC-63`).
+  useEffect(() => {
+    dispatch(
+      onDestinationRouteMounted({
+        destination:
+          listId === null
+            ? { kind: DestinationKind.allTasks }
+            : {
+                kind: DestinationKind.list,
+                listId,
+                listTitle: listTitle ?? '',
+              },
+      }),
+    )
+  }, [dispatch, listId, listTitle])
+
+  useEffect(() => {
+    dispatch(
+      userDidSelectTasksVista({ selection: resolvedSelection, customTitle }),
+    )
+  }, [dispatch, resolvedSelection, customTitle])
+
+  useEffect(() => {
+    let cancelled = false
+    const flags = dispatch(resolveCapabilityFlagsThunk())
+    const lensRestore = dispatch(
+      restoreFindLensThunk({ surface: FindSurface.tasks, vistaId }),
+    )
+    const fetch = dispatch(
+      fetchFindEndeavorsThunk({ surface: FindSurface.tasks, now: new Date() }),
+    )
+
+    void flags.then((action) => {
+      if (cancelled) return
+      const result = resolveCapabilityFlagsThunk.fulfilled.match(action)
+        ? action.payload
+        : null
+      dispatch(
+        onViewLoaded({
+          surface: FindSurface.tasks,
+          now: new Date(),
+          enabledFlags: result !== null && result.ok ? result.value : [],
+        }),
+      )
+    })
+
+    return () => {
+      cancelled = true
+      flags.abort()
+      lensRestore.abort()
+      fetch.abort()
+    }
+  }, [dispatch, vistaId])
+
+  useEffect(() => {
+    const effect = dispatch(
+      persistFindLensThunk({ surface: FindSurface.tasks, vistaId, lens }),
+    )
+    return () => effect.abort()
+  }, [dispatch, vistaId, lens])
+
+  const onOperation = useCallback(
+    (operation: EndeavorOperation, endeavorId: string) => {
+      void dispatch(
+        performEndeavorOperationThunk({
+          surface: FindSurface.tasks,
+          operation,
+          endeavorId,
+          now: new Date(),
+        }),
+      )
+    },
+    [dispatch],
+  )
+
+  /**
+   * Canon's `onSelectTask`, answered with the Detail presentation.
+   *
+   * `viewDetail` is the operation the global overlay listens for, so raising it
+   * through the same Producer keeps one path to Detail from every surface —
+   * rather than a second, surface-local route that would drift the day the
+   * intent queue grows a rule.
+   */
+  const onSelectEndeavor = useCallback(
+    (endeavorId: string) => {
+      void dispatch(
+        performEndeavorOperationThunk({
+          surface: FindSurface.tasks,
+          operation: 'viewDetail',
+          endeavorId,
+          now: new Date(),
+        }),
+      )
+    },
+    [dispatch],
+  )
+
+  const onRetry = useCallback(() => {
+    void dispatch(
+      fetchFindEndeavorsThunk({ surface: FindSurface.tasks, now: new Date() }),
+    )
+  }, [dispatch])
+
+  return (
+    <TasksFragment
+      heading={heading}
+      subtitle={subtitle}
+      query={query}
+      grouping={grouping}
+      groups={groups}
+      expandedGroupKey={expandedGroupKey}
+      capabilities={capabilities}
+      emptyState={emptyState}
+      isLoading={isLoading}
+      exception={exception}
+      now={clockAnchor ?? EPOCH}
+      input={input}
+      locale={locale}
+      onChangeQuery={(next) =>
+        dispatch(
+          userDidChangeSearchQuery({ surface: FindSurface.tasks, query: next }),
+        )
+      }
+      onSelectGrouping={(next: EndeavorGroupingCriteria) =>
+        dispatch(
+          userDidSelectGrouping({ surface: FindSurface.tasks, grouping: next }),
+        )
+      }
+      onExpandGroup={(groupKey) =>
+        dispatch(
+          userDidTapExpandGroup({ surface: FindSurface.tasks, groupKey }),
+        )
+      }
+      onCollapseGroups={() =>
+        dispatch(userDidTapCollapseGroups({ surface: FindSurface.tasks }))
+      }
+      onOperation={onOperation}
+      onSelectEndeavor={onSelectEndeavor}
+      onRetry={onRetry}
+    />
+  )
+}

--- a/packages/app/src/features/find/pages/__tests__/FindCapabilitiesProducer.test.ts
+++ b/packages/app/src/features/find/pages/__tests__/FindCapabilitiesProducer.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The flag read, driven through the real thunk against a stubbed
+ * `FeatureFlagService` injected via `extra` — never a mocked module (`RC-54`,
+ * `RC-35`).
+ */
+import {
+  FeatureFlags,
+  enabledAssignment,
+  makeHardcodedFeatureFlagService,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { makeStore, stubbedThunkExtra } from '../../../../library/store'
+import { resolveCapabilityFlagsThunk } from '../FindCapabilitiesProducer'
+
+const storeWithFlags = (
+  featureFlags = stubbedThunkExtra.featureFlags,
+) => makeStore({ ...stubbedThunkExtra, featureFlags })
+
+describe('resolveCapabilityFlagsThunk', () => {
+  it('reports nothing enabled on the shipping baseline — endeavorDetail is dark-launched', async () => {
+    const store = storeWithFlags()
+
+    const action = await store.dispatch(resolveCapabilityFlagsThunk())
+
+    expect(resolveCapabilityFlagsThunk.fulfilled.match(action)).toBe(true)
+    const result = action.payload
+    expect(result).toEqual({ ok: true, value: [] })
+  })
+
+  it('reports the flag name once a tester has enabled endeavorDetail', async () => {
+    const store = storeWithFlags(
+      makeHardcodedFeatureFlagService({
+        overrides: [enabledAssignment(FeatureFlags.endeavorDetail)],
+      }),
+    )
+
+    const action = await store.dispatch(resolveCapabilityFlagsThunk())
+
+    expect(action.payload).toEqual({ ok: true, value: ['endeavorDetail'] })
+  })
+
+  it('degrades to "nothing enabled" when the flag service throws, rather than failing the surface', async () => {
+    const store = storeWithFlags({
+      ...stubbedThunkExtra.featureFlags,
+      isEnabled: () => {
+        throw new Error('flag store unavailable')
+      },
+    })
+
+    const action = await store.dispatch(resolveCapabilityFlagsThunk())
+
+    expect(action.payload).toEqual({ ok: true, value: [] })
+  })
+
+  it('feeds the surface exactly the shape `enabledFlags` holds — plain names', async () => {
+    const store = storeWithFlags(
+      makeHardcodedFeatureFlagService({
+        overrides: [enabledAssignment(FeatureFlags.endeavorDetail)],
+      }),
+    )
+
+    const action = await store.dispatch(resolveCapabilityFlagsThunk())
+
+    expect(resolveCapabilityFlagsThunk.fulfilled.match(action)).toBe(true)
+    if (!resolveCapabilityFlagsThunk.fulfilled.match(action)) return
+    const result = action.payload
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      for (const name of result.value) expect(typeof name).toBe('string')
+    }
+  })
+})

--- a/packages/app/src/features/find/pages/__tests__/findPresentation.test.ts
+++ b/packages/app/src/features/find/pages/__tests__/findPresentation.test.ts
@@ -1,0 +1,205 @@
+/**
+ * The presentation model is pure, so it is asserted without a surface: the chip
+ * rows against the DOMAIN's own lists (not a transcribed copy), the four empty
+ * messages against canon's strings, and the row projection against the fixtures
+ * `#29` already ships.
+ */
+import {
+  EndeavorHost,
+  EndeavorKind,
+  EndeavorStatus,
+  endeavorHosts,
+  endeavorKinds,
+  endeavorStatuses,
+  makeEndeavor,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { findEndeavorMocks } from '../../FindMocks'
+import {
+  ARCHIVED_CHIP,
+  findEmptyCopy,
+  findFilterRows,
+  findOverflowEntries,
+  findRowBadges,
+  findRowSymbol,
+  findRowTimeInfo,
+  isFilterChipSelected,
+} from '../findPresentation'
+
+const rowFor = (id: 'kind' | 'host' | 'status') => {
+  const row = findFilterRows.find((each) => each.id === id)
+  if (row === undefined) throw new Error(`no ${id} row`)
+  return row
+}
+
+const noneSelected = {
+  kinds: [] as readonly EndeavorKind[],
+  hosts: [] as readonly EndeavorHost[],
+  statuses: [] as readonly EndeavorStatus[],
+  showArchived: false,
+}
+
+describe('the filter rows are derived from the domain, never transcribed', () => {
+  it('offers one chip per kind the domain declares — a new kind cannot go missing', () => {
+    expect(rowFor('kind').chips.map((chip) => chip.id)).toEqual([
+      ...endeavorKinds,
+    ])
+  })
+
+  it('offers one chip per host, so a source the fetch can return is filterable', () => {
+    expect(rowFor('host').chips.map((chip) => chip.id)).toEqual([
+      ...endeavorHosts,
+    ])
+  })
+
+  it('rides the Archived flag at the end of the status row, exactly as canon does', () => {
+    const status = rowFor('status')
+    expect(status.chips.slice(0, -1).map((chip) => chip.id)).toEqual([
+      ...endeavorStatuses,
+    ])
+    expect(status.chips.at(-1)).toBe(ARCHIVED_CHIP)
+  })
+
+  it('gives every chip a glyph and a label, so colour is never the only signal', () => {
+    for (const row of findFilterRows) {
+      for (const chip of row.chips) {
+        expect(chip.label.length).toBeGreaterThan(0)
+        expect(chip.icon.length).toBeGreaterThan(0)
+      }
+    }
+  })
+})
+
+describe('a chip reads as selected when its value is NOT hidden', () => {
+  it('shows Task selected once the user has un-hidden it', () => {
+    const chip = rowFor('kind').chips.find(
+      (each) => each.id === EndeavorKind.task,
+    )
+    if (chip === undefined) throw new Error('no Task chip')
+    expect(
+      isFilterChipSelected(chip, {
+        ...noneSelected,
+        kinds: [EndeavorKind.task],
+      }),
+    ).toBe(true)
+  })
+
+  it('shows a host chip unselected when the lens hides that host', () => {
+    const chip = rowFor('host').chips[0]
+    if (chip === undefined) throw new Error('no host chip')
+    expect(isFilterChipSelected(chip, noneSelected)).toBe(false)
+  })
+
+  it('reads the Archived chip from the lens flag, not from a hidden set', () => {
+    expect(isFilterChipSelected(ARCHIVED_CHIP, noneSelected)).toBe(false)
+    expect(
+      isFilterChipSelected(ARCHIVED_CHIP, {
+        ...noneSelected,
+        showArchived: true,
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('the four empty states are four different sentences', () => {
+  it('tells a first-run user there is nothing to browse yet', () => {
+    expect(findEmptyCopy({ kind: 'noData' })).toMatchObject({
+      title: 'No Endeavors Yet',
+      message: "Add tasks, events, or habits and they'll appear here.",
+    })
+  })
+
+  it('tells a user who turned every chip off why the list is blank', () => {
+    expect(findEmptyCopy({ kind: 'noFilters' }).title).toBe(
+      'No Filters Selected',
+    )
+  })
+
+  it('quotes the query back when a search matched nothing', () => {
+    expect(findEmptyCopy({ kind: 'noResults', query: 'tax' }).message).toBe(
+      'No endeavors match "tax" with the current filters.',
+    )
+  })
+
+  it('distinguishes "filters hid everything" from "there is nothing"', () => {
+    expect(findEmptyCopy({ kind: 'filteredOut' }).title).toBe('Nothing Here')
+    expect(findEmptyCopy({ kind: 'filteredOut' }).title).not.toBe(
+      findEmptyCopy({ kind: 'noData' }).title,
+    )
+  })
+})
+
+describe('the row projection', () => {
+  it('lifts a leading emoji out of the title and draws it as the symbol', () => {
+    expect(findRowSymbol('📊 Prepare quarterly slides')).toEqual({
+      symbol: '📊',
+      isGeneric: false,
+      title: 'Prepare quarterly slides',
+    })
+  })
+
+  it('falls back to a generic glyph when the title has no emoji', () => {
+    const lead = findRowSymbol('Review the auth flow PR')
+    expect(lead.isGeneric).toBe(true)
+    expect(lead.title).toBe('Review the auth flow PR')
+  })
+
+  it('reads a started event with a duration as a time RANGE', () => {
+    const info = findRowTimeInfo(findEndeavorMocks.teamSync)
+    expect(info?.kind).toBe('timeRange')
+  })
+
+  it('reads a due-dated task as a due time carrying its duration', () => {
+    const info = findRowTimeInfo(findEndeavorMocks.morningTask)
+    expect(info).toMatchObject({ kind: 'dueTime' })
+  })
+
+  it('prints no time at all for an undated, unmeasured endeavor', () => {
+    expect(findRowTimeInfo(findEndeavorMocks.undatedTask)).toBeUndefined()
+  })
+
+  it('badges every row with its kind and its status, which is canon\'s Find row', () => {
+    expect(findRowBadges(findEndeavorMocks.afternoonTask)).toEqual([
+      { kind: 'endeavorKind', value: EndeavorKind.task },
+      { kind: 'status', value: EndeavorStatus.ongoing },
+    ])
+  })
+
+  it('keeps a title that is nothing but an emoji from collapsing to a blank row', () => {
+    const lead = findRowSymbol('🎯')
+    expect(lead.symbol).toBe('🎯')
+    expect(lead.title).toBe('')
+  })
+
+  it('projects a host-less endeavor without inventing one', () => {
+    const hostless = makeEndeavor({
+      id: 'x',
+      title: 'Nowhere',
+      kind: EndeavorKind.task,
+      status: EndeavorStatus.pending,
+      hostedBy: [EndeavorHost.local],
+    })
+    expect(findRowBadges(hostless)).toHaveLength(2)
+  })
+})
+
+describe('the bulk menu counts what is visible', () => {
+  it('prints the visible count in both labels, as canon does', () => {
+    const entries = findOverflowEntries(4)
+    expect(entries.map((entry) => entry.label)).toEqual([
+      'Delete all visible (4)',
+      'Archive all visible (4)',
+    ])
+  })
+
+  it('marks only Delete destructive — the affordance canon relies on', () => {
+    expect(findOverflowEntries(0).map((entry) => entry.isDestructive)).toEqual([
+      true,
+      false,
+    ])
+  })
+
+  it('still offers both entries at zero, so the menu never changes shape', () => {
+    expect(findOverflowEntries(0)).toHaveLength(2)
+  })
+})

--- a/packages/app/src/features/find/pages/__tests__/pagesHarness.tsx
+++ b/packages/app/src/features/find/pages/__tests__/pagesHarness.tsx
@@ -1,0 +1,168 @@
+/**
+ * The store harness the KC-IS-#30 surfaces' stories and tests share.
+ *
+ * ## Why a SEEDED store rather than a preloaded one
+ *
+ * `makeStore(extra)` takes no `preloadedState` (`RC-22`: one construction path,
+ * one reducer map), so a story cannot hand a slice a canned `State`. It does
+ * not need to: seeding the in-memory `LocalStore` with real `EndeavorRecord`s
+ * and letting the surface's own fetch run produces the same state through the
+ * **real** Producer, Shifter and reconcile pass — which is a stronger claim
+ * than a preloaded object, because a mapping bug between the record and the
+ * domain shows up here instead of hiding behind the fixture.
+ *
+ * The endeavors themselves are `#29`'s own `findEndeavorMocks` /
+ * `detailEndeavorMocks`, so no scene shows data the slice could not produce
+ * (`RC-31`).
+ *
+ * ## Why it lives under `__tests__/`
+ *
+ * It imports a Service module (`InMemoryLocalStore`), which `RC-6` allows only
+ * from the store, from `services/**` and from test/preview files — and this is
+ * the second of those. `check-uzf-boundaries.mjs` reads the same rule.
+ */
+import type {
+  Endeavor,
+  EndeavorCapabilities,
+  EndeavorGroupingCriteria as EndeavorGroupingCriteriaType,
+  Project,
+} from '@kro/core'
+import {
+  EndeavorGroupingCriteria,
+  EndeavorsVistas,
+  type FeatureFlagService,
+  FeatureFlags,
+  deferRecordFromDefer,
+  enabledAssignment,
+  endeavorRecordFromEndeavor,
+  epochMillisFromDate,
+  projectRecordFromProject,
+  makeHardcodedFeatureFlagService,
+  performanceRecordFromPerform,
+  resolveEndeavorCapabilities,
+} from '@kro/core'
+import type { ReactNode } from 'react'
+import { StoreProvider } from '../../../../library/StoreProvider'
+import { type AppStore, makeStore, stubbedThunkExtra } from '../../../../library/store'
+import { makeInMemoryLocalStore } from '../../../../services/localStore/InMemoryLocalStore'
+import { endeavorRowAdapters } from '../../FindAdapters'
+import { groupEndeavors, limitGroups } from '../../FindGrouping'
+
+/** The flag service a scene needs when it must show a dark-launched binding. */
+export const detailEnabledFlags: FeatureFlagService =
+  makeHardcodedFeatureFlagService({
+    overrides: [enabledAssignment(FeatureFlags.endeavorDetail)],
+  })
+
+export interface HarnessOptions {
+  /** The rows the surface fetches. Empty is a valid, meaningful scene. */
+  readonly endeavors?: readonly Endeavor[]
+  /** The Lists the shell loads — a list destination resolves its title here. */
+  readonly projects?: readonly Project[]
+  /** Defaults to the shipping baseline, where `endeavorDetail` is OFF. */
+  readonly featureFlags?: FeatureFlagService
+  /** The instant every record is stamped at, so a scene never reads a clock. */
+  readonly now?: Date
+}
+
+/**
+ * A store whose local database already holds `endeavors`, their defers and
+ * their performances — the three tables `readStoredEndeavors` joins.
+ */
+export const makeSeededStore = ({
+  endeavors = [],
+  projects = [],
+  featureFlags = stubbedThunkExtra.featureFlags,
+  now = new Date(2026, 5, 18, 9, 40),
+}: HarnessOptions = {}): AppStore => {
+  const nowMillis = epochMillisFromDate(now)
+
+  return makeStore({
+    ...stubbedThunkExtra,
+    featureFlags,
+    localStore: makeInMemoryLocalStore({
+      endeavors: endeavors.map((endeavor) =>
+        endeavorRecordFromEndeavor(endeavor, { now }),
+      ),
+      projects: projects.map((project) =>
+        projectRecordFromProject(project, { now }),
+      ),
+      defers: endeavors.flatMap((endeavor) =>
+        endeavor.defers.map((entry) =>
+          deferRecordFromDefer(entry, {
+            endeavorId: endeavor.id,
+            now,
+            nowMillis,
+          }),
+        ),
+      ),
+      performances: endeavors.flatMap((endeavor) =>
+        endeavor.performances.map((entry) =>
+          performanceRecordFromPerform(entry, {
+            endeavorId: endeavor.id,
+            nowMillis,
+          }),
+        ),
+      ),
+    }),
+  })
+}
+
+/** The provider every scene mounts under. */
+export function Harness({
+  store,
+  children,
+}: {
+  readonly store: AppStore
+  readonly children: ReactNode
+}) {
+  return <StoreProvider store={store}>{children}</StoreProvider>
+}
+
+/* ------------------------------------------------------------------------ */
+/* Fragment scenes                                                           */
+/* ------------------------------------------------------------------------ */
+
+/**
+ * The Find vista's capabilities, flag-resolved exactly as
+ * `selectFindCapabilities` resolves them — so a Fragment scene shows the same
+ * gesture set the running surface would.
+ */
+export const findCapabilitiesWith = (
+  enabledFlags: readonly string[] = [],
+): EndeavorCapabilities =>
+  resolveEndeavorCapabilities(EndeavorsVistas.find.capabilities, (flag) =>
+    enabledFlags.includes(flag),
+  )
+
+export const tasksCapabilitiesWith = (
+  enabledFlags: readonly string[] = [],
+): EndeavorCapabilities =>
+  resolveEndeavorCapabilities(EndeavorsVistas.tasksDefault.capabilities, (flag) =>
+    enabledFlags.includes(flag),
+  )
+
+/** Rows, adapted the way `selectFindRowAdapters` adapts them. */
+export const adaptedRows = (
+  endeavors: readonly Endeavor[],
+  capabilities: EndeavorCapabilities,
+) => endeavorRowAdapters(endeavors, capabilities)
+
+/** Groups, grouped and limited the way `selectTasksGroups` does. */
+export const adaptedGroups = (
+  endeavors: readonly Endeavor[],
+  capabilities: EndeavorCapabilities,
+  options: {
+    readonly grouping?: EndeavorGroupingCriteriaType
+    readonly limit?: number | null
+    readonly expandedGroupKey?: string | null
+  } = {},
+) =>
+  limitGroups(
+    groupEndeavors(endeavors, options.grouping ?? EndeavorGroupingCriteria.status),
+    options.limit === undefined ? 7 : options.limit,
+    options.expandedGroupKey ?? null,
+  ).map((group) => ({
+    group,
+    rows: endeavorRowAdapters(group.endeavors, capabilities),
+  }))

--- a/packages/app/src/features/find/pages/__tests__/pagesHarness.tsx
+++ b/packages/app/src/features/find/pages/__tests__/pagesHarness.tsx
@@ -25,6 +25,7 @@ import type {
   Endeavor,
   EndeavorCapabilities,
   EndeavorGroupingCriteria as EndeavorGroupingCriteriaType,
+  EndeavorsLensSnapshot,
   Project,
 } from '@kro/core'
 import {
@@ -59,6 +60,8 @@ export interface HarnessOptions {
   readonly endeavors?: readonly Endeavor[]
   /** The Lists the shell loads — a list destination resolves its title here. */
   readonly projects?: readonly Project[]
+  /** Saved lens snapshots, by vista id — what a returning user's device holds. */
+  readonly lensSnapshots?: Readonly<Record<string, EndeavorsLensSnapshot>>
   /** Defaults to the shipping baseline, where `endeavorDetail` is OFF. */
   readonly featureFlags?: FeatureFlagService
   /** The instant every record is stamped at, so a scene never reads a clock. */
@@ -72,6 +75,7 @@ export interface HarnessOptions {
 export const makeSeededStore = ({
   endeavors = [],
   projects = [],
+  lensSnapshots = {},
   featureFlags = stubbedThunkExtra.featureFlags,
   now = new Date(2026, 5, 18, 9, 40),
 }: HarnessOptions = {}): AppStore => {
@@ -96,6 +100,7 @@ export const makeSeededStore = ({
           }),
         ),
       ),
+      lensSnapshots,
       performances: endeavors.flatMap((endeavor) =>
         endeavor.performances.map((entry) =>
           performanceRecordFromPerform(entry, {

--- a/packages/app/src/features/find/pages/findPresentation.ts
+++ b/packages/app/src/features/find/pages/findPresentation.ts
@@ -1,0 +1,343 @@
+/**
+ * The render tier's presentation mapping for Find and All Tasks — the port of
+ * the display decisions that live inside `KroUI/Find/FindView.swift` and
+ * `KroUI/Tasks/TasksView.swift` themselves.
+ *
+ * Everything here is pure and has no React in it, so the three chip rows, the
+ * four empty states and the row projection are unit-testable without mounting a
+ * surface. That split is deliberate: canon's `FindView` hardcodes six kind
+ * chips, six host chips and nine status chips inline, and a hardcoded list is
+ * exactly what drifts from the domain the day a kind is added.
+ *
+ * ## The chips are DERIVED, not transcribed
+ *
+ * Canon lists its chips literally. Here each row is built by mapping
+ * `@kro/core`'s own `endeavorKinds` / `endeavorHosts` / `endeavorStatuses`
+ * through the merged kit's projections (`kindShortLabel`, `kindGlyph`,
+ * `kindTint`, …), so a new kind arrives with a chip and a contrast-verified
+ * tint rather than silently missing one. The one place canon's literal list and
+ * the domain disagree is `reminder`: canon's Find has no Reminder chip because
+ * iOS folds reminders into tasks at the source. The web fetches the same
+ * domain, so the chip is present and the test says why.
+ *
+ * ## Canon's `badgeColor` is NOT ported
+ *
+ * `FindView`'s `FilterChip` paints `.blue`, `.red`, `Color(white: 0.8)` — the
+ * raw system tints the kit's `endeavorProjections` header already refuses,
+ * because canon's own comment calls them unreadable (2.0–3.5:1). The chips here
+ * carry the contrast-verified semantic roles instead, which is the same
+ * substitution the merged kit made for the row badges.
+ *
+ * ## Two SF Symbols canon names that this build cannot draw
+ *
+ * `line.3.horizontal.decrease.circle` and `slider.horizontal.3` are in neither
+ * the design system's map nor the endeavor kit's, and both maps are merged
+ * lanes this issue does not own. Rather than fork a third symbol table for two
+ * glyphs, the two empty states below use the nearest mapped neighbours —
+ * `line.3.horizontal` and `eye.circle.fill` — and say so here. Folding the two
+ * real rows into `system/icons/icons.ts` is a one-line-per-row follow-up for
+ * whichever child next touches that file.
+ */
+import {
+  type Endeavor,
+  type EndeavorComputedState,
+  type EndeavorHost,
+  type EndeavorKind,
+  type EndeavorStatus,
+  assertNever,
+  endeavorHostDisplayName,
+  endeavorHosts,
+  endeavorKinds,
+  endeavorStatuses,
+} from '@kro/core'
+import type {
+  EndeavorRowBadge,
+  EndeavorRowTimeInfo,
+} from '../../../design/endeavor/EndeavorRow'
+import { type ChipTint, semanticTint } from '../../../design/endeavor/KroChip'
+import type { KitSymbolName } from '../../../design/endeavor/endeavorIcons'
+import {
+  hostGlyph,
+  hostTint,
+  kindGlyph,
+  kindShortLabel,
+  kindTint,
+  statusGlyph,
+  statusShortLabel,
+  statusTint,
+} from '../../../design/endeavor/endeavorProjections'
+import type { FindEmptyState, FindFilterToggle } from '../FindState'
+
+/* ------------------------------------------------------------------------ */
+/* Filter chips                                                              */
+/* ------------------------------------------------------------------------ */
+
+/** One chip in one of Find's filter rows. */
+export interface FindFilterChip {
+  /** Stable key — the raw domain value, or `'archived'` for the odd one out. */
+  readonly id: string
+  readonly label: string
+  readonly icon: KitSymbolName
+  readonly tint: ChipTint
+  /**
+   * What flipping the chip dispatches, or `null` for Show Archived — which is
+   * its own event because it is a lens *flag*, not a hidden-set membership.
+   */
+  readonly toggle: FindFilterToggle | null
+}
+
+/** One labelled row of chips. Canon renders three horizontal scrollers. */
+export interface FindFilterRow {
+  readonly id: 'kind' | 'host' | 'status'
+  /** The row's accessible name. Canon's rows are unlabelled visually. */
+  readonly label: string
+  readonly chips: readonly FindFilterChip[]
+}
+
+const kindChip = (kind: EndeavorKind): FindFilterChip => ({
+  id: kind,
+  label: kindShortLabel(kind),
+  icon: kindGlyph(kind),
+  tint: semanticTint(kindTint(kind)),
+  toggle: { axis: 'kind', value: kind },
+})
+
+const hostChip = (host: EndeavorHost): FindFilterChip => ({
+  id: host,
+  label: endeavorHostDisplayName(host),
+  icon: hostGlyph(host),
+  tint: semanticTint(hostTint(host)),
+  toggle: { axis: 'host', value: host },
+})
+
+const statusChip = (status: EndeavorStatus): FindFilterChip => ({
+  id: status,
+  label: statusShortLabel(status),
+  icon: statusGlyph(status),
+  tint: semanticTint(statusTint(status)),
+  toggle: { axis: 'status', value: status },
+})
+
+/**
+ * Canon's Archived chip: the last chip of the status row, and the only one that
+ * is not a status. It flips the lens's `showArchived` flag, so it carries no
+ * `toggle`; the surface dispatches `userDidToggleShowArchived` for it.
+ */
+export const ARCHIVED_CHIP: FindFilterChip = {
+  id: 'archived',
+  label: 'Archived',
+  icon: 'archivebox',
+  tint: semanticTint('chipNeutral'),
+  toggle: null,
+}
+
+/**
+ * The three rows Find shows, in canon's order: kinds, hosts, statuses (+ the
+ * Archived flag riding at the end of the status row, exactly as canon does).
+ */
+export const findFilterRows: readonly FindFilterRow[] = [
+  { id: 'kind', label: 'Kinds', chips: endeavorKinds.map(kindChip) },
+  { id: 'host', label: 'Sources', chips: endeavorHosts.map(hostChip) },
+  {
+    id: 'status',
+    label: 'Statuses',
+    chips: [...endeavorStatuses.map(statusChip), ARCHIVED_CHIP],
+  },
+]
+
+/**
+ * Whether a chip reads as selected.
+ *
+ * The lens stores what is HIDDEN, so a chip is selected when its value is
+ * absent from the hidden set — canon's `selectedKinds.contains(...)` read from
+ * the other end. Show Archived is the flag itself.
+ */
+export const isFilterChipSelected = (
+  chip: FindFilterChip,
+  selected: {
+    readonly kinds: readonly EndeavorKind[]
+    readonly hosts: readonly EndeavorHost[]
+    readonly statuses: readonly EndeavorStatus[]
+    readonly computedStates?: readonly EndeavorComputedState[]
+    readonly showArchived: boolean
+  },
+): boolean => {
+  const toggle = chip.toggle
+  if (toggle === null) return selected.showArchived
+  switch (toggle.axis) {
+    case 'kind':
+      return selected.kinds.includes(toggle.value)
+    case 'host':
+      return selected.hosts.includes(toggle.value)
+    case 'status':
+      return selected.statuses.includes(toggle.value)
+    case 'computedState':
+      return (selected.computedStates ?? []).includes(toggle.value)
+    case 'calendar':
+      return false
+    default:
+      return assertNever(toggle)
+  }
+}
+
+/* ------------------------------------------------------------------------ */
+/* Rows                                                                      */
+/* ------------------------------------------------------------------------ */
+
+/**
+ * A leading emoji in the title, canon's `EndeavorCardModel` rule: the first
+ * grapheme is the row symbol when it is an emoji, and the title loses it.
+ *
+ * Re-derived here rather than reached for through `endeavorCardModelFrom`,
+ * because that seam builds a whole card model (urgency, reward, due bands) the
+ * Find row does not render, and building one per row per keystroke of the
+ * search field is the cost this avoids.
+ */
+const EMOJI_LEAD = /^(\p{Extended_Pictographic}(️|‍\p{Extended_Pictographic})*)\s*/u
+
+/** The row's symbol and the title with a leading emoji stripped. */
+export const findRowSymbol = (
+  title: string,
+): { readonly symbol: string; readonly isGeneric: boolean; readonly title: string } => {
+  const match = EMOJI_LEAD.exec(title)
+  const lead = match?.[1]
+  if (match === null || lead === undefined) {
+    return { symbol: 'checkmark.circle', isGeneric: true, title: title.trim() }
+  }
+  return {
+    symbol: lead,
+    isGeneric: false,
+    title: title.slice(match[0].length).trim(),
+  }
+}
+
+/**
+ * What a Find row prints about time. Canon's `find` row preset shows time info,
+ * and an endeavor with a `start` reads as a range when it also has a duration.
+ */
+export const findRowTimeInfo = (
+  endeavor: Endeavor,
+): EndeavorRowTimeInfo | undefined => {
+  if (endeavor.start !== null && endeavor.duration !== null) {
+    return {
+      kind: 'timeRange',
+      start: endeavor.start,
+      end: new Date(endeavor.start.getTime() + endeavor.duration * 1000),
+    }
+  }
+  if (endeavor.due !== null) {
+    return { kind: 'dueTime', date: endeavor.due, duration: endeavor.duration }
+  }
+  if (endeavor.duration !== null) {
+    return { kind: 'duration', seconds: endeavor.duration }
+  }
+  return undefined
+}
+
+/**
+ * The two trailing badges the `find` row preset carries: the kind and the
+ * status. Canon's Find row shows exactly those two, which is why the preset
+ * puts badges on the trailing edge rather than under the title.
+ */
+export const findRowBadges = (
+  endeavor: Endeavor,
+): readonly EndeavorRowBadge[] => [
+  { kind: 'endeavorKind', value: endeavor.kind },
+  { kind: 'status', value: endeavor.status },
+]
+
+/* ------------------------------------------------------------------------ */
+/* Empty states                                                              */
+/* ------------------------------------------------------------------------ */
+
+/** Canon's `placeholderView` content, verbatim, for each of the four states. */
+export interface FindEmptyCopy {
+  readonly icon: KitSymbolName
+  readonly title: string
+  readonly message: string
+}
+
+/**
+ * The four messages `FindView.mainContent` branches between, in canon's words.
+ *
+ * They are four different sentences because they are four different problems:
+ * nothing fetched, everything filtered out by the chips, a search that matched
+ * nothing, and filters that hid what was there. Collapsing any two would be the
+ * regression `#29`'s `FindEmptyState` union exists to prevent.
+ */
+export const findEmptyCopy = (state: FindEmptyState): FindEmptyCopy => {
+  switch (state.kind) {
+    case 'noData':
+      return {
+        icon: 'tray',
+        title: 'No Endeavors Yet',
+        message: "Add tasks, events, or habits and they'll appear here.",
+      }
+    case 'noFilters':
+      return {
+        // Canon: `line.3.horizontal.decrease.circle` — see the header note.
+        icon: 'line.3.horizontal',
+        title: 'No Filters Selected',
+        message: 'Select at least one filter above to browse your endeavors.',
+      }
+    case 'noResults':
+      return {
+        icon: 'magnifyingglass',
+        title: 'No Results',
+        message: `No endeavors match "${state.query}" with the current filters.`,
+      }
+    case 'filteredOut':
+      return {
+        // Canon: `slider.horizontal.3` — see the header note.
+        icon: 'eye.circle.fill',
+        title: 'Nothing Here',
+        message: 'Try adjusting your filters to see more endeavors.',
+      }
+    default:
+      return assertNever(state)
+  }
+}
+
+/* ------------------------------------------------------------------------ */
+/* The ellipsis menu                                                         */
+/* ------------------------------------------------------------------------ */
+
+/** One entry of Find's overflow menu. */
+export interface FindOverflowEntry {
+  readonly id: 'deleteAllVisible' | 'archiveAllVisible'
+  readonly label: string
+  readonly icon: KitSymbolName
+  readonly isDestructive: boolean
+}
+
+/**
+ * Canon's two bulk entries, with canon's counted labels.
+ *
+ * Canon's menu also carries Sources and Settings; both are the *shell's*
+ * destinations here (`MainShellFragment` already renders the Settings gear on
+ * every non-primary tab, and Sources is Settings → Integrations), so repeating
+ * them inside a feature's menu would be the second copy of a control the
+ * container already owns — the ownership rule the shell's own header states.
+ *
+ * There is deliberately **no confirmation step**: `FindProducer`'s own note
+ * rules that canon applies both immediately and optimistically, and that adding
+ * a confirm dialog "would be a new business rule". The destructive *role* on
+ * Delete is the affordance, which is what the kit's `DropdownMenuItem`
+ * destructive treatment and this flag carry.
+ */
+export const findOverflowEntries = (
+  visibleCount: number,
+): readonly FindOverflowEntry[] => [
+  {
+    id: 'deleteAllVisible',
+    label: `Delete all visible (${visibleCount})`,
+    icon: 'trash',
+    isDestructive: true,
+  },
+  {
+    id: 'archiveAllVisible',
+    label: `Archive all visible (${visibleCount})`,
+    icon: 'archivebox',
+    isDestructive: false,
+  },
+]

--- a/packages/app/src/features/find/pages/index.ts
+++ b/packages/app/src/features/find/pages/index.ts
@@ -1,0 +1,33 @@
+/**
+ * The Find/Tasks render tier's public surface — a pure re-export barrel.
+ *
+ * `apps/web`'s route files import from here (through `@kro/app`) rather than
+ * reaching into individual modules, so the boundary between the shell and the
+ * feature is one line to read.
+ */
+export {
+  CAPABILITY_FLAGS,
+  resolveCapabilityFlagsThunk,
+} from './FindCapabilitiesProducer'
+export { type FindFragmentProps, FindFragment } from './FindFragment'
+export { type FindPageProps, FindPage } from './FindPage'
+export {
+  type TasksFragmentProps,
+  type TasksGroupModel,
+  TasksFragment,
+} from './TasksFragment'
+export { type TasksPageProps, TasksPage } from './TasksPage'
+export {
+  ARCHIVED_CHIP,
+  type FindEmptyCopy,
+  type FindFilterChip,
+  type FindFilterRow,
+  type FindOverflowEntry,
+  findEmptyCopy,
+  findFilterRows,
+  findOverflowEntries,
+  findRowBadges,
+  findRowSymbol,
+  findRowTimeInfo,
+  isFilterChipSelected,
+} from './findPresentation'

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -46,6 +46,15 @@ export {
  */
 export * from './features/main'
 
+/*
+ * Feature render tiers, one line each. A feature's LOGIC stays unexported —
+ * `apps/web` never reads a slice — so only the Pages a route file mounts and
+ * the overlay the shell hosts cross this boundary.
+ */
+// KC-IS-#30 — Find, All Tasks and the global Endeavor Detail overlay.
+export * from './features/find/pages'
+export * from './features/endeavorDetail/pages'
+
 // SCAFFOLDING — the demo feature proving the loop. Feature children replace it.
 export {
   type GreetingLoadState,


### PR DESCRIPTION
> 🟥 **Ichigo · Substitute** — the local plane, entire · *local, on your creds · I open PRs for **you** to merge (I never merge `main`, never review my own work)*
> Acting as **Shinigami** (product code). Authored locally in Claude Code on behalf of @zheref — no CI run.

Closes #30 · Part of #1 · Canon: `zheref/KroApple@2117efc` (epic pin was `2c1ee45` — divergence noted below).

# What this changes for you

Three surfaces that were "not built yet" cards until now:

- **Find** (`/search`) — the all-endeavors browser. A search field, three rows of filter chips (kinds · sources · statuses, with Archived riding the status row exactly as canon does), rows carrying the vista's own operations, and the ellipsis menu's two bulk actions.
- **All Tasks** (`/tasks`, and every `/lists/<id>` destination) — the grouped list, with the grouping control the lens exposes, seven rows per group, and *Show All* / *Collapse* / *Show* per group state.
- **Endeavor Detail** — one glass overlay mounted once for the whole app, opened by the `viewDetail` intent any endeavor row raises. Behind it: the read surface, the Edit form, the three-bound Duration profile, and the four relation screens.

Rows speak **both input grammars from one props contract**: on touch the vista's swipe bindings are swipe surfaces; on pointer the *same* bindings are a hover strip and a right-click menu. Nothing here declares a gesture — `EndeavorCapabilities` does, and `EndeavorActionSurface` renders it.

## How to verify

```bash
git fetch origin && git checkout ichigo/30-find-detail-ui
make setup && make lint && make typecheck && make test && make build
```

Then, in the built app (`pnpm --filter @kro/web exec next start`):

| # | Do this | Expect |
|---|---|---|
| 1 | Open `/search` | Three chip rows; every chip is a pressed/unpressed toggle. Nothing stored yet ⇒ **"No Endeavors Yet"** |
| 2 | Turn every kind, host and status chip off | **"No Filters Selected"** — a different message from ① on purpose |
| 3 | Type a query that matches nothing | **"No Results"**, quoting the query |
| 4 | Open the ellipsis menu | *Delete all visible (N)* in red and *Archive all visible (N)*; Escape closes it and focus returns to the trigger |
| 5 | Open `/tasks` with ≥8 tasks in one status | Seven rows and **"Show more…"**; the header states the group's **total** |
| 6 | Press *Show All* | That group lists in full, its siblings collapse, and their affordance reads *Show* |
| 7 | Press a row's **›** | The Detail sheet (phone) / dialog (desktop) opens over the surface |
| 8 | Press a Detail row's chevron | That field's editor opens; the title bar's leading control becomes **Back** and **Save** appears, disabled |
| 9 | Change the field | Save enables. Press it ⇒ the row updates and Save goes back to disabled |
| 10 | Open Detail on a **calendar event** | Performances and Defers carry a **Read only** chip and no *Manage*; Hosts and Shadows do offer it |
| 11 | Open the Duration profile (Detail → Duration ›) | *Observed focus time* is a card with **no control at all**; each bound has a switch and, once on, a keyboard-operable dial |
| 12 | Hover a Find row (desktop) and press *Edit* | The full Edit form opens. On a **blueprint** it has no Start, Duration or Reward rows — the matrix removed them |

`/lists/<id>` is the same All Tasks surface over `tasksForList(id)`; it mounts and heads correctly but lists nothing — see **Divergence 3**, which is a defect in the merged logic tier, not in this PR.

---

## Screenshots

Captured from the **production build** (`next build && next start`) in a real Chromium, at both viewports and in both schemes. The rows are real `EndeavorRecord`s written into the app's own IndexedDB and read back through the real Producer — the only thing the driver does that a user cannot is *create* them, because the capture UI is #24.

### Find — `/search`

| loaded · mixed rows + chips | a chip actively hiding a kind |
|---|---|
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/find-mobile-light.png) mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/find-filtered-mobile-light.png) mobile · light |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/find-mobile-dark.png) mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/find-filtered-mobile-dark.png) mobile · dark |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/find-desktop-light.png) desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/find-filtered-desktop-light.png) desktop · light |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/find-desktop-dark.png) desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/find-filtered-desktop-dark.png) desktop · dark |

### All Tasks — `/tasks` and a Lists destination

| grouped, clipped to seven | a list destination (`/lists/proj-1`) |
|---|---|
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/tasks-mobile-light.png) mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/list-mobile-light.png) mobile · light |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/tasks-mobile-dark.png) mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/list-mobile-dark.png) mobile · dark |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/tasks-desktop-light.png) desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/list-desktop-light.png) desktop · light |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/tasks-desktop-dark.png) desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/list-desktop-dark.png) desktop · dark |

### Endeavor Detail — the overlay, over a surface

| task (every field) | calendar event | read-only relations |
|---|---|---|
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-mobile-light.png) mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-calendar-event-mobile-light.png) mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-readonly-relations-mobile-light.png) mobile · light |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-mobile-dark.png) mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-calendar-event-mobile-dark.png) mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-readonly-relations-mobile-dark.png) mobile · dark |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-desktop-light.png) desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-calendar-event-desktop-light.png) desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-readonly-relations-desktop-light.png) desktop · light |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-desktop-dark.png) desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-calendar-event-desktop-dark.png) desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/detail-readonly-relations-desktop-dark.png) desktop · dark |

### Edit, Duration, and the relation screens

| Edit · blueprint (fields absent per matrix) | Duration profile | Performances | Shadows |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/edit-blueprint-mobile-light.png) mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/duration-mobile-light.png) mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/relation-performances-mobile-light.png) mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/relation-shadows-mobile-light.png) mobile · light |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/edit-blueprint-mobile-dark.png) mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/duration-mobile-dark.png) mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/relation-performances-mobile-dark.png) mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/relation-shadows-mobile-dark.png) mobile · dark |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/edit-blueprint-desktop-light.png) desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/duration-desktop-light.png) desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/relation-performances-desktop-light.png) desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/relation-shadows-desktop-light.png) desktop · light |
| ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/edit-blueprint-desktop-dark.png) desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/duration-desktop-dark.png) desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/relation-performances-desktop-dark.png) desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/30-find-detail-ui/relation-shadows-desktop-dark.png) desktop · dark |

**A read-only relation *screen* is unreachable by design** and therefore has no built-app shot: canon never offers *Manage* for a relation the kind cannot edit, so the read-only path is the Detail card's **Read only** chip (column 3 above) plus the defensive banner, whose evidence is the `PerformancesReadOnly` story.

---

## A defect this PR had to fix to ship: glass overlays were never overlays

`.kro-glass` sets `position: relative`. `sheet.tsx` asks for `fixed inset-x-0 bottom-0 rounded-t-kro-surface`; `dialog.tsx` for `fixed top-1/2 left-1/2 -translate-…`; `dropdown-menu.tsx` for `rounded-kro-field`. **Unlayered CSS beats layered CSS**, Tailwind emits every utility inside `@layer utilities`, and `glass.css` was imported unlayered — so `.kro-glass` silently won all three, and every glass overlay in the app rendered *inline in the document flow* instead of over the page.

jsdom applies no stylesheets, so the primitives' own suites could not see it (`sheet.test.tsx` passes today and passed before). The first production build to put a sheet on screen did — the screenshots above are how it surfaced, which is exactly what `UZF-26`'s visual evidence is for.

The fix is one word — `@import "./glass/glass.css" layer(components);` — in `packages/app/src/design/system/styles.css`, with the reasoning written at the import. `components` is the layer Tailwind declares *before* `utilities` precisely so a default can be overridden by a utility. Guarded by `endeavorDetail/pages/__tests__/overlayCascade.test.ts`, which reads the stylesheet from disk the same way the design system's contrast suite reads `tokens.css`.

**This is a cross-lane touch** (`design/system/**` is #6's). It is one line, it is the only way this issue ships a working overlay, and it is called out here rather than buried.

---

## Divergences from canon, each deliberate

1. **The row's `Open ›` control is not canon's.** Canon's Find row opens Detail with a whole-row tap, and the registry binds that tap `requires: 'endeavorDetail'` — a flag `statusQuoSet` ships **off**, because iOS is dark-launching Detail while its own epic lands. With the tap alone, the surface this issue builds would be unreachable in a shipping build and AC 2 ("opens from any endeavor row") could not be met. So Find and All Tasks rows each carry a labelled `Open <title>` control, **and the vista's tap keeps its flag untouched** — the gate is not weakened, a second, unflagged affordance sits beside it. All Tasks additionally has canon's own precedent: macOS `TaskRow` raises `onSelected`, answered there with a trailing detail panel and here with the sheet the epic's idiom rule maps that content onto. **This is the divergence most worth your judgement at G2.**

2. **The control sits OUTSIDE the action surface**, not in `EndeavorRow`'s `trailing` slot. Three reasons, all of which only appear in a browser: a `<button>` may hold only phrasing content; on pointer the kit's hover strip is an absolutely-positioned overlay on the row's trailing edge with `pointer-events` on while hovered, so anything under it is unclickable; and on touch the action surface takes a **pointer capture** on `pointerdown`, so a control inside it never sees its click. Both were caught by the built app, and both are asserted by tests now.

3. **A Lists destination lists nothing** — a defect in the merged logic tier, not here. `FindProducer.readStoredEndeavors` hydrates each endeavor's defers and performances but leaves `list: null` (`EndeavorRecord`'s own note says the list "is looked up from `ProjectStore`", and nothing looks it up). `tasksForList(id)`'s query filters on `endeavor.list?.id`, so every row is filtered out and the surface honestly shows **"Nothing Here"**. The mount, the vista, the heading and the sidebar highlight are all correct — see the screenshots. Fixing it is a join in `packages/app/src/features/find/FindProducer.ts`, which is #29's lane. **Reported, not patched.**

4. **Hosts cannot be attached.** `attachHostThunk` / `detachHostThunk` (#29) refuse with `hostAdapterUnavailable` for every provider, and `hostAttachCandidatesOf` reports `isAttachable: false` with a reason. The brief said #33 landed a Google adapter; the merged logic tier still refuses, so the screen renders that truthfully — every candidate listed, its Attach control **disabled with the reason beside it**, because a hidden control makes the gap invisible. Wiring the adapter is #29/#33's lane.

5. **No confirmation on the bulk operations.** `FindProducer`'s own note rules that canon applies delete-all/archive-all immediately and optimistically, and that adding a confirm dialog "would be a new business rule". The destructive *role* on Delete is the affordance — the brief's "kit's destructive flows" is realized as the kit's destructive treatment (red, named), not as `DeleteConfirmationPopover`.

6. **The ellipsis menu is a hand-built disclosure, not the kit's Radix dropdown.** `system/primitives/__tests__/radixEnvironment.tsx` records that mounting a Radix popper under jsdom costs 5–12 s and made `make test` fail, so those panels are covered only by a Storybook runner this repo has never executed. *Delete all visible* is irreversible and unconfirmed; "covered by a runner nobody has run" is the wrong bar for it. The menu is the same shape the chrome kit's `LiquidGlassFABMenu` already ships (`aria-expanded` trigger, labelled `role="menu"`, Escape closes, focus returns) and its whole flow is an ordinary interaction test.

7. **No new-task box on All Tasks, and no Reminders banner.** Creating an endeavor is capture's (#23/#24) and `findSlice` declares no create event; Apple Reminders has no web equivalent at all (epic: out of scope). Both named rather than faked.

8. **Nine SF Symbols canon names are drawn with the nearest mapped neighbour** — `line.3.horizontal.decrease.circle`, `slider.horizontal.3`, `textformat`, `circle.lefthalf.filled`, `star.fill`, `flame.fill`, `folder`, `minus`, `flag.checkered`. Neither symbol map carries them and both are merged lanes; each substitution names canon's symbol in a comment beside it. Folding the real rows into `system/icons/icons.ts` is a one-line-per-row follow-up.

9. **The associated-colour row prints its hex instead of a swatch.** `PropertyRowValue`'s `tint` case takes a `ChipTint`, which is a design-system token *role* by construction — deliberately, so no caller can paint an unmeasured colour — and there is no token for "whatever the user picked". Cross-lane follow-up for whichever child next opens `PropertyRow`.

10. **Canon pin moved.** The epic pins `KroApple@2c1ee45`; `origin/main` is now `2117efc`. `FindView.swift`, `TasksView.swift`, `EndeavorDetailView.swift`, `Endeavor+DetailDisplay.swift` and the four relation views were re-read at the new tip; nothing this issue ports had changed.

---

## Cross-lane touches (three, all named)

| File | Why | Whose lane |
|---|---|---|
| `packages/app/src/index.ts` | two `export * from './features/{find,endeavorDetail}/pages'` lines — `apps/web` cannot import a Page that the barrel does not export, and the package's `exports` map has no wildcard | shared barrel, same shape as #13's own line |
| `packages/app/src/design/system/styles.css` | one word (`layer(components)`) — the cascade defect above; without it no overlay in the app is an overlay | #6 |
| `apps/web/src/app/(shell)/AppShellClient.tsx` | the shared one-line overlay anchor, as briefed | shell |

## Definition of Done

- [x] `make lint && make typecheck && make test && make build` green locally — **5 630** app tests, **1 843** core, **147** web, all passing. CI green on this head.
- [x] ≥3 stories **and** ≥3 mirroring render tests per Page and Fragment (`RC-11`): `FindFragment` 7/20, `FindPage` 4/11, `TasksFragment` 6/16, `TasksPage` 4/10, `EndeavorDetailFragment` 6/13, `EndeavorEditFragment` 7/14, `EndeavorDurationFragment` 5/10, `EndeavorRelationFragment` 7/31, `DetailOverlays` 5/20.
- [x] Interaction tests for the flows the issue names: full-swipe commit (touch), hover-strip click (pointer), the named context-menu trigger, both bulk operations end to end, Detail opening **from an All Tasks row** and **from a Find row**, dirty→Save→clean, and a matrix-refused edit leaving the draft clean.
- [x] ≥80 % line coverage on every touched source file. Measured: `DetailOverlaySelectors` 100, `EndeavorDetailFragment` 100, `EndeavorDurationFragment` 100, `TasksFragment` 100, `FindCapabilitiesProducer` 100, `FindFragment` 99.1, `EndeavorRelationFragment` 98.5, `findPresentation` 95.9, `endeavorDetailDisplay` 93.9, `DetailOverlays` 93.2, `FindPage` 90.6, `TasksPage` 90.3, `EndeavorEditFragment` 81.3.
      **Exemptions:** the nine `*.stories.tsx` files (they *are* the `UZF-26`/`RC-11` evidence, not code under test) and the two `index.ts` barrels (pure re-exports — the repo's own guard exempts them).
      **Note:** `@kro/app` declares no coverage provider (only `@kro/web` does) and its `test` script passes no `--coverage`, so this was measured with `@vitest/coverage-v8` linked in locally. Wiring it permanently is a toolchain change, not this issue's.
- [x] Tests use `stubbedThunkExtra` / a seeded in-memory `LocalStore` — never the live network, never a mocked `fetch`, never a `State` built inline instead of from `<F>Mocks`.
- [x] No new `any`, no `@ts-ignore`. The two `biome-ignore` lines state their reason on the same line.
- [x] Conventional Commit, ≤72-char subject, no LLM trailers. Nothing committed with `--no-verify`.
- [ ] **`docs/Features/*.md` spec + mermaid diagram (`UZF-21`, `UZF-23` item 2/3).** Not written. `docs/Features/` does not exist in this repo yet and no merged child has created it, so the first one sets the shape for all thirty-four — a call worth making deliberately rather than as a side effect of a UI child. Flagged as an open item, not claimed as done.
- [x] Flag wrapping (`UZF-22`): `endeavorDetail` already exists and is resolved through a Producer; this PR introduces no new user-visible behaviour that lacks a flag, and adds none.

## Review rounds

**Copilot, round 1 → 8e359fe.** Three findings, all real, all fixed with regression tests; every thread replied to and resolved. Round 2 was requested on the fixed head and returned no new findings.

1. **The mount raced itself** (`FindPage`, `TasksPage`). `withFindViewLoaded` resets `isLensRestored` to `false` and re-stamps `clockAnchor`; `withLensSnapshotRestored` refuses to run twice. So a restore that landed *before* the install was un-flagged and could never re-run — `selectIsFindLensLoading` stayed true for the life of the surface. The restore and the fetch now wait for `onViewLoaded`.
2. **The lens was persisted before it was restored** — the worse half, and a silent data loss: opening Find wrote the vista's *defaults* over the user's own saved filters, destroying the snapshot the same mount was about to read. The persist effect is gated on `isLensRestored`, and three new tests seed a real `lensSnapshots` table and assert both the restore and the untouched snapshot on disk.
3. **A test whose name and interaction disagreed** — and behind it, dead code: `onCommitDraft`'s `hosts` branch was unreachable, because that screen has no form at all (a provider is attached by its own row control). The branch is gone; the one test is two, each asserting what it says.

## Notes for the reviewer

- **`FindCapabilitiesProducer` has no reducer arm, deliberately.** `#29`'s `onViewLoaded` takes `enabledFlags` as an argument so capability gating stays a pure Selector read; a Page cannot read a Service (`RC-6`), so a Producer resolves the list and the Page dispatches the plain event with it. Adding arms would put the flag list in `State` twice.
- **`__tests__/pagesHarness.tsx` seeds a real database rather than preloading a slice.** `makeStore(extra)` takes no `preloadedState` (`RC-22`), and it does not need to: seeding `LocalStore` and letting the real fetch run exercises the Producer, the Shifter and the reconcile pass, so a record↔domain mapping bug shows up instead of hiding behind a fixture.
- **One Page serves three destinations.** `/tasks`, `/lists/<id>` and a seeded search differ only in which `.tasks*` vista is installed — the same argument `FindState`'s header makes for one slice carrying two surfaces.
