### PR TITLE
feat(settings): schema-driven Settings hub, auth surface and profile

### DIFF
--- a/apps/web/src/app/(legacy)/integrations/page.tsx
+++ b/apps/web/src/app/(legacy)/integrations/page.tsx
@@ -1,8 +1,16 @@
+import { redirect } from 'next/navigation'
+
+/**
+ * `/integrations` — retired by KC-IS-#32.
+ *
+ * The stub it replaces said "This is the integrations page." The real surface is
+ * the Integrations pane inside the Settings hub; there is no separate
+ * destination for it in canon and there is none here, so the route redirects to
+ * the hub rather than to a page that would have to explain itself.
+ *
+ * Same ownership note as `/settings`: the route file is #13's, its content is
+ * this issue's, and the `(legacy)` group is retired wholesale by #22.
+ */
 export default function IntegrationsPage() {
-  return (
-    <div>
-      <h1>Integrations</h1>
-      <p>This is the integrations page.</p>
-    </div>
-  )
+  redirect('/adjust')
 }

--- a/apps/web/src/app/(legacy)/settings/page.spec.tsx
+++ b/apps/web/src/app/(legacy)/settings/page.spec.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+/**
+ * The two retired stubs.
+ *
+ * `redirect()` throws a sentinel Next.js catches upstream, so the assertion is
+ * that the page *calls* it with the parity destination — which is the whole
+ * behaviour these two files now have.
+ */
+const redirect = vi.fn()
+vi.mock('next/navigation', () => ({
+  redirect: (path: string) => redirect(path),
+}))
+
+describe('the retired legacy stubs', () => {
+  it('sends /settings to the Adjust destination', async () => {
+    const { default: SettingsPage } = await import('./page')
+
+    SettingsPage()
+
+    expect(redirect).toHaveBeenCalledWith('/adjust')
+  })
+
+  it('sends /integrations to the same hub — canon has no separate destination', async () => {
+    redirect.mockClear()
+    const { default: IntegrationsPage } = await import('../integrations/page')
+
+    IntegrationsPage()
+
+    expect(redirect).toHaveBeenCalledWith('/adjust')
+  })
+
+  it('renders nothing of its own — the stub content is gone', async () => {
+    redirect.mockClear()
+    const { default: SettingsPage } = await import('./page')
+
+    expect(SettingsPage()).toBeUndefined()
+  })
+})

--- a/apps/web/src/app/(legacy)/settings/page.tsx
+++ b/apps/web/src/app/(legacy)/settings/page.tsx
@@ -1,8 +1,16 @@
+import { redirect } from 'next/navigation'
+
+/**
+ * `/settings` — retired by KC-IS-#32.
+ *
+ * This was a create-next-app-era stub ("This is the settings page."). The real
+ * surface is the Adjust destination inside the parity shell, so the route stays
+ * — a bookmark or an old link must not 404 — and redirects there permanently.
+ *
+ * The file itself belongs to the shell child's route tree (#13); what changes
+ * here is only its content, which is what KC-IS-#32's lane covers. The `(legacy)`
+ * group as a whole is retired by #22.
+ */
 export default function SettingsPage() {
-  return (
-    <div>
-      <h1>Settings</h1>
-      <p>This is the settings page.</p>
-    </div>
-  )
+  redirect('/adjust')
 }

--- a/apps/web/src/app/(shell)/adjust/AdjustPageClient.spec.tsx
+++ b/apps/web/src/app/(shell)/adjust/AdjustPageClient.spec.tsx
@@ -1,0 +1,22 @@
+import { StoreProvider, makeStore, stubbedThunkExtra } from '@kro/app'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { AdjustPageClient } from './AdjustPageClient'
+
+/**
+ * The client wrapper is a passive shell (`RC-57`): it imports the Page and
+ * forwards nothing. This one assertion proves the wiring — that `/adjust`
+ * reaches the settings surface rather than the shared placeholder — and every
+ * behaviour is covered by `SettingsHubPage`'s own suite in `packages/app`.
+ */
+describe('AdjustPageClient', () => {
+  it('mounts the Settings hub rather than the destination placeholder', async () => {
+    render(
+      <StoreProvider store={makeStore(stubbedThunkExtra)}>
+        <AdjustPageClient />
+      </StoreProvider>,
+    )
+
+    expect(await screen.findByTestId('settings-hub')).toBeTruthy()
+  })
+})

--- a/apps/web/src/app/(shell)/adjust/AdjustPageClient.tsx
+++ b/apps/web/src/app/(shell)/adjust/AdjustPageClient.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { SettingsHubPage } from '@kro/app'
+
+/**
+ * Client wrapper (`RC-39`): imports the Page, forwards props, ≤10 lines.
+ *
+ * `/adjust` is the first destination whose body exists, so it is the first
+ * route to swap the shared placeholder for a real Page. The generic
+ * `DestinationPageClient` still serves every other destination.
+ */
+export function AdjustPageClient() {
+  return <SettingsHubPage />
+}

--- a/apps/web/src/app/(shell)/adjust/page.tsx
+++ b/apps/web/src/app/(shell)/adjust/page.tsx
@@ -1,13 +1,18 @@
-import { DestinationPageClient } from '../DestinationPageClient'
+import { AdjustPageClient } from './AdjustPageClient'
 
 /**
- * `/adjust` — the Adjust destination.
+ * `/adjust` — the Adjust destination (canon's Settings).
  *
- * A passive Server Component (`RC-38`): it names its destination and renders
- * the client wrapper. No hook, no store read, no markup. The surface itself
- * lives in `packages/app`, so the feature child that builds Settings replaces
- * a Page there and never touches this file.
+ * A passive Server Component (`RC-38`): it renders the client wrapper and
+ * nothing else. No hook, no store read, no markup. The surface itself lives in
+ * `packages/app`, so KC-IS-#32 replaced a Page there and this file changed by
+ * exactly one import — which is what the shell child (#13) wrote the route tree
+ * for.
+ *
+ * The shell's own selection still follows the URL: `SettingsHubPage` dispatches
+ * the destination-mounted event the shared `DestinationPage` used to, so a
+ * pasted link and a back step land the same way they did before.
  */
 export default function AdjustRoute() {
-  return <DestinationPageClient kind="settings" />
+  return <AdjustPageClient />
 }

--- a/packages/app/src/features/auth/__tests__/AuthSelectors.test.ts
+++ b/packages/app/src/features/auth/__tests__/AuthSelectors.test.ts
@@ -41,6 +41,7 @@ import { initialPlatformState } from '../../platform/PlatformFeature'
 import { initialSessionState } from '../../session/SessionState'
 import { AuthFlow, type AuthState } from '../AuthState'
 import { signOutIntents } from '../SignOutIntents'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 const rootWith = (auth: AuthState): RootState => ({
   greeting: initialGreetingState,
@@ -55,6 +56,7 @@ const rootWith = (auth: AuthState): RootState => ({
   earn: initialEarnState,
   platform: initialPlatformState,
   session: initialSessionState,
+  settings: initialSettingsState,
   auth,
   main: initialMainState,
 })

--- a/packages/app/src/features/auth/pages/AuthSurfaceFragment.stories.tsx
+++ b/packages/app/src/features/auth/pages/AuthSurfaceFragment.stories.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from 'react'
+import { AuthFlow, AuthMode } from '../AuthState'
+import { AuthSurfaceFragment } from './AuthSurfaceFragment'
+
+/**
+ * The auth surface, in both modes and in every state it can report.
+ *
+ * The surface pins its own dark scheme (canon's
+ * `.preferredColorScheme(.dark)`), so the light/dark pair below is deliberately
+ * a pair of *stages*: what changes between them is the page behind the panel,
+ * not the panel. That is the fact worth seeing — the surface reads the same on
+ * a light desktop and a dark one.
+ */
+export default {
+  title: 'Auth/Surface',
+  component: AuthSurfaceFragment,
+  parameters: { layout: 'centered' },
+}
+
+const noop = () => {}
+
+function Stage({
+  theme = 'light',
+  children,
+}: {
+  theme?: 'light' | 'dark'
+  children: ReactNode
+}) {
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        width: 420,
+        padding: 16,
+        background: 'var(--kro-color-back)',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+const surface = (
+  overrides: Partial<Parameters<typeof AuthSurfaceFragment>[0]> = {},
+) => (
+  <AuthSurfaceFragment
+    mode={AuthMode.signIn}
+    email=""
+    password=""
+    name=""
+    errorCopy={null}
+    authenticatingFlow={null}
+    isSubmitEnabled={false}
+    isUnavailable={false}
+    onChangeEmail={noop}
+    onChangePassword={noop}
+    onChangeName={noop}
+    onSubmit={noop}
+    onToggleMode={noop}
+    onTapApple={noop}
+    onTapGoogle={noop}
+    onTapCancel={noop}
+    {...overrides}
+  />
+)
+
+/** Sign in, empty — the disabled submit names what blocks it. */
+export const SignInEmpty = {
+  render: () => <Stage>{surface()}</Stage>,
+}
+
+/** Sign in, ready to submit. */
+export const SignInReady = {
+  render: () => (
+    <Stage>
+      {surface({
+        email: 'ada@example.com',
+        password: 'correct-horse',
+        isSubmitEnabled: true,
+      })}
+    </Stage>
+  ),
+}
+
+/** Create an account — the name field appears and the copy changes. */
+export const SignUp = {
+  render: () => (
+    <Stage>
+      {surface({
+        mode: AuthMode.signUp,
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+        password: 'correct-horse',
+        isSubmitEnabled: true,
+      })}
+    </Stage>
+  ),
+}
+
+/** A rejected credential — derived copy, never the provider's message. */
+export const CredentialRejected = {
+  render: () => (
+    <Stage>
+      {surface({
+        email: 'ada@example.com',
+        password: 'wrong',
+        isSubmitEnabled: true,
+        errorCopy: 'Incorrect email or password.',
+      })}
+    </Stage>
+  ),
+}
+
+/** A provider flow in flight — the running button spins, the other locks. */
+export const GoogleInFlight = {
+  render: () => (
+    <Stage>{surface({ authenticatingFlow: AuthFlow.google })}</Stage>
+  ),
+}
+
+/**
+ * The honest unavailable state: no Supabase project is configured, every route
+ * in is inert, and the copy says local use still works.
+ */
+export const CloudUnavailable = {
+  render: () => <Stage>{surface({ isUnavailable: true })}</Stage>,
+}
+
+/** The same panel on a light page and a dark one. */
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Stage theme="light">{surface()}</Stage>
+      <Stage theme="dark">{surface()}</Stage>
+    </div>
+  ),
+}

--- a/packages/app/src/features/auth/pages/AuthSurfaceFragment.tsx
+++ b/packages/app/src/features/auth/pages/AuthSurfaceFragment.tsx
@@ -1,0 +1,387 @@
+'use client'
+
+/**
+ * The auth surface — canon `AuthView` (`RC-15`: passive; every value and every
+ * intent is a prop, and it dispatches nothing).
+ *
+ * Canon's composition, kept: the indigo→grape field, a glass form card holding
+ * the fields and the primary action, an "or continue with" divider above the
+ * two provider buttons, and the sign-in ⇄ create toggle at the bottom. Canon's
+ * `.preferredColorScheme(.dark)` is the reason the surface pins `data-theme` to
+ * dark: the whole thing sits on a saturated gradient, and a light scheme would
+ * put light-on-light text on it.
+ *
+ * ## The honest unavailable state
+ *
+ * Canon has no such state — the iOS build resolves its Supabase connection from
+ * a bundled resolver and `fatalError`s without one. On the web, signed-out
+ * local-only use is a first-class mode (`authenticationEnforced` is OFF), so a
+ * checkout with no `NEXT_PUBLIC_SUPABASE_*` is a *state this surface reports*,
+ * not a crash: every control is disabled, and the copy says the app still works
+ * on this device. KC-IS-#31's `AuthExceptions.unavailable` is where that comes
+ * from; this Fragment only renders it.
+ *
+ * Both provider buttons carry the providers' own artwork rather than an SF
+ * Symbol — see `ProviderMarks`.
+ */
+import type { ReactNode } from 'react'
+import { colorVar } from '../../../design/system/tokens/roles'
+import { GlassSurface } from '../../../design/system/glass/GlassSurface'
+import { GradientBackdrop } from '../../../design/system/gradient/GradientBackdrop'
+import { cn } from '../../../design/system/utils/cn'
+import { AuthFlow, AuthMode } from '../AuthState'
+import { AppleMark, GoogleMark } from './ProviderMarks'
+
+export interface AuthSurfaceFragmentProps {
+  readonly mode: AuthMode
+  readonly email: string
+  readonly password: string
+  readonly name: string
+  /** Copy for the error banner, or `null`. Canon's `errorMessage`. */
+  readonly errorCopy: string | null
+  /** Which provider flow is spinning, or `null`. Canon's `isLoading`, typed. */
+  readonly authenticatingFlow: AuthFlow | null
+  /** Canon's `isSignInReady`/`isSignUpReady`, resolved for the current mode. */
+  readonly isSubmitEnabled: boolean
+  /** No Supabase project is configured — every control is inert and says why. */
+  readonly isUnavailable: boolean
+  readonly onChangeEmail: (value: string) => void
+  readonly onChangePassword: (value: string) => void
+  readonly onChangeName: (value: string) => void
+  readonly onSubmit: () => void
+  readonly onToggleMode: () => void
+  readonly onTapApple: () => void
+  readonly onTapGoogle: () => void
+  readonly onTapCancel: () => void
+}
+
+export function AuthSurfaceFragment({
+  mode,
+  email,
+  password,
+  name,
+  errorCopy,
+  authenticatingFlow,
+  isSubmitEnabled,
+  isUnavailable,
+  onChangeEmail,
+  onChangePassword,
+  onChangeName,
+  onSubmit,
+  onToggleMode,
+  onTapApple,
+  onTapGoogle,
+  onTapCancel,
+}: AuthSurfaceFragmentProps) {
+  const isSignIn = mode === AuthMode.signIn
+  const isBusy = authenticatingFlow !== null
+
+  return (
+    <div
+      // Canon's `.preferredColorScheme(.dark)`. The attribute is the design
+      // system's own scoping mechanism, so nested tokens resolve to the dark
+      // scheme without touching the document.
+      data-theme="dark"
+      data-testid="auth-surface"
+      data-mode={mode}
+      className="relative flex w-full flex-col overflow-hidden rounded-kro-surface"
+    >
+      <GradientBackdrop height="100%" hardEdge className="absolute inset-0" />
+
+      <div className="relative flex w-full flex-col items-stretch gap-kro-medium p-kro-large">
+        <div className="flex items-start justify-between">
+          <span />
+          <button
+            type="button"
+            onClick={onTapCancel}
+            className={cn(
+              'inline-flex h-9 items-center rounded-kro-small px-2 text-[15px] font-medium',
+              'outline-none focus-visible:shadow-[var(--kro-ring)]',
+            )}
+            style={{ color: colorVar('fore') }}
+          >
+            Cancel
+          </button>
+        </div>
+
+        <header className="flex flex-col items-center gap-2 pb-kro-small text-center">
+          <span
+            className="text-[34px] font-bold tracking-tight"
+            style={{ color: colorVar('fore') }}
+          >
+            Kro
+          </span>
+          <span className="text-[15px]" style={{ color: colorVar('foreSecondary') }}>
+            {isSignIn ? 'Welcome back' : 'Create your account'}
+          </span>
+        </header>
+
+        {isUnavailable ? (
+          <p
+            role="status"
+            data-testid="auth-unavailable"
+            className="m-0 rounded-kro-field p-3 text-[13px] leading-snug"
+            style={{
+              backgroundColor: colorVar('bannerWarning'),
+              color: colorVar('fore'),
+            }}
+          >
+            Kro Cloud is not set up for this build, so signing in is unavailable
+            here. You can keep using Kro on this device — everything you create
+            stays local until an account exists.
+          </p>
+        ) : null}
+
+        <GlassSurface
+          material="surface"
+          className="flex w-full flex-col overflow-hidden rounded-kro-surface"
+        >
+          <form
+            data-testid="auth-form"
+            onSubmit={(event) => {
+              event.preventDefault()
+              onSubmit()
+            }}
+            className="flex w-full flex-col"
+          >
+            {isSignIn ? null : (
+              <Field
+                id="auth-name"
+                label="Full name"
+                type="text"
+                autoComplete="name"
+                value={name}
+                isDisabled={isUnavailable || isBusy}
+                onChange={onChangeName}
+              />
+            )}
+            <Field
+              id="auth-email"
+              label="Email address"
+              type="email"
+              autoComplete="email"
+              value={email}
+              isDisabled={isUnavailable || isBusy}
+              onChange={onChangeEmail}
+            />
+            <Field
+              id="auth-password"
+              label="Password"
+              type="password"
+              autoComplete={isSignIn ? 'current-password' : 'new-password'}
+              value={password}
+              isDisabled={isUnavailable || isBusy}
+              onChange={onChangePassword}
+            />
+
+            {/*
+              The unavailable banner above already says this, calmly. Repeating
+              it here in red would tell the user their *credentials* were
+              rejected, when in fact they have not tried anything — so the
+              inline error is suppressed while the deployment itself is the
+              problem.
+            */}
+            {errorCopy === null || isUnavailable ? null : (
+              <p
+                role="alert"
+                data-testid="auth-error"
+                className="m-0 px-4 py-2.5 text-[13px]"
+                style={{ color: colorVar('kroRed') }}
+              >
+                {errorCopy}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              data-testid="auth-submit"
+              disabled={isUnavailable || !isSubmitEnabled}
+              className={cn(
+                'flex h-12 w-full items-center justify-center text-[15px] font-semibold',
+                'outline-none focus-visible:shadow-[var(--kro-ring)]',
+                'disabled:cursor-not-allowed',
+              )}
+              style={{
+                backgroundColor: colorVar('accent'),
+                color: colorVar('onAccent'),
+                opacity: isUnavailable || !isSubmitEnabled ? 0.62 : undefined,
+              }}
+            >
+              {authenticatingFlow === AuthFlow.emailPassword
+                ? 'Signing in…'
+                : isSignIn
+                  ? 'Sign In'
+                  : 'Create Account'}
+            </button>
+          </form>
+        </GlassSurface>
+
+        {/*
+          Canon's disabled-control rule: a disabled submit names what blocks it.
+          `isSubmitEnabled` is false either because a field is empty or because
+          the password is under canon's six-character minimum, so the hint says
+          which — an empty form gets the shorter sentence.
+        */}
+        {isUnavailable || isSubmitEnabled ? null : (
+          <p
+            data-testid="auth-submit-hint"
+            className="m-0 text-center text-[13px]"
+            style={{ color: colorVar('foreSecondary') }}
+          >
+            {isSignIn
+              ? 'Enter your email and password to continue.'
+              : 'Enter your name, email and a password of at least 6 characters.'}
+          </p>
+        )}
+
+        <div className="flex items-center gap-3" aria-hidden>
+          <span
+            className="h-px flex-1"
+            style={{ backgroundColor: colorVar('hairline') }}
+          />
+          <span className="text-[12px]" style={{ color: colorVar('foreSecondary') }}>
+            or continue with
+          </span>
+          <span
+            className="h-px flex-1"
+            style={{ backgroundColor: colorVar('hairline') }}
+          />
+        </div>
+
+        {/*
+          Provider branding: Apple's control is white-on-black artwork with the
+          exact wordmark; Google's is the four-colour G on white. Neither is
+          restyled to the app's palette, which is what both guidelines require.
+        */}
+        <ProviderButton
+          testId="auth-apple"
+          label="Sign in with Apple"
+          isDisabled={isUnavailable || isBusy}
+          isBusy={authenticatingFlow === AuthFlow.apple}
+          background="#000000"
+          foreground="#ffffff"
+          onClick={onTapApple}
+        >
+          <AppleMark />
+        </ProviderButton>
+
+        <ProviderButton
+          testId="auth-google"
+          label="Sign in with Google"
+          isDisabled={isUnavailable || isBusy}
+          isBusy={authenticatingFlow === AuthFlow.google}
+          background="#ffffff"
+          foreground="#1f1f1f"
+          onClick={onTapGoogle}
+        >
+          <GoogleMark />
+        </ProviderButton>
+
+        <button
+          type="button"
+          data-testid="auth-toggle-mode"
+          onClick={onToggleMode}
+          disabled={isBusy}
+          className={cn(
+            'mx-auto inline-flex h-11 items-center gap-1 rounded-kro-small px-2 text-[15px]',
+            'outline-none focus-visible:shadow-[var(--kro-ring)]',
+          )}
+          style={{ color: colorVar('foreSecondary') }}
+        >
+          {isSignIn ? "Don't have an account?" : 'Already have an account?'}
+          <span className="font-semibold" style={{ color: colorVar('fore') }}>
+            {isSignIn ? 'Sign Up' : 'Sign In'}
+          </span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function Field({
+  id,
+  label,
+  type,
+  autoComplete,
+  value,
+  isDisabled,
+  onChange,
+}: {
+  readonly id: string
+  readonly label: string
+  readonly type: 'text' | 'email' | 'password'
+  readonly autoComplete: string
+  readonly value: string
+  readonly isDisabled: boolean
+  readonly onChange: (value: string) => void
+}) {
+  return (
+    <div
+      className="flex w-full flex-col gap-1 border-b px-4 py-3"
+      style={{ borderColor: colorVar('hairline') }}
+    >
+      <label
+        htmlFor={id}
+        className="text-[12px] font-medium"
+        style={{ color: colorVar('foreSecondary') }}
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type={type}
+        autoComplete={autoComplete}
+        disabled={isDisabled}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className={cn(
+          'w-full bg-transparent text-[15px] outline-none',
+          'disabled:cursor-not-allowed',
+        )}
+        style={{ color: colorVar('fore'), opacity: isDisabled ? 0.62 : undefined }}
+      />
+    </div>
+  )
+}
+
+function ProviderButton({
+  testId,
+  label,
+  isDisabled,
+  isBusy,
+  background,
+  foreground,
+  onClick,
+  children,
+}: {
+  readonly testId: string
+  readonly label: string
+  readonly isDisabled: boolean
+  readonly isBusy: boolean
+  readonly background: string
+  readonly foreground: string
+  readonly onClick: () => void
+  readonly children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      disabled={isDisabled}
+      onClick={onClick}
+      className={cn(
+        'flex h-12 w-full items-center justify-center gap-2.5 rounded-kro-field',
+        'text-[15px] font-medium outline-none focus-visible:shadow-[var(--kro-ring)]',
+        'disabled:cursor-not-allowed',
+      )}
+      style={{
+        backgroundColor: background,
+        color: foreground,
+        opacity: isDisabled ? 0.62 : undefined,
+      }}
+    >
+      {children}
+      {isBusy ? 'Signing in…' : label}
+    </button>
+  )
+}

--- a/packages/app/src/features/auth/pages/AuthSurfacePage.stories.tsx
+++ b/packages/app/src/features/auth/pages/AuthSurfacePage.stories.tsx
@@ -1,0 +1,111 @@
+import { StoreProvider } from '../../../library/StoreProvider'
+import { type ThunkExtra, makeStore, stubbedThunkExtra } from '../../../library/store'
+import { makeStubbedAuthService } from '../../../services/auth/AuthService'
+import { AuthExceptions } from '../AuthException'
+import {
+  userDidChangeEmail,
+  userDidChangePassword,
+  userDidTapToggleMode,
+} from '../AuthFeature'
+import { restoreSessionThunk } from '../AuthProducer'
+import { AuthSurfacePage } from './AuthSurfacePage'
+
+/**
+ * The auth surface wired to a real store (`RC-22`) over fixture-backed Services
+ * (`RC-35`).
+ *
+ * Where the Fragment stories set every value as a prop, these drive the slice —
+ * so what they show is the surface a user gets, including the fact that the
+ * form survives a mode toggle.
+ */
+export default {
+  title: 'Auth/Surface (wired)',
+  component: AuthSurfacePage,
+  parameters: { layout: 'centered' },
+}
+
+function Stage({
+  theme = 'light',
+  extra = stubbedThunkExtra,
+  prime,
+}: {
+  theme?: 'light' | 'dark'
+  extra?: ThunkExtra
+  prime?: (store: ReturnType<typeof makeStore>) => void
+}) {
+  const store = makeStore(extra)
+  prime?.(store)
+
+  return (
+    <div
+      data-theme={theme}
+      style={{ width: 420, padding: 16, background: 'var(--kro-color-back)' }}
+    >
+      <StoreProvider store={store}>
+        <AuthSurfacePage redirectTo="https://kro.example" onDismiss={() => {}} />
+      </StoreProvider>
+    </div>
+  )
+}
+
+/** Sign in, empty. */
+export const SignIn = {
+  render: () => <Stage />,
+}
+
+/** Sign up, after the toggle — the form carried over. */
+export const SignUp = {
+  render: () => (
+    <Stage
+      prime={(store) => {
+        store.dispatch(userDidChangeEmail('ada@example.com'))
+        store.dispatch(userDidTapToggleMode())
+      }}
+    />
+  ),
+}
+
+/** Ready to submit. */
+export const Ready = {
+  render: () => (
+    <Stage
+      prime={(store) => {
+        store.dispatch(userDidChangeEmail('ada@example.com'))
+        store.dispatch(userDidChangePassword('correct-horse'))
+      }}
+    />
+  ),
+}
+
+/** No Supabase project configured — the honest unavailable state, end to end. */
+export const CloudUnavailable = {
+  render: () => (
+    <Stage
+      extra={{
+        ...stubbedThunkExtra,
+        authService: makeStubbedAuthService({
+          failures: {
+            restoreSession: AuthExceptions.unavailable([
+              'NEXT_PUBLIC_SUPABASE_URL',
+              'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+            ]),
+          },
+        }),
+      }}
+      prime={(store) => {
+        // The launch restore is what discovers it; the surface only renders it.
+        void store.dispatch(restoreSessionThunk({ now: new Date() }))
+      }}
+    />
+  ),
+}
+
+/** Both schemes. */
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Stage theme="light" />
+      <Stage theme="dark" />
+    </div>
+  ),
+}

--- a/packages/app/src/features/auth/pages/AuthSurfacePage.tsx
+++ b/packages/app/src/features/auth/pages/AuthSurfacePage.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+/**
+ * The auth surface's stateful container (`RC-37`; implements `UZF-4`).
+ *
+ * The only artifact in this lane that calls both `useAppSelector` and
+ * `useAppDispatch`. It selects through KC-IS-#31's named Selectors, dispatches
+ * that feature's Producers, and renders exactly one Fragment.
+ *
+ * ## Both providers go through the OAuth redirect
+ *
+ * Canon splits Apple in two — `beginAppleSignInThunk` mints a nonce pair and
+ * `signInWithAppleThunk` exchanges the id token Apple's native control hands
+ * back. That split exists because iOS *has* a native control. The web does not:
+ * `ASAuthorizationAppleIDCredential` has no browser counterpart, and Apple's
+ * JS SDK is a separate script this repo does not load. So both buttons take
+ * `startOAuthRedirectThunk`, which KC-IS-#31 built for exactly this — its own
+ * header calls it "Google, **and Apple with no id token**". The nonce pair
+ * stays unused here rather than being minted and thrown away, so no stale nonce
+ * can ever sit in state waiting to be replayed.
+ *
+ * ## Where the redirect comes back to
+ *
+ * `redirectTo` defaults to this document's origin. Reading `location` here is
+ * the one platform read this Page makes, for the same reason the shell reads
+ * `matchMedia`: it is a property of the browser the surface is rendering in,
+ * not data. It is a prop first, so a story and a test never touch `location` at
+ * all.
+ */
+import { useCallback } from 'react'
+import { useAppDispatch, useAppSelector } from '../../../library/hooks'
+import {
+  userDidChangeEmail,
+  userDidChangeName,
+  userDidChangePassword,
+  userDidTapToggleMode,
+} from '../AuthFeature'
+import {
+  signInWithEmailThunk,
+  signUpWithEmailThunk,
+  startOAuthRedirectThunk,
+} from '../AuthProducer'
+import {
+  selectAuthErrorCopy,
+  selectAuthException,
+  selectAuthForm,
+  selectAuthMode,
+  selectAuthenticatingFlow,
+  selectIsSubmitEnabled,
+} from '../AuthSelectors'
+import { AuthMode } from '../AuthState'
+import { AuthSurfaceFragment } from './AuthSurfaceFragment'
+
+export interface AuthSurfacePageProps {
+  /** Where a provider sends the browser back to. Defaults to this origin. */
+  readonly redirectTo?: string
+  /** Canon's Cancel — the presenter decides what dismissal means. */
+  readonly onDismiss: () => void
+}
+
+/** This document's origin, or `''` where there is no document (SSR, a test). */
+export const currentOrigin = (): string =>
+  typeof globalThis.location === 'undefined' ? '' : globalThis.location.origin
+
+export function AuthSurfacePage({
+  redirectTo,
+  onDismiss,
+}: AuthSurfacePageProps) {
+  const dispatch = useAppDispatch()
+
+  const mode = useAppSelector(selectAuthMode)
+  const form = useAppSelector(selectAuthForm)
+  const errorCopy = useAppSelector(selectAuthErrorCopy)
+  const exception = useAppSelector(selectAuthException)
+  const authenticatingFlow = useAppSelector(selectAuthenticatingFlow)
+  const isSubmitEnabled = useAppSelector(selectIsSubmitEnabled)
+
+  const target = redirectTo ?? currentOrigin()
+
+  const onSubmit = useCallback(() => {
+    const now = new Date()
+    if (mode === AuthMode.signIn) {
+      void dispatch(
+        signInWithEmailThunk({ email: form.email, password: form.password, now }),
+      )
+      return
+    }
+    void dispatch(
+      signUpWithEmailThunk({
+        email: form.email,
+        password: form.password,
+        name: form.name,
+        now,
+      }),
+    )
+  }, [dispatch, form.email, form.name, form.password, mode])
+
+  return (
+    <AuthSurfaceFragment
+      mode={mode}
+      email={form.email}
+      password={form.password}
+      name={form.name}
+      errorCopy={errorCopy}
+      authenticatingFlow={authenticatingFlow}
+      isSubmitEnabled={isSubmitEnabled}
+      // `unavailable` is the one exception that describes the *deployment*
+      // rather than the attempt, so it disables the surface instead of showing
+      // a banner the user could retry past.
+      isUnavailable={exception?.kind === 'unavailable'}
+      onChangeEmail={(value) => dispatch(userDidChangeEmail(value))}
+      onChangePassword={(value) => dispatch(userDidChangePassword(value))}
+      onChangeName={(value) => dispatch(userDidChangeName(value))}
+      onSubmit={onSubmit}
+      onToggleMode={() => dispatch(userDidTapToggleMode())}
+      onTapApple={() => {
+        void dispatch(
+          startOAuthRedirectThunk({ provider: 'apple', redirectTo: target }),
+        )
+      }}
+      onTapGoogle={() => {
+        void dispatch(
+          startOAuthRedirectThunk({ provider: 'google', redirectTo: target }),
+        )
+      }}
+      onTapCancel={onDismiss}
+    />
+  )
+}

--- a/packages/app/src/features/auth/pages/LocalDataDialogFragment.stories.tsx
+++ b/packages/app/src/features/auth/pages/LocalDataDialogFragment.stories.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react'
+import { LocalDataDialogFragment } from './LocalDataDialogFragment'
+
+/**
+ * The existing-local-data dialog — canon's three-button alert.
+ *
+ * It is a Radix dialog and renders into a portal, so each story mounts it
+ * inside a themed stage that fills the frame; what the story shows is the
+ * panel over its scrim, which is what the user sees.
+ */
+export default {
+  title: 'Auth/Local data dialog',
+  component: LocalDataDialogFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+const noop = () => {}
+
+function Stage({
+  theme = 'light',
+  children,
+}: {
+  theme?: 'light' | 'dark'
+  children: ReactNode
+}) {
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        position: 'relative',
+        minHeight: 420,
+        background: 'var(--kro-color-back)',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+const dialog = (
+  overrides: Partial<Parameters<typeof LocalDataDialogFragment>[0]> = {},
+) => (
+  <LocalDataDialogFragment
+    isPresented
+    anonymousCount={3}
+    isResolving={false}
+    onChoose={noop}
+    onDismiss={noop}
+    {...overrides}
+  />
+)
+
+/** The ordinary case: several rows on the device, three ways forward. */
+export const ThreeChoices = {
+  render: () => <Stage>{dialog()}</Stage>,
+}
+
+/** A single row — the message reads in the singular. */
+export const SingleEndeavor = {
+  render: () => <Stage>{dialog({ anonymousCount: 1 })}</Stage>,
+}
+
+/** A choice being applied: every button locks, the prompt stays. */
+export const Resolving = {
+  render: () => <Stage>{dialog({ isResolving: true })}</Stage>,
+}
+
+/** Both schemes. */
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <Stage theme="light">{dialog()}</Stage>
+      <Stage theme="dark">{dialog({ anonymousCount: 12 })}</Stage>
+    </div>
+  ),
+}

--- a/packages/app/src/features/auth/pages/LocalDataDialogFragment.tsx
+++ b/packages/app/src/features/auth/pages/LocalDataDialogFragment.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+/**
+ * The existing-local-data dialog — canon's `migrationAlert` (`RC-15`: passive;
+ * every intent is a callback prop).
+ *
+ * Canon presents three buttons in one `alert`: *Sign All Endeavors to My
+ * Account*, *Clear Everything and Start Over* (destructive role) and *Cancel*.
+ * KC-IS-#31 already owns the title, the interpolated message and what each arm
+ * does (`LocalDataDialog.ts`); this only presents them, on the design system's
+ * dialog kit.
+ *
+ * `hideClose` and the two `onInteractOutside`-style guards are deliberate:
+ * canon's alert has no dismiss affordance beyond its own three buttons, and a
+ * stray tap on the scrim landing on "Cancel" — which pulls from the cloud with
+ * the local rows left unowned — is a decision the user did not make. Escape
+ * still closes, because a modal that traps the keyboard is worse; it routes to
+ * the same arm canon routes swipe-to-dismiss to.
+ */
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../../../design/system/primitives/dialog'
+import { colorVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import {
+  LOCAL_DATA_DIALOG_TITLE,
+  type LocalDataChoice,
+  localDataDialogMessage,
+} from '../LocalDataDialog'
+
+export interface LocalDataDialogFragmentProps {
+  readonly isPresented: boolean
+  /** The anonymous-row count canon interpolates into the message. */
+  readonly anonymousCount: number
+  /** A choice is being applied — every button waits rather than double-firing. */
+  readonly isResolving: boolean
+  readonly onChoose: (choice: LocalDataChoice) => void
+  /** Escape, and any other dismissal canon treats as Cancel. */
+  readonly onDismiss: () => void
+}
+
+export function LocalDataDialogFragment({
+  isPresented,
+  anonymousCount,
+  isResolving,
+  onChoose,
+  onDismiss,
+}: LocalDataDialogFragmentProps) {
+  return (
+    <Dialog
+      open={isPresented}
+      onOpenChange={(next) => {
+        if (!next) onDismiss()
+      }}
+    >
+      <DialogContent
+        hideClose
+        data-testid="local-data-dialog"
+        // `.kro-glass` sets `position: relative` from an unlayered stylesheet
+        // and beats the kit's `fixed` utility, so every glass dialog computes
+        // to `relative` and lands after the shell in normal flow. The inline
+        // style is the one declaration that outranks it. The fix belongs in
+        // `design/system/` — outside this issue's lane; named in the PR body.
+        style={{ position: 'fixed' }}
+        className="top-[8dvh] max-h-[84dvh] max-w-[420px] translate-y-0 overflow-y-auto"
+        onInteractOutside={(event) => event.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle style={{ color: colorVar('fore') }}>
+            {LOCAL_DATA_DIALOG_TITLE}
+          </DialogTitle>
+          <DialogDescription style={{ color: colorVar('foreSecondary') }}>
+            {localDataDialogMessage(anonymousCount)}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-kro-small">
+          <ChoiceButton
+            testId="local-data-sign-all"
+            title="Sign All Endeavors to My Account"
+            tone="primary"
+            isDisabled={isResolving}
+            onClick={() => onChoose('signAll')}
+          />
+          <ChoiceButton
+            testId="local-data-clear-all"
+            title="Clear Everything and Start Over"
+            tone="destructive"
+            isDisabled={isResolving}
+            onClick={() => onChoose('clearAll')}
+          />
+          <ChoiceButton
+            testId="local-data-cancel"
+            title="Cancel"
+            tone="plain"
+            isDisabled={isResolving}
+            onClick={() => onChoose('cancel')}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ChoiceButton({
+  testId,
+  title,
+  tone,
+  isDisabled,
+  onClick,
+}: {
+  readonly testId: string
+  readonly title: string
+  readonly tone: 'primary' | 'destructive' | 'plain'
+  readonly isDisabled: boolean
+  readonly onClick: () => void
+}) {
+  const color =
+    tone === 'destructive'
+      ? colorVar('kroRed')
+      : tone === 'primary'
+        ? colorVar('onAccent')
+        : colorVar('fore')
+
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      disabled={isDisabled}
+      onClick={onClick}
+      className={cn(
+        'flex h-11 w-full items-center justify-center rounded-kro-field border px-3',
+        'text-[15px] font-semibold outline-none focus-visible:shadow-[var(--kro-ring)]',
+        'disabled:cursor-not-allowed',
+      )}
+      style={{
+        backgroundColor:
+          tone === 'primary' ? colorVar('accent') : colorVar('backInner'),
+        borderColor: colorVar('hairline'),
+        color,
+        opacity: isDisabled ? 0.62 : undefined,
+      }}
+    >
+      {title}
+    </button>
+  )
+}

--- a/packages/app/src/features/auth/pages/ProviderMarks.tsx
+++ b/packages/app/src/features/auth/pages/ProviderMarks.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+/**
+ * The provider marks, drawn to each provider's own brand rules.
+ *
+ * Canon uses `SignInWithAppleButton` (Apple's own control, `.white` style) and
+ * an `Image(systemName: "network")` for Google. Neither is available in a
+ * browser: Apple ships no web control, and SF Symbols is not a web font. So the
+ * marks are drawn here as inline SVG, which is also what both providers'
+ * branding guidelines require on the web:
+ *
+ * - **Apple** — *Sign in with Apple* button: the Apple logo followed by the
+ *   exact string "Sign in with Apple", the logo at the type's cap height, on a
+ *   solid white or black field with the corner radius Apple specifies. The
+ *   white variant is canon's (`.signInWithAppleButtonStyle(.white)`).
+ * - **Google** — *Sign in with Google* button: the four-colour "G" on a white
+ *   field, never recoloured, never on a coloured field, with the wordmark
+ *   "Sign in with Google". The G's four path fills are the brand's own values
+ *   and are the one place in this repo a literal hex is correct: they are the
+ *   mark, not a theme.
+ *
+ * Both marks are `aria-hidden` — the button's own text is the accessible name,
+ * so a screen reader hears "Sign in with Apple" once rather than twice.
+ */
+
+/** Apple's logo, drawn from Apple's own single-path outline. */
+export function AppleMark({ size = 18 }: { readonly size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      data-testid="apple-mark"
+    >
+      <path d="M16.365 1.43c0 1.14-.42 2.2-1.26 3.02-.99.99-2.08 1.56-3.26 1.47-.02-.13-.03-.27-.03-.41 0-1.09.47-2.25 1.29-3.05.44-.44.98-.8 1.63-1.09.64-.28 1.25-.43 1.82-.45.01.17.02.34.02.51ZM20.5 17.1c-.33.77-.73 1.48-1.19 2.13-.63.89-1.15 1.5-1.55 1.84-.62.56-1.29.85-2 .87-.51 0-1.13-.15-1.85-.44-.72-.29-1.38-.44-1.99-.44-.63 0-1.31.15-2.04.44-.73.3-1.32.45-1.77.47-.68.03-1.36-.27-2.05-.9-.43-.37-.98-1-1.63-1.9-.7-.96-1.28-2.08-1.73-3.35C2.22 14.44 2 13.11 2 11.83c0-1.47.32-2.74.96-3.8.5-.85 1.17-1.53 2-2.02.83-.5 1.74-.75 2.71-.77.54 0 1.25.17 2.13.5.88.33 1.44.5 1.69.5.19 0 .82-.2 1.87-.59.99-.36 1.83-.51 2.52-.45 1.86.15 3.26.88 4.19 2.2-1.67 1.01-2.49 2.42-2.48 4.23.02 1.41.53 2.59 1.53 3.52.45.43.96.76 1.53.99-.12.36-.25.7-.39 1.03l-.01-.07Z" />
+    </svg>
+  )
+}
+
+/** Google's four-colour G. The four fills are the mark and are never themed. */
+export function GoogleMark({ size = 18 }: { readonly size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 48 48"
+      aria-hidden="true"
+      focusable="false"
+      data-testid="google-mark"
+    >
+      <path
+        fill="#4285F4"
+        d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17Z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46Z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M11.69 28.18c-.44-1.32-.69-2.73-.69-4.18s.25-2.86.69-4.18v-5.7H4.34A21.99 21.99 0 0 0 2 24c0 3.55.85 6.91 2.34 9.88l7.35-5.7Z"
+      />
+      <path
+        fill="#EA4335"
+        d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07Z"
+      />
+    </svg>
+  )
+}

--- a/packages/app/src/features/auth/pages/__tests__/AuthSurfaceFragment.test.tsx
+++ b/packages/app/src/features/auth/pages/__tests__/AuthSurfaceFragment.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * The auth surface's render tests, mirroring `AuthSurfaceFragment.stories.tsx`
+ * (`RC-11`).
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AuthFlow, AuthMode } from '../../AuthState'
+import { AuthSurfaceFragment } from '../AuthSurfaceFragment'
+
+afterEach(cleanup)
+
+const renderSurface = (
+  overrides: Partial<Parameters<typeof AuthSurfaceFragment>[0]> = {},
+) =>
+  render(
+    <AuthSurfaceFragment
+      mode={AuthMode.signIn}
+      email=""
+      password=""
+      name=""
+      errorCopy={null}
+      authenticatingFlow={null}
+      isSubmitEnabled={false}
+      isUnavailable={false}
+      onChangeEmail={() => {}}
+      onChangePassword={() => {}}
+      onChangeName={() => {}}
+      onSubmit={() => {}}
+      onToggleMode={() => {}}
+      onTapApple={() => {}}
+      onTapGoogle={() => {}}
+      onTapCancel={() => {}}
+      {...overrides}
+    />,
+  )
+
+describe('the sign-in ⇄ create toggle', () => {
+  it('shows canon sign-in copy and no name field', () => {
+    renderSurface()
+
+    expect(screen.getByText('Welcome back')).toBeTruthy()
+    expect(screen.getByTestId('auth-submit').textContent).toBe('Sign In')
+    expect(screen.queryByLabelText('Full name')).toBeNull()
+  })
+
+  it('adds the name field and changes the copy in create mode', () => {
+    renderSurface({ mode: AuthMode.signUp })
+
+    expect(screen.getByText('Create your account')).toBeTruthy()
+    expect(screen.getByLabelText('Full name')).toBeTruthy()
+    expect(screen.getByTestId('auth-submit').textContent).toBe('Create Account')
+  })
+
+  it('reports the toggle rather than switching modes itself', async () => {
+    const onToggleMode = vi.fn()
+    renderSurface({ onToggleMode })
+
+    await userEvent.click(screen.getByTestId('auth-toggle-mode'))
+
+    expect(onToggleMode).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('the email and password form', () => {
+  it('reports each keystroke to its owner rather than holding it', async () => {
+    const onChangeEmail = vi.fn()
+    renderSurface({ onChangeEmail })
+
+    await userEvent.type(screen.getByLabelText('Email address'), 'a')
+
+    expect(onChangeEmail).toHaveBeenCalledWith('a')
+  })
+
+  it('masks the password field', () => {
+    renderSurface()
+
+    expect((screen.getByLabelText('Password') as HTMLInputElement).type).toBe(
+      'password',
+    )
+  })
+
+  it('disables submit on an empty form and names what blocks it', () => {
+    renderSurface()
+
+    expect((screen.getByTestId('auth-submit') as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+    expect(screen.getByTestId('auth-submit-hint').textContent).toContain(
+      'Enter your email and password',
+    )
+  })
+
+  it("names canon six-character minimum when the blocked form is a sign-up", () => {
+    renderSurface({ mode: AuthMode.signUp })
+
+    expect(screen.getByTestId('auth-submit-hint').textContent).toContain(
+      'at least 6 characters',
+    )
+  })
+
+  it('submits once the form is ready', async () => {
+    const onSubmit = vi.fn()
+    renderSurface({
+      email: 'ada@example.com',
+      password: 'correct-horse',
+      isSubmitEnabled: true,
+      onSubmit,
+    })
+
+    await userEvent.click(screen.getByTestId('auth-submit'))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('auth-submit-hint')).toBeNull()
+  })
+
+  it('shows the error banner as an alert, derived copy only', () => {
+    renderSurface({ errorCopy: 'Incorrect email or password.' })
+
+    expect(screen.getByRole('alert').textContent).toBe(
+      'Incorrect email or password.',
+    )
+  })
+})
+
+describe('the provider buttons carry each provider own branding', () => {
+  it('offers Sign in with Apple with the Apple mark', () => {
+    renderSurface()
+
+    const button = screen.getByTestId('auth-apple')
+    expect(button.textContent).toContain('Sign in with Apple')
+    expect(screen.getByTestId('apple-mark')).toBeTruthy()
+  })
+
+  it('offers Sign in with Google with the four-colour G', () => {
+    renderSurface()
+
+    const button = screen.getByTestId('auth-google')
+    expect(button.textContent).toContain('Sign in with Google')
+    expect(screen.getByTestId('google-mark')).toBeTruthy()
+  })
+
+  it('reports each provider tap to its own handler', async () => {
+    const onTapApple = vi.fn()
+    const onTapGoogle = vi.fn()
+    renderSurface({ onTapApple, onTapGoogle })
+
+    await userEvent.click(screen.getByTestId('auth-apple'))
+    await userEvent.click(screen.getByTestId('auth-google'))
+
+    expect(onTapApple).toHaveBeenCalledTimes(1)
+    expect(onTapGoogle).toHaveBeenCalledTimes(1)
+  })
+
+  it('spins the provider that is running and locks the other', () => {
+    renderSurface({ authenticatingFlow: AuthFlow.google })
+
+    expect(screen.getByTestId('auth-google').textContent).toContain('Signing in…')
+    expect((screen.getByTestId('auth-apple') as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+  })
+})
+
+describe('the honest unavailable state', () => {
+  it("says the build has no cloud and that local use still works", () => {
+    renderSurface({ isUnavailable: true })
+
+    expect(screen.getByTestId('auth-unavailable').textContent).toContain(
+      'Kro Cloud is not set up for this build',
+    )
+    expect(screen.getByTestId('auth-unavailable').textContent).toContain(
+      'keep using Kro on this device',
+    )
+  })
+
+  it('disables every route in rather than letting one fail opaquely', () => {
+    renderSurface({ isUnavailable: true, isSubmitEnabled: true })
+
+    expect((screen.getByTestId('auth-submit') as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+    expect((screen.getByTestId('auth-apple') as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+    expect((screen.getByTestId('auth-google') as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+    expect(
+      (screen.getByLabelText('Email address') as HTMLInputElement).disabled,
+    ).toBe(true)
+  })
+
+  it('does not also shout the same thing in red — the calm banner is enough', () => {
+    renderSurface({
+      isUnavailable: true,
+      errorCopy: 'Kro Cloud is not set up for this build.',
+    })
+
+    expect(screen.getByTestId('auth-unavailable')).toBeTruthy()
+    expect(screen.queryByTestId('auth-error')).toBeNull()
+  })
+
+  it('still offers Cancel, so the surface is never a trap', async () => {
+    const onTapCancel = vi.fn()
+    renderSurface({ isUnavailable: true, onTapCancel })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onTapCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/src/features/auth/pages/__tests__/AuthSurfacePage.test.tsx
+++ b/packages/app/src/features/auth/pages/__tests__/AuthSurfacePage.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * The auth surface's container, against a real store built with
+ * `makeStore(stubbedThunkExtra)` (`RC-22`, `RC-35`).
+ */
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { StoreProvider } from '../../../../library/StoreProvider'
+import {
+  type ThunkExtra,
+  makeStore,
+  stubbedThunkExtra,
+} from '../../../../library/store'
+import { makeStubbedAuthService } from '../../../../services/auth/AuthService'
+import { authUserMocks } from '../../AuthMocks'
+import { AuthExceptions } from '../../AuthException'
+import { AuthSurfacePage, currentOrigin } from '../AuthSurfacePage'
+
+afterEach(cleanup)
+
+const renderPage = (
+  extra: ThunkExtra = stubbedThunkExtra,
+  onDismiss: () => void = () => {},
+) => {
+  const store = makeStore(extra)
+  const view = render(
+    <StoreProvider store={store}>
+      <AuthSurfacePage redirectTo="https://kro.test" onDismiss={onDismiss} />
+    </StoreProvider>,
+  )
+  return { store, view }
+}
+
+describe('the form is the slice, not local state', () => {
+  it('records each field in the store rather than in the component', async () => {
+    const { store } = renderPage()
+
+    await userEvent.type(screen.getByLabelText('Email address'), 'ada@example.com')
+
+    expect(store.getState().auth.form.email).toBe('ada@example.com')
+  })
+
+  it('keeps the typed email when the mode toggles — canon form survives it', async () => {
+    const { store } = renderPage()
+
+    await userEvent.type(screen.getByLabelText('Email address'), 'ada@example.com')
+    await userEvent.click(screen.getByTestId('auth-toggle-mode'))
+
+    expect(store.getState().auth.mode).toBe('signUp')
+    expect(store.getState().auth.form.email).toBe('ada@example.com')
+  })
+
+  it('enables submit only once the current mode requirements are met', async () => {
+    renderPage()
+
+    expect((screen.getByTestId('auth-submit') as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+
+    await userEvent.type(screen.getByLabelText('Email address'), 'ada@example.com')
+    await userEvent.type(screen.getByLabelText('Password'), 'secret')
+
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId('auth-submit') as HTMLButtonElement).disabled,
+      ).toBe(false)
+    })
+  })
+})
+
+describe('email and password', () => {
+  it('signs in through the injected service and lands a session', async () => {
+    const { store } = renderPage({
+      ...stubbedThunkExtra,
+      authService: makeStubbedAuthService({}),
+    })
+
+    await userEvent.type(screen.getByLabelText('Email address'), 'ada@example.com')
+    await userEvent.type(screen.getByLabelText('Password'), 'correct-horse')
+    await userEvent.click(screen.getByTestId('auth-submit'))
+
+    await waitFor(() => {
+      expect(store.getState().auth.session.kind).toBe('signedIn')
+    })
+  })
+
+  it('creates an account in sign-up mode rather than signing in', async () => {
+    const invoked: string[] = []
+    const authService = makeStubbedAuthService({})
+    const spy = {
+      ...authService,
+      signUpWithEmail: async (...args: Parameters<typeof authService.signUpWithEmail>) => {
+        invoked.push('signUp')
+        return authService.signUpWithEmail(...args)
+      },
+    }
+    renderPage({ ...stubbedThunkExtra, authService: spy })
+
+    await userEvent.click(screen.getByTestId('auth-toggle-mode'))
+    await userEvent.type(screen.getByLabelText('Full name'), 'Ada Lovelace')
+    await userEvent.type(screen.getByLabelText('Email address'), 'ada@example.com')
+    await userEvent.type(screen.getByLabelText('Password'), 'correct-horse')
+    await userEvent.click(screen.getByTestId('auth-submit'))
+
+    await waitFor(() => {
+      expect(invoked).toEqual(['signUp'])
+    })
+  })
+
+  it('shows derived copy for a rejected credential, never the raw message', async () => {
+    const { store } = renderPage({
+      ...stubbedThunkExtra,
+      authService: makeStubbedAuthService({
+        failures: { signInWithEmail: AuthExceptions.invalidCredentials() },
+      }),
+    })
+
+    await userEvent.type(screen.getByLabelText('Email address'), 'ada@example.com')
+    await userEvent.type(screen.getByLabelText('Password'), 'wrong')
+    await userEvent.click(screen.getByTestId('auth-submit'))
+
+    await waitFor(() => {
+      expect(store.getState().auth.session.kind).toBe('failed')
+    })
+    expect(screen.getByRole('alert').textContent).toBe(
+      'Incorrect email or password.',
+    )
+  })
+})
+
+describe('the provider buttons', () => {
+  it('starts the Google redirect through the injected service', async () => {
+    const urls: string[] = []
+    const authService = makeStubbedAuthService({})
+    renderPage({
+      ...stubbedThunkExtra,
+      authService: {
+        ...authService,
+        startOAuthRedirect: async (input) => {
+          urls.push(`${input.provider}:${input.redirectTo}`)
+          return authService.startOAuthRedirect(input)
+        },
+      },
+    })
+
+    await userEvent.click(screen.getByTestId('auth-google'))
+
+    await waitFor(() => {
+      expect(urls).toEqual(['google:https://kro.test'])
+    })
+  })
+
+  it('takes Apple through the same redirect — the web has no native control', async () => {
+    const providers: string[] = []
+    const authService = makeStubbedAuthService({})
+    renderPage({
+      ...stubbedThunkExtra,
+      authService: {
+        ...authService,
+        startOAuthRedirect: async (input) => {
+          providers.push(input.provider)
+          return authService.startOAuthRedirect(input)
+        },
+      },
+    })
+
+    await userEvent.click(screen.getByTestId('auth-apple'))
+
+    await waitFor(() => {
+      expect(providers).toEqual(['apple'])
+    })
+  })
+
+  it('mints no Apple nonce, so no stale nonce can wait in state to be replayed', async () => {
+    const { store } = renderPage({
+      ...stubbedThunkExtra,
+      authService: makeStubbedAuthService({}),
+    })
+
+    await userEvent.click(screen.getByTestId('auth-apple'))
+
+    await waitFor(() => {
+      expect(store.getState().auth.session.kind).not.toBe('unknown')
+    })
+    expect(store.getState().auth.appleRawNonce).toBeNull()
+  })
+})
+
+describe('the unavailable deployment', () => {
+  it('renders the honest state when no Supabase project is configured', async () => {
+    const { store } = renderPage({
+      ...stubbedThunkExtra,
+      authService: makeStubbedAuthService({
+        failures: {
+          restoreSession: AuthExceptions.unavailable([
+            'NEXT_PUBLIC_SUPABASE_URL',
+          ]),
+        },
+      }),
+    })
+
+    // The launch restore is what discovers it; the surface only renders it.
+    const { restoreSessionThunk } = await import('../../AuthProducer')
+    await store.dispatch(restoreSessionThunk({ now: new Date() }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-unavailable')).toBeTruthy()
+    })
+    expect((screen.getByTestId('auth-google') as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+  })
+
+  it('is not shown for an ordinary credential failure', async () => {
+    renderPage({
+      ...stubbedThunkExtra,
+      authService: makeStubbedAuthService({
+        failures: { signInWithEmail: AuthExceptions.invalidCredentials() },
+      }),
+    })
+
+    await userEvent.type(screen.getByLabelText('Email address'), 'ada@example.com')
+    await userEvent.type(screen.getByLabelText('Password'), 'wrong')
+    await userEvent.click(screen.getByTestId('auth-submit'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('auth-unavailable')).toBeNull()
+  })
+})
+
+describe('dismissal and the redirect target', () => {
+  it('reports Cancel to its presenter rather than closing itself', async () => {
+    const onDismiss = vi.fn()
+    renderPage(stubbedThunkExtra, onDismiss)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to this document origin when no target is supplied', () => {
+    expect(currentOrigin()).toBe(globalThis.location.origin)
+  })
+
+  it('renders for a signed-in user too — the presenter decides when to show it', () => {
+    const { store } = renderPage({
+      ...stubbedThunkExtra,
+      authService: makeStubbedAuthService({ initialUser: authUserMocks.typical }),
+    })
+
+    expect(store.getState().auth.session.kind).toBe('unknown')
+    expect(screen.getByTestId('auth-surface')).toBeTruthy()
+  })
+})

--- a/packages/app/src/features/auth/pages/__tests__/LocalDataDialogFragment.test.tsx
+++ b/packages/app/src/features/auth/pages/__tests__/LocalDataDialogFragment.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * The existing-local-data dialog's render tests, mirroring
+ * `LocalDataDialogFragment.stories.tsx` (`RC-11`).
+ *
+ * The middle block is the issue's three-way test: each of canon's three
+ * buttons reports its own choice, and none reports another's.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LocalDataChoice, localDataChoices } from '../../LocalDataDialog'
+import { LocalDataDialogFragment } from '../LocalDataDialogFragment'
+
+afterEach(cleanup)
+
+const renderDialog = (
+  overrides: Partial<Parameters<typeof LocalDataDialogFragment>[0]> = {},
+) =>
+  render(
+    <LocalDataDialogFragment
+      isPresented
+      anonymousCount={3}
+      isResolving={false}
+      onChoose={() => {}}
+      onDismiss={() => {}}
+      {...overrides}
+    />,
+  )
+
+describe('the prompt', () => {
+  it("shows canon title and interpolates the row count", () => {
+    renderDialog()
+
+    expect(screen.getByText('You Have Local Data')).toBeTruthy()
+    expect(screen.getByText(/You have 3 local endeavors/)).toBeTruthy()
+  })
+
+  it('says "endeavor" in the singular for a single row', () => {
+    renderDialog({ anonymousCount: 1 })
+
+    expect(screen.getByText(/You have 1 local endeavor\./)).toBeTruthy()
+  })
+
+  it('renders nothing at all when it is not presented', () => {
+    renderDialog({ isPresented: false })
+
+    expect(screen.queryByTestId('local-data-dialog')).toBeNull()
+  })
+})
+
+describe('the three choices', () => {
+  it('offers exactly the three canon arms declares, in canon order', () => {
+    renderDialog()
+
+    expect(localDataChoices).toEqual(['signAll', 'clearAll', 'cancel'])
+    expect(screen.getByTestId('local-data-sign-all').textContent).toBe(
+      'Sign All Endeavors to My Account',
+    )
+    expect(screen.getByTestId('local-data-clear-all').textContent).toBe(
+      'Clear Everything and Start Over',
+    )
+    expect(screen.getByTestId('local-data-cancel').textContent).toBe('Cancel')
+  })
+
+  it('reports signAll and nothing else when the first button is pressed', async () => {
+    const onChoose = vi.fn()
+    renderDialog({ onChoose })
+
+    await userEvent.click(screen.getByTestId('local-data-sign-all'))
+
+    expect(onChoose.mock.calls).toEqual([[LocalDataChoice.signAll]])
+  })
+
+  it('reports clearAll and nothing else when the destructive button is pressed', async () => {
+    const onChoose = vi.fn()
+    renderDialog({ onChoose })
+
+    await userEvent.click(screen.getByTestId('local-data-clear-all'))
+
+    expect(onChoose.mock.calls).toEqual([[LocalDataChoice.clearAll]])
+  })
+
+  it('reports cancel and nothing else when Cancel is pressed', async () => {
+    const onChoose = vi.fn()
+    renderDialog({ onChoose })
+
+    await userEvent.click(screen.getByTestId('local-data-cancel'))
+
+    expect(onChoose.mock.calls).toEqual([[LocalDataChoice.cancel]])
+  })
+})
+
+describe('while a choice is being applied', () => {
+  it('locks all three buttons, so a second press cannot double-apply', () => {
+    renderDialog({ isResolving: true })
+
+    for (const id of [
+      'local-data-sign-all',
+      'local-data-clear-all',
+      'local-data-cancel',
+    ]) {
+      expect((screen.getByTestId(id) as HTMLButtonElement).disabled).toBe(true)
+    }
+  })
+
+  it('keeps the prompt on screen rather than closing optimistically', () => {
+    renderDialog({ isResolving: true })
+
+    expect(screen.getByTestId('local-data-dialog')).toBeTruthy()
+  })
+
+  it('re-enables them when the attempt ends', () => {
+    renderDialog({ isResolving: false })
+
+    expect(
+      (screen.getByTestId('local-data-sign-all') as HTMLButtonElement).disabled,
+    ).toBe(false)
+  })
+})
+
+describe('dismissal', () => {
+  it('offers no close affordance — the three buttons are the only exits', () => {
+    renderDialog()
+
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+  })
+
+  it('routes Escape to the dismissal handler rather than trapping the keyboard', async () => {
+    const onDismiss = vi.fn()
+    renderDialog({ onDismiss })
+
+    await userEvent.keyboard('{Escape}')
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not report a choice when it is dismissed', async () => {
+    const onChoose = vi.fn()
+    renderDialog({ onChoose })
+
+    await userEvent.keyboard('{Escape}')
+
+    expect(onChoose).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/features/auth/pages/__tests__/ProviderMarks.test.tsx
+++ b/packages/app/src/features/auth/pages/__tests__/ProviderMarks.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * The provider marks.
+ *
+ * What matters about a brand mark is that it is drawn as the brand specifies
+ * and that it never becomes the button's accessible name — the wordmark beside
+ * it already is. These pin both, plus Google's requirement that the G keeps its
+ * four colours rather than taking the app's palette.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { AppleMark, GoogleMark } from '../ProviderMarks'
+
+afterEach(cleanup)
+
+describe('the Apple mark', () => {
+  it('draws an SVG rather than a font glyph', () => {
+    render(<AppleMark />)
+    expect(screen.getByTestId('apple-mark').tagName.toLowerCase()).toBe('svg')
+  })
+
+  it('takes the button colour, as Apple monochrome mark requires', () => {
+    render(<AppleMark />)
+    expect(screen.getByTestId('apple-mark').getAttribute('fill')).toBe(
+      'currentColor',
+    )
+  })
+
+  it('is hidden from assistive technology — the wordmark is the name', () => {
+    render(<AppleMark />)
+    expect(screen.getByTestId('apple-mark').getAttribute('aria-hidden')).toBe(
+      'true',
+    )
+  })
+
+  it('honours a requested size', () => {
+    render(<AppleMark size={32} />)
+    expect(screen.getByTestId('apple-mark').getAttribute('width')).toBe('32')
+  })
+})
+
+describe('the Google mark', () => {
+  it('draws the four brand colours, never a themed fill', () => {
+    render(<GoogleMark />)
+
+    const fills = Array.from(
+      screen.getByTestId('google-mark').querySelectorAll('path'),
+    ).map((path) => path.getAttribute('fill'))
+
+    expect(fills).toEqual(['#4285F4', '#34A853', '#FBBC05', '#EA4335'])
+  })
+
+  it('is hidden from assistive technology — the wordmark is the name', () => {
+    render(<GoogleMark />)
+    expect(screen.getByTestId('google-mark').getAttribute('aria-hidden')).toBe(
+      'true',
+    )
+  })
+
+  it('honours a requested size', () => {
+    render(<GoogleMark size={24} />)
+    expect(screen.getByTestId('google-mark').getAttribute('height')).toBe('24')
+  })
+})

--- a/packages/app/src/features/auth/pages/index.ts
+++ b/packages/app/src/features/auth/pages/index.ts
@@ -1,0 +1,21 @@
+/**
+ * The auth feature's render tier (KC-IS-#32) — the surface KC-IS-#31's slice
+ * drives, and the dialog its local-data arm presents.
+ *
+ * A pure re-export barrel. The slice tier is KC-IS-#31's and is exported from
+ * its own modules; nothing here re-exports it.
+ */
+export {
+  type AuthSurfaceFragmentProps,
+  AuthSurfaceFragment,
+} from './AuthSurfaceFragment'
+export {
+  type AuthSurfacePageProps,
+  AuthSurfacePage,
+  currentOrigin,
+} from './AuthSurfacePage'
+export {
+  type LocalDataDialogFragmentProps,
+  LocalDataDialogFragment,
+} from './LocalDataDialogFragment'
+export { AppleMark, GoogleMark } from './ProviderMarks'

--- a/packages/app/src/features/capture/__tests__/CaptureSelectors.test.ts
+++ b/packages/app/src/features/capture/__tests__/CaptureSelectors.test.ts
@@ -49,6 +49,7 @@ import {
   withTriageRequested,
 } from '../CaptureShifters'
 import { initialMainState } from '../../main/MainFeature'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 /** Selectors run against a hand-built root state, never a live store. */
 const rootWith = (slice: CaptureState): RootState => ({
@@ -65,6 +66,7 @@ const rootWith = (slice: CaptureState): RootState => ({
   earn: initialEarnState,
   platform: initialPlatformState,
   session: initialSessionState,
+  settings: initialSettingsState,
   auth: initialAuthState,
   main: initialMainState,
 })

--- a/packages/app/src/features/do/__tests__/DoSelectors.test.ts
+++ b/packages/app/src/features/do/__tests__/DoSelectors.test.ts
@@ -32,6 +32,7 @@ import { initialFindState } from '../../find/FindState'
 import { initialPlanState } from '../../plan/PlanState'
 import { initialTriageState } from '../../triage/TriageFeature'
 import { initialMainState } from '../../main/MainFeature'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 /** Selectors run against a hand-built root state, never a live store. */
 const rootWith = (slice: DoState): RootState => ({
@@ -48,6 +49,7 @@ const rootWith = (slice: DoState): RootState => ({
   earn: initialEarnState,
   platform: initialPlatformState,
   session: initialSessionState,
+  settings: initialSettingsState,
   auth: initialAuthState,
   main: initialMainState,
 })

--- a/packages/app/src/features/earn/__tests__/EarnSelectors.test.ts
+++ b/packages/app/src/features/earn/__tests__/EarnSelectors.test.ts
@@ -43,6 +43,7 @@ import {
   selectTotalEarnedPoints,
 } from '../EarnSelectors'
 import { initialMainState } from '../../main/MainFeature'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 const rootWith = (earn: EarnState): RootState => ({
   greeting: initialGreetingState,
@@ -57,6 +58,7 @@ const rootWith = (earn: EarnState): RootState => ({
   earn,
   platform: initialPlatformState,
   session: initialSessionState,
+  settings: initialSettingsState,
   auth: initialAuthState,
   main: initialMainState,
 })

--- a/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailSelectors.test.ts
+++ b/packages/app/src/features/endeavorDetail/__tests__/EndeavorDetailSelectors.test.ts
@@ -54,6 +54,7 @@ import {
 } from '../EndeavorDetailSelectors'
 import type { EndeavorDetailState } from '../EndeavorDetailState'
 import { initialMainState } from '../../main/MainFeature'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 const rootWith = (endeavorDetail: EndeavorDetailState): RootState => ({
   greeting: initialGreetingState,
@@ -67,6 +68,7 @@ const rootWith = (endeavorDetail: EndeavorDetailState): RootState => ({
   earn: initialEarnState,
   platform: initialPlatformState,
   session: initialSessionState,
+  settings: initialSettingsState,
   auth: initialAuthState,
   main: initialMainState,
 })

--- a/packages/app/src/features/find/__tests__/FindSelectors.test.ts
+++ b/packages/app/src/features/find/__tests__/FindSelectors.test.ts
@@ -56,6 +56,7 @@ import {
   selectTasksVista,
 } from '../FindSelectors'
 import { initialMainState } from '../../main/MainFeature'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 const rootWith = (find: FindState): RootState => ({
   greeting: initialGreetingState,
@@ -70,6 +71,7 @@ const rootWith = (find: FindState): RootState => ({
   earn: initialEarnState,
   platform: initialPlatformState,
   session: initialSessionState,
+  settings: initialSettingsState,
   auth: initialAuthState,
   main: initialMainState,
 })

--- a/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
+++ b/packages/app/src/features/greeting/__tests__/GreetingSelectors.test.ts
@@ -21,6 +21,7 @@ import {
   selectIsGreetingLoading,
 } from '../GreetingSelectors'
 import { initialMainState } from '../../main/MainFeature'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 /**
  * Selectors are exercised against a hand-built root state, never a live store.
@@ -40,6 +41,7 @@ const rootWith = (greeting: GreetingState): RootState => ({
   earn: initialEarnState,
   platform: initialPlatformState,
   session: initialSessionState,
+  settings: initialSettingsState,
   auth: initialAuthState,
   main: initialMainState,
 })

--- a/packages/app/src/features/main/MainShellFragment.tsx
+++ b/packages/app/src/features/main/MainShellFragment.tsx
@@ -48,7 +48,7 @@ import {
   type SidebarFragmentProps,
 } from './SidebarFragment'
 import { TabBarFragment } from './TabBarFragment'
-import { ToolbarOutlet } from './ToolbarSlots'
+import { ToolbarOutlet, useToolbarSlotFilled } from './ToolbarSlots'
 
 export interface MainShellFragmentProps
   extends Omit<SidebarFragmentProps, 'layout' | 'sections' | 'selected'> {
@@ -204,13 +204,7 @@ function ContentToolbar({
         </ToolbarButton>
 
         {layout.showsProfileControl && (
-          <ToolbarButton
-            label="Profile"
-            layout={layout}
-            onClick={onTapProfile}
-          >
-            <User size={ICON_SIZE.medium} aria-hidden="true" />
-          </ToolbarButton>
+          <ProfileControl layout={layout} onTapProfile={onTapProfile} />
         )}
 
         <ToolbarOutlet
@@ -286,9 +280,7 @@ function TabBarToolbar({
         className="flex items-center"
         style={{ gap: `${layout.minimumControlSpacing}px` }}
       >
-        <ToolbarButton label="Profile" layout={layout} onClick={onTapProfile}>
-          <User size={ICON_SIZE.medium} aria-hidden="true" />
-        </ToolbarButton>
+        <ProfileControl layout={layout} onTapProfile={onTapProfile} />
 
         {!isPrimaryTab && (
           <ToolbarButton
@@ -324,6 +316,40 @@ function TabBarToolbar({
         </ToolbarButton>
       </div>
     </GlassSurface>
+  )
+}
+
+/**
+ * The Profile control — the shell's placement, a feature's content.
+ *
+ * The outlet is always rendered, so a feature's `ToolbarSlot placement="profile"`
+ * has somewhere to portal into. The shell's own button renders **only while no
+ * feature has supplied one**, which is what keeps the flag-off path
+ * byte-identical to what shipped: with nothing slotted this is the same
+ * `ToolbarButton` calling the same `onTapProfile`, in the same position.
+ *
+ * The settings child (KC-IS-#32) fills the slot with canon's
+ * `ProfilePopoverView` trigger; the comment in `MainShellPage` that said the
+ * popover "belongs to the settings child" is the contract this implements.
+ */
+function ProfileControl({
+  layout,
+  onTapProfile,
+}: {
+  readonly layout: DoSurfaceLayout
+  readonly onTapProfile: () => void
+}) {
+  const isSlotted = useToolbarSlotFilled('profile')
+
+  return (
+    <>
+      <ToolbarOutlet placement="profile" className="flex items-center" />
+      {isSlotted ? null : (
+        <ToolbarButton label="Profile" layout={layout} onClick={onTapProfile}>
+          <User size={ICON_SIZE.medium} aria-hidden="true" />
+        </ToolbarButton>
+      )}
+    </>
   )
 }
 

--- a/packages/app/src/features/main/MainShellPage.tsx
+++ b/packages/app/src/features/main/MainShellPage.tsx
@@ -47,6 +47,7 @@ import {
   selectTabBarElements,
 } from './MainSelectors'
 import { onCaptureRouteDelivered } from '../capture/CaptureFeature'
+import { ProfileControlPage } from '../settings/pages/ProfileControlPage'
 import { searchDestination } from './NavigationSections'
 import {
   DestinationKind,
@@ -227,6 +228,22 @@ export function MainShellPage({
           onSelectDestination({ kind: DestinationKind.settings })
         }
       >
+        {/*
+          The Profile control's CONTENT, mounted shell-wide (KC-IS-#32).
+
+          It fills the shell's `profile` toolbar slot with canon's
+          `ProfilePopoverView`, and it hosts the two surfaces that must be
+          reachable from anywhere rather than from one destination: the auth
+          sheet, and the existing-local-data dialog — which appears after a
+          sign-in that may have completed via an OAuth redirect landing on any
+          route at all.
+
+          Mounted here rather than inside `/adjust` for exactly that reason, and
+          composed by the shell's Page rather than imported by its Fragment: a
+          Page is the artifact allowed to reach across features (`RC-37`), the
+          same way this one already dispatches into the capture slice above.
+        */}
+        <ProfileControlPage />
         {children}
       </MainShellFragment>
     </ToolbarSlotsProvider>

--- a/packages/app/src/features/main/ToolbarSlots.tsx
+++ b/packages/app/src/features/main/ToolbarSlots.tsx
@@ -28,40 +28,63 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from 'react'
 import { createPortal } from 'react-dom'
 
 /**
- * The placements canon's two toolbars have.
+ * The placements canon's two toolbars have, plus the one shell-owned control
+ * whose CONTENT belongs to a feature.
  *
  * `navigation` and `primary` are the Mac's two `ToolbarItemGroup` placements
  * (`.navigation`, `.primaryAction`); `leading` and `trailing` are the phone's
  * (`.topBarLeading`, `.topBarTrailing`). Both shells expose all four so a
  * feature does not have to branch on the shell to place a control.
+ *
+ * `profile` is different in kind and deliberately so (KC-IS-#32). Canon's
+ * Profile control is the *container's* — this shell owns where it sits and
+ * what it looks like — but what it opens is `ProfilePopoverView`, which is the
+ * settings feature's. So the shell keeps ownership of the placement and hands
+ * the control itself over when, and only when, a feature supplies one. With no
+ * slot filled the shell renders exactly the button it rendered before this
+ * placement existed, which is what makes the change additive.
  */
 export type ToolbarPlacement =
   | 'navigation'
   | 'primary'
   | 'leading'
   | 'trailing'
+  | 'profile'
 
 export const TOOLBAR_PLACEMENTS: readonly ToolbarPlacement[] = [
   'navigation',
   'primary',
   'leading',
   'trailing',
+  'profile',
 ]
 
 type Containers = Partial<Record<ToolbarPlacement, HTMLElement | null>>
+type Fills = Partial<Record<ToolbarPlacement, number>>
 
 interface ToolbarSlotsValue {
   readonly containers: Containers
+  readonly fills: Fills
   readonly attach: (
     placement: ToolbarPlacement,
     element: HTMLElement | null,
   ) => void
+  /**
+   * A slot mounted (`+1`) or unmounted (`-1`) for a placement.
+   *
+   * A count rather than a boolean: two slots for one placement is legal (the
+   * shell renders one outlet and both portal into it), and a boolean would let
+   * the first unmount claim the placement is empty while the second is still
+   * rendering.
+   */
+  readonly fill: (placement: ToolbarPlacement, delta: 1 | -1) => void
 }
 
 const ToolbarSlotsContext = createContext<ToolbarSlotsValue | null>(null)
@@ -76,6 +99,7 @@ export function ToolbarSlotsProvider({
   readonly children: ReactNode
 }) {
   const [containers, setContainers] = useState<Containers>({})
+  const [fills, setFills] = useState<Fills>({})
 
   const attach = useCallback(
     (placement: ToolbarPlacement, element: HTMLElement | null) => {
@@ -88,9 +112,16 @@ export function ToolbarSlotsProvider({
     [],
   )
 
+  const fill = useCallback((placement: ToolbarPlacement, delta: 1 | -1) => {
+    setFills((current) => ({
+      ...current,
+      [placement]: Math.max(0, (current[placement] ?? 0) + delta),
+    }))
+  }, [])
+
   const value = useMemo<ToolbarSlotsValue>(
-    () => ({ containers, attach }),
-    [containers, attach],
+    () => ({ containers, fills, attach, fill }),
+    [containers, fills, attach, fill],
   )
 
   return (
@@ -148,6 +179,15 @@ export function ToolbarSlot({
 }) {
   const value = useContext(ToolbarSlotsContext)
   const container = value?.containers[placement] ?? null
+  const fill = value?.fill
+
+  // Mount/unmount only — the count changes when a slot appears or goes away,
+  // never on a re-render of its content, so this cannot loop.
+  useEffect(() => {
+    if (fill === undefined) return
+    fill(placement, 1)
+    return () => fill(placement, -1)
+  }, [fill, placement])
 
   if (container === null) return null
   return createPortal(children, container)
@@ -162,4 +202,18 @@ export function useToolbarOutletPresent(
 ): boolean {
   const value = useContext(ToolbarSlotsContext)
   return (value?.containers[placement] ?? null) !== null
+}
+
+/**
+ * Whether any feature has slotted content for a placement.
+ *
+ * The shell asks this about `profile` so it can render its own default control
+ * *only* while nobody has supplied one — the mechanism that keeps
+ * KC-IS-#32's popover an addition rather than a rewrite of the toolbar.
+ * Distinct from `useToolbarOutletPresent`, which asks the opposite question
+ * (has the shell provided somewhere to portal *to*).
+ */
+export function useToolbarSlotFilled(placement: ToolbarPlacement): boolean {
+  const value = useContext(ToolbarSlotsContext)
+  return (value?.fills[placement] ?? 0) > 0
 }

--- a/packages/app/src/features/main/__tests__/MainSelectors.test.ts
+++ b/packages/app/src/features/main/__tests__/MainSelectors.test.ts
@@ -33,6 +33,7 @@ import {
   selectTabBarElements,
 } from '../MainSelectors'
 import { DestinationKind } from '../SidebarDestination'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 const rootWith = (main: MainState): RootState => ({
   greeting: initialGreetingState,
@@ -48,6 +49,7 @@ const rootWith = (main: MainState): RootState => ({
   auth: initialAuthState,
   platform: initialPlatformState,
   session: initialSessionState,
+  settings: initialSettingsState,
   main,
 })
 

--- a/packages/app/src/features/main/__tests__/ToolbarSlots.test.tsx
+++ b/packages/app/src/features/main/__tests__/ToolbarSlots.test.tsx
@@ -2,7 +2,7 @@
  * The slot mechanism: a feature's control, rendered deep inside the
  * destination, lands in the shell's toolbar without the shell holding it.
  */
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -12,6 +12,7 @@ import {
   ToolbarSlot,
   ToolbarSlotsProvider,
   useToolbarOutletPresent,
+  useToolbarSlotFilled,
 } from '../ToolbarSlots'
 
 afterEach(cleanup)
@@ -178,6 +179,61 @@ describe('the placement set', () => {
       'primary',
       'leading',
       'trailing',
+      // The fifth is not a toolbar group: it is the shell-owned Profile
+      // *control* whose content a feature supplies (KC-IS-#32). See the union's
+      // own comment for why it lives in the same set.
+      'profile',
     ])
+  })
+})
+
+describe('a slot claims its placement while it is mounted', () => {
+  function FillProbe({ placement }: { readonly placement: 'profile' | 'primary' }) {
+    const filled = useToolbarSlotFilled(placement)
+    return <p>{`filled: ${String(filled)}`}</p>
+  }
+
+  it('reports nothing filled before a feature slots anything', () => {
+    render(
+      <ToolbarSlotsProvider>
+        <ToolbarOutlet placement="profile" />
+        <FillProbe placement="profile" />
+      </ToolbarSlotsProvider>,
+    )
+
+    expect(screen.getByText('filled: false')).toBeTruthy()
+  })
+
+  it('reports the placement filled once a slot mounts for it', async () => {
+    render(
+      <ToolbarSlotsProvider>
+        <ToolbarOutlet placement="profile" />
+        <FillProbe placement="profile" />
+        <ToolbarSlot placement="profile">
+          <button type="button">Profile</button>
+        </ToolbarSlot>
+      </ToolbarSlotsProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('filled: true')).toBeTruthy()
+    })
+  })
+
+  it('answers per placement — a filled profile says nothing about primary', async () => {
+    render(
+      <ToolbarSlotsProvider>
+        <ToolbarOutlet placement="profile" />
+        <ToolbarOutlet placement="primary" />
+        <FillProbe placement="primary" />
+        <ToolbarSlot placement="profile">
+          <button type="button">Profile</button>
+        </ToolbarSlot>
+      </ToolbarSlotsProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('filled: false')).toBeTruthy()
+    })
   })
 })

--- a/packages/app/src/features/plan/__tests__/PlanSelectors.test.ts
+++ b/packages/app/src/features/plan/__tests__/PlanSelectors.test.ts
@@ -58,6 +58,7 @@ import {
 import type { TimelineEditSession } from '../PlanEditSession'
 import type { PlanState } from '../PlanState'
 import { initialMainState } from '../../main/MainFeature'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 const today = startOfPlanDay(PLAN_REFERENCE_DAY)
 const tomorrow = addingPlanDays(today, 1)
@@ -75,6 +76,7 @@ const rootWith = (plan: PlanState): RootState => ({
   earn: initialEarnState,
   platform: initialPlatformState,
   session: initialSessionState,
+  settings: initialSettingsState,
   auth: initialAuthState,
   main: initialMainState,
 })

--- a/packages/app/src/features/platform/__tests__/PlatformSelectors.test.ts
+++ b/packages/app/src/features/platform/__tests__/PlatformSelectors.test.ts
@@ -31,6 +31,7 @@ import {
   selectPlatformException,
   selectShouldOfferNotificationPrompt,
 } from '../PlatformSelectors'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 const rootWith = (platform: PlatformState): RootState => ({
   greeting: initialGreetingState,
@@ -46,6 +47,7 @@ const rootWith = (platform: PlatformState): RootState => ({
   auth: initialAuthState,
   main: initialMainState,
   session: initialSessionState,
+  settings: initialSettingsState,
   platform,
 })
 

--- a/packages/app/src/features/session/__tests__/SessionSelectors.test.ts
+++ b/packages/app/src/features/session/__tests__/SessionSelectors.test.ts
@@ -66,6 +66,7 @@ import {
   withException,
 } from '../SessionShifters'
 import { SessionPhase, SessionPillAffordance, SessionTint } from '../SessionVocabulary'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 /** Selectors run against a hand-built root state, never a live store. */
 const rootWith = (session: SessionState): RootState => ({
@@ -83,6 +84,7 @@ const rootWith = (session: SessionState): RootState => ({
   session,
   auth: initialAuthState,
   main: initialMainState,
+  settings: initialSettingsState,
 })
 
 const running = rootWith(sessionStateMocks.running)

--- a/packages/app/src/features/settings/SettingsElements.ts
+++ b/packages/app/src/features/settings/SettingsElements.ts
@@ -1,0 +1,473 @@
+/**
+ * The preference schema, arranged for rendering — canon's five
+ * `…PreferencesView`s expressed as data over `@kro/core`'s `SettingOption`
+ * table instead of five hand-written forms.
+ *
+ * ## Why this is data and not five components
+ *
+ * KC-IS-#11 ported canon's `SettingOptions.swift` option for option: every
+ * key, value shape, glyph, default and sync scope. Canon's *views* then restate
+ * that list a second time, in Swift, as `@Binding`s — which is why a canon
+ * option can exist with no row (and did: `nowVisibleTypes`). Here the rows are
+ * **derived** from the schema, so an option cannot be declared and then
+ * silently not offered. `__tests__/SettingsElements.test.ts` pins that as an
+ * exact set equality over `allPreferenceOptions`.
+ *
+ * What is *not* derived is the copy: a row's label, its section header, its
+ * footer and an `int` option's bounds are canon's own strings and numbers,
+ * transcribed here per key. Deriving a label from a key would produce
+ * "Now Threshold Hours" where canon says `“Now” window`. So:
+ *
+ * - **which options exist, and in which group** — the schema's, always.
+ * - **how each is rendered** — derived from `option.type` (`RC-24`'s closed
+ *   union), with two documented per-key refinements (stepper bounds; the accent
+ *   swatch row).
+ * - **what each is called** — canon's copy, keyed by the schema's own key.
+ *
+ * An option the copy table does not name still renders, under a fallback label
+ * derived from its key and in a trailing "Other" subgroup. That is deliberate:
+ * a schema addition must show up as an unpolished row, never as a missing one.
+ */
+import {
+  type SettingGroup,
+  type SettingOption,
+  accentColorOption,
+  appearanceModeLabel,
+  accentChoiceLabel,
+  assertNever,
+  dayViewRangeLabel,
+  landingChoiceLabel,
+  planListGroupingLabel,
+  planListSortLabel,
+  pointsFormulaLabel,
+  SettingConsumption,
+  settingOptionsByGroup,
+  SettingSyncScope,
+} from '@kro/core'
+
+// ---------------------------------------------------------------------------
+// Controls
+// ---------------------------------------------------------------------------
+
+/** One option of a picker: the raw value the schema stores, and its copy. */
+export interface SettingChoice {
+  readonly value: string
+  readonly label: string
+}
+
+/**
+ * How one option is edited. Derived from `SettingOption['type']`, which is the
+ * closed union KC-IS-#11 ported, so a new value shape is a compile error here
+ * rather than a row that renders nothing.
+ */
+export type SettingControl =
+  /** `bool` — canon's `Toggle`. */
+  | { readonly kind: 'toggle' }
+  /** `timeOfDay` — canon's `DatePicker(displayedComponents: .hourAndMinute)`. */
+  | { readonly kind: 'time' }
+  /** `daysSet` — canon's seven-chip `WeekDayPicker`. */
+  | { readonly kind: 'days' }
+  /** `int` — canon's `Stepper`, with its `in:`/`step:` range. */
+  | {
+      readonly kind: 'stepper'
+      readonly min: number
+      readonly max: number
+      readonly step: number
+      /** The unit canon interpolates into the stepper's title (`min`, `h`). */
+      readonly unit: string | null
+    }
+  /** `enumeration` — canon's `Picker`. */
+  | { readonly kind: 'choice'; readonly choices: readonly SettingChoice[] }
+  /** `enumeration`, drawn as canon's `AccentColorPicker` swatch row. */
+  | { readonly kind: 'swatches'; readonly choices: readonly SettingChoice[] }
+  /** `string` — canon's timezone `Picker` over the known identifiers. */
+  | { readonly kind: 'timezone' }
+
+// ---------------------------------------------------------------------------
+// Copy, keyed by the schema's own key
+// ---------------------------------------------------------------------------
+
+/** Canon's row label per option key. */
+const OPTION_LABELS: Readonly<Record<string, string>> = {
+  // General — `GeneralPreferencesView`
+  'general.workingHoursStart': 'Start',
+  'general.workingHoursEnd': 'End',
+  'general.workingDays': 'Working days',
+  'general.timezone': 'Time Zone',
+  'general.morningPlanTime': 'Morning plan',
+  'general.streakReminders': 'Streak reminders',
+  'general.overdueAlerts': 'Overdue alerts',
+  'general.appearance': 'Theme',
+  'general.accentColor': 'Accent color',
+  'general.weekStartDay': 'Week starts on',
+  'general.defaultLandingSection': 'Open to',
+  'general.haptics': 'Haptics',
+  // Plan — `PlanPreferencesView`
+  'plan.dayViewRange': 'Visible hours',
+  'plan.showCompletedInTimeline': 'Show completed',
+  'plan.defaultSlotDuration': 'Default slot',
+  'plan.listSort': 'Sort by',
+  'plan.listGrouping': 'Group by',
+  'plan.autoCommitDrafts': 'Auto-commit AI drafts',
+  // Do — `DoPreferencesView`
+  'do.nowThresholdHours': '“Now” window',
+  'do.showSuggestions': 'Show suggestions',
+  'do.autoAdvanceAfterComplete': 'Auto-advance after complete',
+  'do.notifyOnOverdue': 'Notify when overdue',
+  // Earn — `EarnPreferencesView`
+  'earn.pointsFormula': 'Points formula',
+  'earn.defaultRewardThreshold': 'New reward cost',
+  'earn.showWeeklyChallenge': 'Show weekly challenge',
+  'earn.celebrateMilestones': 'Celebrate milestones',
+  'earn.milestoneHaptics': 'Milestone haptics',
+  // Session — `SessionPreferencesView`
+  'session.defaultDuration': 'Session',
+  'session.defaultBreakDuration': 'Break',
+  'session.enableStopwatch': 'Enable stopwatch mode',
+  'session.enableBreaks': 'Enable breaks',
+  'session.autoStartBreak': 'Auto-start break after session',
+  'session.keepScreenAwake': 'Keep screen awake',
+  'session.soundOnEnd': 'Sound on session end',
+}
+
+/**
+ * Canon's `Stepper(… in: … step: …)` bounds per `int` option, plus the unit its
+ * title interpolates.
+ *
+ * An `int` option with no entry falls back to a wide, coarse range rather than
+ * to no control at all — see `settingControlFor`.
+ */
+const STEPPER_BOUNDS: Readonly<
+  Record<string, { min: number; max: number; step: number; unit: string | null }>
+> = {
+  'plan.defaultSlotDuration': { min: 5, max: 120, step: 5, unit: 'min' },
+  'do.nowThresholdHours': { min: 1, max: 12, step: 1, unit: 'h' },
+  'earn.defaultRewardThreshold': { min: 10, max: 1000, step: 10, unit: null },
+  'session.defaultDuration': { min: 5, max: 120, step: 5, unit: 'min' },
+  'session.defaultBreakDuration': { min: 1, max: 30, step: 1, unit: 'min' },
+}
+
+/** The fallback range for an `int` option the table above does not name. */
+export const DEFAULT_STEPPER_BOUNDS = {
+  min: 0,
+  max: 1000,
+  step: 1,
+  unit: null,
+} as const
+
+/**
+ * The copy for one raw case of an `enumeration` option.
+ *
+ * Every branch delegates to the label function `@kro/core` already exports for
+ * that choice type, so the web and canon cannot disagree about what "Sliding
+ * scale" is called. A key with no branch falls back to the raw value, which is
+ * ugly and readable — the two properties a fallback needs.
+ */
+export const settingChoiceLabel = (optionKey: string, raw: string): string => {
+  switch (optionKey) {
+    case 'general.appearance':
+      return appearanceModeLabel(raw as Parameters<typeof appearanceModeLabel>[0])
+    case 'general.accentColor':
+      return accentChoiceLabel(raw as Parameters<typeof accentChoiceLabel>[0])
+    case 'general.defaultLandingSection':
+      return landingChoiceLabel(raw as Parameters<typeof landingChoiceLabel>[0])
+    case 'general.weekStartDay':
+      // Canon: `Text(day.rawValue.capitalized)`.
+      return raw.charAt(0).toUpperCase() + raw.slice(1)
+    case 'plan.dayViewRange':
+      return dayViewRangeLabel(raw as Parameters<typeof dayViewRangeLabel>[0])
+    case 'plan.listSort':
+      return planListSortLabel(raw as Parameters<typeof planListSortLabel>[0])
+    case 'plan.listGrouping':
+      return planListGroupingLabel(
+        raw as Parameters<typeof planListGroupingLabel>[0],
+      )
+    case 'earn.pointsFormula':
+      return pointsFormulaLabel(raw as Parameters<typeof pointsFormulaLabel>[0])
+    default:
+      return raw
+  }
+}
+
+/**
+ * The label a row shows. Canon's copy when the key is known; otherwise the
+ * key's last segment, spaced and sentence-cased, so a newly declared option is
+ * legible before anyone writes copy for it.
+ */
+export const settingLabel = (option: SettingOption): string => {
+  const known = OPTION_LABELS[option.key]
+  if (known !== undefined) return known
+  const tail = option.key.split('.').at(-1) ?? option.key
+  const spaced = tail.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+/**
+ * How an option is edited, derived from its declared value shape.
+ *
+ * Two refinements sit on top of the type dispatch, both of them canon's:
+ * `general.accentColor` is a swatch row rather than a dropdown
+ * (`AccentColorPicker`), and each `int` carries the range canon's `Stepper`
+ * declares.
+ */
+export const settingControlFor = (option: SettingOption): SettingControl => {
+  switch (option.type.kind) {
+    case 'bool':
+      return { kind: 'toggle' }
+    case 'timeOfDay':
+      return { kind: 'time' }
+    case 'daysSet':
+      return { kind: 'days' }
+    case 'string':
+      return { kind: 'timezone' }
+    case 'int': {
+      const bounds = STEPPER_BOUNDS[option.key] ?? DEFAULT_STEPPER_BOUNDS
+      return { kind: 'stepper', ...bounds }
+    }
+    case 'enumeration': {
+      const choices = option.type.cases.map((value) => ({
+        value,
+        label: settingChoiceLabel(option.key, value),
+      }))
+      return option.key === accentColorOption.key
+        ? { kind: 'swatches', choices }
+        : { kind: 'choice', choices }
+    }
+    default:
+      return assertNever(option.type)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Elements and subgroups
+// ---------------------------------------------------------------------------
+
+/** One rendered preference row. */
+export interface SettingElement {
+  readonly option: SettingOption
+  readonly label: string
+  readonly control: SettingControl
+  /**
+   * Canon's *"On this device"* badge — shown for a `local` option, which is
+   * read straight off the schema rather than from a per-row flag.
+   */
+  readonly isDeviceLocal: boolean
+  /**
+   * Whether canon has a surface reading this value today. `false` is canon's
+   * *"declared, not yet consumed"*, which the surface says out loud rather than
+   * pretending the control does something.
+   */
+  readonly isConsumed: boolean
+}
+
+/** One `Section { … } header: … footer: …` of a canon preferences form. */
+export interface SettingSubgroup {
+  readonly id: string
+  /** Canon's `header:`. `null` for a headerless section. */
+  readonly title: string | null
+  /** Canon's `footer:`. `null` when it has none. */
+  readonly footnote: string | null
+  readonly elements: readonly SettingElement[]
+}
+
+/** The subgroup layout of one preferences pane, as canon lays it out. */
+interface SubgroupSpec {
+  readonly id: string
+  readonly title: string | null
+  readonly footnote: string | null
+  readonly keys: readonly string[]
+}
+
+const SUBGROUPS: Readonly<Record<SettingGroup, readonly SubgroupSpec[]>> = {
+  general: [
+    {
+      id: 'workingHours',
+      title: 'Working Hours',
+      // Canon's footer is the end-≤-start warning, which is conditional and
+      // therefore rendered by the surface, not carried here.
+      footnote: null,
+      keys: [
+        'general.workingHoursStart',
+        'general.workingHoursEnd',
+        'general.workingDays',
+      ],
+    },
+    {
+      id: 'timezone',
+      title: 'Time Zone',
+      footnote: null,
+      keys: ['general.timezone'],
+    },
+    {
+      id: 'notifications',
+      title: 'Notifications',
+      footnote: null,
+      keys: [
+        'general.morningPlanTime',
+        'general.streakReminders',
+        'general.overdueAlerts',
+      ],
+    },
+    {
+      id: 'appearance',
+      title: 'Appearance',
+      footnote:
+        'Theme is saved on this device only. Accent color syncs with your account.',
+      keys: ['general.appearance', 'general.accentColor'],
+    },
+    {
+      id: 'general',
+      title: 'General',
+      footnote: null,
+      keys: [
+        'general.weekStartDay',
+        'general.defaultLandingSection',
+        'general.haptics',
+      ],
+    },
+  ],
+  plan: [
+    {
+      id: 'timeline',
+      title: 'Timeline',
+      footnote: null,
+      keys: [
+        'plan.dayViewRange',
+        'plan.showCompletedInTimeline',
+        'plan.defaultSlotDuration',
+      ],
+    },
+    {
+      id: 'lists',
+      title: 'Lists',
+      footnote: null,
+      keys: ['plan.listSort', 'plan.listGrouping'],
+    },
+    {
+      id: 'drafts',
+      title: 'Drafts',
+      footnote: null,
+      keys: ['plan.autoCommitDrafts'],
+    },
+  ],
+  do: [
+    { id: 'now', title: 'Now', footnote: null, keys: ['do.nowThresholdHours'] },
+    {
+      id: 'cards',
+      title: 'Cards',
+      footnote: null,
+      keys: ['do.showSuggestions', 'do.autoAdvanceAfterComplete'],
+    },
+    {
+      id: 'notifications',
+      title: 'Notifications',
+      footnote: null,
+      keys: ['do.notifyOnOverdue'],
+    },
+  ],
+  earn: [
+    {
+      id: 'scoring',
+      title: 'Scoring',
+      footnote:
+        'The formula decides how points are awarded when you finish a session.',
+      keys: ['earn.pointsFormula', 'earn.defaultRewardThreshold'],
+    },
+    {
+      id: 'goals',
+      title: 'Goals',
+      footnote: null,
+      keys: ['earn.showWeeklyChallenge'],
+    },
+    {
+      id: 'feedback',
+      title: 'Feedback',
+      footnote: 'Milestone haptics are saved on this device only.',
+      keys: ['earn.celebrateMilestones', 'earn.milestoneHaptics'],
+    },
+  ],
+  session: [
+    {
+      id: 'durations',
+      title: 'Durations',
+      footnote: null,
+      keys: ['session.defaultDuration', 'session.defaultBreakDuration'],
+    },
+    {
+      id: 'modes',
+      title: 'Modes',
+      footnote:
+        'Stopwatch and breaks also depend on their feature flags being enabled.',
+      keys: [
+        'session.enableStopwatch',
+        'session.enableBreaks',
+        'session.autoStartBreak',
+      ],
+    },
+    {
+      id: 'duringAndAfter',
+      title: 'During & after',
+      footnote: 'Keep-awake and end sound are saved on this device only.',
+      keys: ['session.keepScreenAwake', 'session.soundOnEnd'],
+    },
+  ],
+}
+
+/** The subgroup id an unspecified option lands in. */
+export const OTHER_SUBGROUP_ID = 'other'
+
+const elementFor = (option: SettingOption): SettingElement => ({
+  option,
+  label: settingLabel(option),
+  control: settingControlFor(option),
+  isDeviceLocal: option.syncScope === SettingSyncScope.local,
+  isConsumed: option.consumption === SettingConsumption.live,
+})
+
+/**
+ * One preferences pane's subgroups, in canon's display order.
+ *
+ * The group's schema list is the authority for *membership*: every option the
+ * schema declares for the group appears exactly once, and any option no
+ * subgroup names is appended in a trailing "Other" subgroup rather than
+ * dropped. An empty subgroup is omitted — canon omits a `Section` with no rows
+ * for the same reason (it would still draw a header and footer over nothing).
+ */
+export const settingSubgroupsFor = (
+  group: SettingGroup,
+): readonly SettingSubgroup[] => {
+  const options = settingOptionsByGroup[group]
+  const byKey = new Map(options.map((option) => [option.key, option]))
+  const placed = new Set<string>()
+
+  const named = SUBGROUPS[group]
+    .map((spec) => {
+      const elements = spec.keys.flatMap((key) => {
+        const option = byKey.get(key)
+        if (option === undefined) return []
+        placed.add(key)
+        return [elementFor(option)]
+      })
+      return { id: spec.id, title: spec.title, footnote: spec.footnote, elements }
+    })
+    .filter((subgroup) => subgroup.elements.length > 0)
+
+  const leftovers = options.filter((option) => !placed.has(option.key))
+  if (leftovers.length === 0) return named
+
+  return [
+    ...named,
+    {
+      id: OTHER_SUBGROUP_ID,
+      title: 'Other',
+      footnote: null,
+      elements: leftovers.map(elementFor),
+    },
+  ]
+}
+
+/** Every element of a pane, flattened — what a completeness check counts. */
+export const settingElementsFor = (
+  group: SettingGroup,
+): readonly SettingElement[] =>
+  settingSubgroupsFor(group).flatMap((subgroup) => subgroup.elements)

--- a/packages/app/src/features/settings/SettingsException.ts
+++ b/packages/app/src/features/settings/SettingsException.ts
@@ -1,0 +1,39 @@
+/**
+ * The settings surface's typed failures (`RC-8`, `UZF-8`).
+ *
+ * Two of the four are canon's `IntegrationsException` cases, narrowed: canon's
+ * `notConfigured` becomes `integrationUnconfigured` (it is the deployment's
+ * Google client that is missing, not the user's grant) and
+ * `connectionFailed`/`networkUnavailable` collapse into
+ * `integrationUnavailable`, because on the web both arrive as the same failed
+ * same-origin call and the recovery is identical. The other two are this
+ * surface's own: reading and writing the on-device preference store.
+ *
+ * No case carries a provider message through to the user — `message` is
+ * developer detail for logs, and every user-facing string is derived from
+ * `kind` by `SettingsSelectors` (`RC-8`).
+ */
+import { type Exception, exception } from '@kro/core'
+
+export type SettingsException =
+  /** The preference store could not be read at all. */
+  | Exception<'preferencesUnavailable'>
+  /** A write was refused — the value did not fit the option's declared shape. */
+  | Exception<'preferenceRejected'>
+  /** This deployment has no Google client, so connecting cannot work. */
+  | Exception<'integrationUnconfigured'>
+  /** The connect or disconnect call did not complete. */
+  | Exception<'integrationUnavailable'>
+
+export const SettingsExceptions = {
+  preferencesUnavailable: (message = ''): SettingsException =>
+    exception('preferencesUnavailable', message, true),
+  preferenceRejected: (message = ''): SettingsException =>
+    exception('preferenceRejected', message, true),
+  // Not recoverable by the user: no amount of retrying supplies a Google client
+  // to a deployment that has none. A human G5 step (Google Cloud + env) does.
+  integrationUnconfigured: (message = ''): SettingsException =>
+    exception('integrationUnconfigured', message, false),
+  integrationUnavailable: (message = ''): SettingsException =>
+    exception('integrationUnavailable', message, true),
+}

--- a/packages/app/src/features/settings/SettingsFeature.ts
+++ b/packages/app/src/features/settings/SettingsFeature.ts
@@ -1,0 +1,216 @@
+/**
+ * The settings slice (`RC-1`, `RC-2`, `RC-24`, `RC-36`) — canon's
+ * `SettingsFeature` and `IntegrationsFeature`, merged.
+ *
+ * `reducers` carries synchronous, locally-originated events only: opening a
+ * pane, going back, presenting and dismissing the auth surface.
+ * `extraReducers` carries thunk lifecycles and nothing else (`RC-36`), and
+ * every multi-field change goes through a named Shifter applied with
+ * `Object.assign` (`RC-4`).
+ *
+ * ## The `.rejected` arms are defensive
+ *
+ * Every Producer here catches and resolves `err(...)`, so `.rejected` is
+ * structurally unreachable (`RC-26`). Each is still wired, into the same
+ * exception Shifter the `.fulfilled` false branch uses, so an unexpected throw
+ * degrades to a typed failure rather than to a spinner that never stops.
+ */
+import { type PayloadAction, createSlice } from '@reduxjs/toolkit'
+import { SettingsExceptions } from './SettingsException'
+import {
+  connectGoogleThunk,
+  disconnectGoogleThunk,
+  loadGoogleConnectionThunk,
+  loadSettingsThunk,
+  updateSettingThunk,
+} from './SettingsProducer'
+import type { SettingsSectionId } from './SettingsSection'
+import {
+  withAuthDismissed,
+  withAuthPresented,
+  withGoogleBusy,
+  withGoogleConnection,
+  withGoogleEnabled,
+  withGoogleFailed,
+  withPaneClosed,
+  withPaneOpened,
+  withPreferencesFailed,
+  withPreferencesLoaded,
+  withPreferencesLoading,
+  withSettingValue,
+} from './SettingsShifters'
+import { initialSettingsState } from './SettingsState'
+
+export const settingsSlice = createSlice({
+  name: 'settings',
+  initialState: initialSettingsState,
+  reducers: {
+    /** Canon's `userDidTapSection` — push the pane. */
+    userDidTapSection(state, action: PayloadAction<SettingsSectionId>) {
+      Object.assign(state, withPaneOpened(state, action.payload))
+    },
+
+    /** The pane's back affordance — canon's `NavigationStack` pop. */
+    userDidTapBackToHub(state) {
+      Object.assign(state, withPaneClosed(state))
+    },
+
+    /**
+     * Either sign-in entry point. The origin travels so dismissing returns the
+     * user to what they were doing.
+     */
+    userDidTapSignIn(
+      state,
+      action: PayloadAction<{ origin: 'profilePopover' | 'settingsHub' }>,
+    ) {
+      Object.assign(state, withAuthPresented(state, action.payload.origin))
+    },
+
+    /** Canon's `AuthView` Cancel, and the sheet's own dismissal. */
+    userDidDismissAuth(state) {
+      Object.assign(state, withAuthDismissed(state))
+    },
+
+    /**
+     * The auth feature says a session now exists.
+     *
+     * Dispatched by the Page that owns both surfaces (`RC-37`) rather than
+     * matched off `auth`'s thunk here — a slice that reacted to another
+     * feature's lifecycle would be reaching into it (`RC-20`).
+     */
+    childAuthDelegatedSignedIn(state) {
+      Object.assign(state, withAuthDismissed(state))
+    },
+  },
+
+  extraReducers: (builder) => {
+    builder
+      // --- the preference snapshot -----------------------------------------
+      .addCase(loadSettingsThunk.pending, (state) => {
+        Object.assign(state, withPreferencesLoading(state))
+      })
+      .addCase(loadSettingsThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (!result.ok) {
+          Object.assign(state, withPreferencesFailed(state, result.error))
+          return
+        }
+        Object.assign(state, withPreferencesLoaded(state, result.value.values))
+        Object.assign(state, withGoogleEnabled(state, result.value.isGoogleEnabled))
+      })
+      .addCase(loadSettingsThunk.rejected, (state, action) => {
+        Object.assign(
+          state,
+          withPreferencesFailed(
+            state,
+            SettingsExceptions.preferencesUnavailable(action.error.message ?? ''),
+          ),
+        )
+      })
+
+      // --- one preference write ---------------------------------------------
+      .addCase(updateSettingThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (!result.ok) {
+          // The previous value stays on screen: showing a value the store
+          // refused would be the one outcome worse than the refusal.
+          Object.assign(state, withPreferencesFailed(state, result.error))
+          return
+        }
+        Object.assign(
+          state,
+          withSettingValue(state, result.value.key, result.value.value),
+        )
+        // A successful write clears a previous failure banner — the surface is
+        // working again, and a stale banner would say otherwise.
+        if (state.load.kind === 'failed') {
+          Object.assign(state, withPreferencesLoaded(state, state.values))
+        }
+      })
+      .addCase(updateSettingThunk.rejected, (state, action) => {
+        Object.assign(
+          state,
+          withPreferencesFailed(
+            state,
+            SettingsExceptions.preferenceRejected(action.error.message ?? ''),
+          ),
+        )
+      })
+
+      // --- the Google connection --------------------------------------------
+      .addCase(loadGoogleConnectionThunk.pending, (state) => {
+        Object.assign(state, withGoogleBusy(state))
+      })
+      .addCase(loadGoogleConnectionThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        Object.assign(
+          state,
+          result.ok
+            ? withGoogleConnection(state, result.value)
+            : withGoogleFailed(state, result.error),
+        )
+      })
+      .addCase(loadGoogleConnectionThunk.rejected, (state, action) => {
+        Object.assign(
+          state,
+          withGoogleFailed(
+            state,
+            SettingsExceptions.integrationUnavailable(action.error.message ?? ''),
+          ),
+        )
+      })
+
+      .addCase(connectGoogleThunk.pending, (state) => {
+        Object.assign(state, withGoogleBusy(state))
+      })
+      .addCase(connectGoogleThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        if (result.ok) {
+          // The browser is on its way to Google. The row stays busy: the
+          // connection's real answer arrives on the way back, through
+          // `loadGoogleConnectionThunk`.
+          return
+        }
+        Object.assign(state, withGoogleFailed(state, result.error))
+      })
+      .addCase(connectGoogleThunk.rejected, (state, action) => {
+        Object.assign(
+          state,
+          withGoogleFailed(
+            state,
+            SettingsExceptions.integrationUnavailable(action.error.message ?? ''),
+          ),
+        )
+      })
+
+      .addCase(disconnectGoogleThunk.pending, (state) => {
+        Object.assign(state, withGoogleBusy(state))
+      })
+      .addCase(disconnectGoogleThunk.fulfilled, (state, action) => {
+        const result = action.payload
+        Object.assign(
+          state,
+          result.ok
+            ? withGoogleConnection(state, result.value)
+            : withGoogleFailed(state, result.error),
+        )
+      })
+      .addCase(disconnectGoogleThunk.rejected, (state, action) => {
+        Object.assign(
+          state,
+          withGoogleFailed(
+            state,
+            SettingsExceptions.integrationUnavailable(action.error.message ?? ''),
+          ),
+        )
+      })
+  },
+})
+
+export const {
+  childAuthDelegatedSignedIn,
+  userDidDismissAuth,
+  userDidTapBackToHub,
+  userDidTapSection,
+  userDidTapSignIn,
+} = settingsSlice.actions

--- a/packages/app/src/features/settings/SettingsIntegrations.ts
+++ b/packages/app/src/features/settings/SettingsIntegrations.ts
@@ -1,0 +1,174 @@
+/**
+ * The Integrations pane's rows — canon `IntegrationsShifters.applyItemsLoaded`,
+ * ported as a pure function of the connection state rather than a mutation.
+ *
+ * Canon builds four rows: Kro Cloud (always "connected", no affordance), Google
+ * Calendar (only while the `googleCalendar` flag is on), and Apple Calendar and
+ * Apple Reminders — whose Connect buttons are rendered `.disabled(true)`,
+ * unconditionally, on the platform that *has* EventKit. They are decoration.
+ *
+ * ## Web parity is honest about the same inertness
+ *
+ * The epic puts Apple EventKit hosts out of scope: there is no EventKit in a
+ * browser and there never will be. Canon's two rows are ported exactly as canon
+ * ships them — present, listed, and inert — rather than hidden, because hiding
+ * them would make the web's Integrations pane a *different* list from the Mac's
+ * for a user comparing the two. `action: 'unavailable'` is what an inert
+ * Connect is, said out loud, and the row explains itself instead of offering a
+ * button that does nothing when pressed.
+ *
+ * ## Google's four states, not two
+ *
+ * Canon's `connected: Bool` cannot distinguish "this build has no Google client
+ * configured" from "you have not connected yet" — on iOS the client is baked
+ * into the bundle, so the distinction does not arise. On the web it does
+ * (KC-IS-#33's `GoogleCalendarConnection`), and collapsing them would show a
+ * Connect button on a deployment where connecting cannot possibly work: the
+ * user presses it, Google returns an opaque OAuth error, and nothing in the
+ * product explains why. So `unconfigured` gets its own row state and its own
+ * copy.
+ */
+import { assertNever } from '@kro/core'
+import type { GoogleConnectionState } from './SettingsState'
+
+/** What a row offers. One field, so "connected and connecting" is unsayable. */
+export const IntegrationAction = {
+  /** Nothing to press — Kro Cloud, and Google while connected-and-idle. */
+  none: 'none',
+  /** Canon's Connect. */
+  connect: 'connect',
+  /** A grant existed and stopped working — KC-IS-#33's fourth state. */
+  reconnect: 'reconnect',
+  disconnect: 'disconnect',
+  /** An attempt is in flight — canon's `isConnecting` spinner. */
+  busy: 'busy',
+  /** This deployment cannot offer the connection at all. */
+  unavailable: 'unavailable',
+} as const
+
+export type IntegrationAction =
+  (typeof IntegrationAction)[keyof typeof IntegrationAction]
+
+/** Canon's `IntegrationItem`, plus the state the web can actually be in. */
+export interface IntegrationRow {
+  readonly id: string
+  readonly title: string
+  readonly subtitle: string
+  /** Canon's SF Symbol name; the surface resolves it. */
+  readonly glyph: string
+  readonly isConnected: boolean
+  readonly action: IntegrationAction
+}
+
+/** Canon's row ids, so a test names them rather than spelling strings twice. */
+export const IntegrationId = {
+  kroCloud: 'kro-cloud',
+  google: 'google',
+  appleCalendar: 'apple-calendar',
+  appleReminders: 'apple-reminders',
+} as const
+
+export type IntegrationId = (typeof IntegrationId)[keyof typeof IntegrationId]
+
+/** The Google row's subtitle, which is the only one that varies by state. */
+export const googleIntegrationSubtitle = (
+  connection: GoogleConnectionState,
+): string => {
+  switch (connection.kind) {
+    case 'unknown':
+      return 'Checking your connection…'
+    case 'unconfigured':
+      return 'Not available on this deployment — no Google client is configured.'
+    case 'disconnected':
+      // Canon's copy, verbatim.
+      return 'See all your events in one place.'
+    case 'connected':
+      return 'Connected. Your events appear alongside your plans.'
+    case 'needsReconnect':
+      return 'Kro no longer has access. Reconnect to see your events.'
+    default:
+      return assertNever(connection)
+  }
+}
+
+const googleAction = (
+  connection: GoogleConnectionState,
+  isBusy: boolean,
+): IntegrationAction => {
+  if (isBusy) return IntegrationAction.busy
+  switch (connection.kind) {
+    case 'unknown':
+      return IntegrationAction.busy
+    case 'unconfigured':
+      return IntegrationAction.unavailable
+    case 'disconnected':
+      return IntegrationAction.connect
+    case 'connected':
+      return IntegrationAction.disconnect
+    case 'needsReconnect':
+      return IntegrationAction.reconnect
+    default:
+      return assertNever(connection)
+  }
+}
+
+export interface IntegrationRowsInput {
+  readonly connection: GoogleConnectionState
+  readonly isBusy: boolean
+  /** The `googleCalendar` feature flag. */
+  readonly isGoogleEnabled: boolean
+}
+
+/**
+ * The pane's rows, in canon's order: Kro Cloud, Google (flag-gated), then the
+ * two Apple rows.
+ */
+export const integrationRows = (
+  input: IntegrationRowsInput,
+): readonly IntegrationRow[] => {
+  const rows: IntegrationRow[] = [
+    {
+      id: IntegrationId.kroCloud,
+      title: 'Kro Cloud',
+      subtitle: 'Always on — stores your plans across devices.',
+      glyph: 'icloud.fill',
+      isConnected: true,
+      action: IntegrationAction.none,
+    },
+  ]
+
+  if (input.isGoogleEnabled) {
+    rows.push({
+      id: IntegrationId.google,
+      title: 'Google Calendar',
+      subtitle: googleIntegrationSubtitle(input.connection),
+      glyph: 'calendar.circle.fill',
+      isConnected: input.connection.kind === 'connected',
+      action: googleAction(input.connection, input.isBusy),
+    })
+  }
+
+  rows.push(
+    {
+      id: IntegrationId.appleCalendar,
+      title: 'Apple Calendar',
+      // Canon's subtitle is "EventKit on this device." — true of a Mac and of
+      // an iPhone, and false of every browser. The row stays; the sentence
+      // becomes the one the web can defend.
+      subtitle: 'Not available on the web — Apple provides no browser API.',
+      glyph: 'calendar.circle.fill',
+      isConnected: false,
+      action: IntegrationAction.unavailable,
+    },
+    {
+      id: IntegrationId.appleReminders,
+      title: 'Apple Reminders',
+      subtitle: 'Not available on the web — Apple provides no browser API.',
+      glyph: 'checklist',
+      isConnected: false,
+      action: IntegrationAction.unavailable,
+    },
+  )
+
+  return rows
+}

--- a/packages/app/src/features/settings/SettingsIntegrations.ts
+++ b/packages/app/src/features/settings/SettingsIntegrations.ts
@@ -70,13 +70,24 @@ export const IntegrationId = {
 
 export type IntegrationId = (typeof IntegrationId)[keyof typeof IntegrationId]
 
-/** The Google row's subtitle, which is the only one that varies by state. */
+/**
+ * The Google row's subtitle, which is the only one that varies by state.
+ *
+ * `unknown` reads two ways and the difference matters: while an attempt is in
+ * flight it means *"still asking"*; once nothing is in flight it means *"we
+ * asked and could not find out"* — the state a failed first `/api/google/status`
+ * leaves behind. Saying "Checking…" forever there would be a lie about work
+ * that is not happening. (Reported by Copilot on KC-PR-#70.)
+ */
 export const googleIntegrationSubtitle = (
   connection: GoogleConnectionState,
+  isBusy = false,
 ): string => {
   switch (connection.kind) {
     case 'unknown':
-      return 'Checking your connection…'
+      return isBusy
+        ? 'Checking your connection…'
+        : 'We could not check your connection. Try connecting again.'
     case 'unconfigured':
       return 'Not available on this deployment — no Google client is configured.'
     case 'disconnected':
@@ -98,7 +109,16 @@ const googleAction = (
   if (isBusy) return IntegrationAction.busy
   switch (connection.kind) {
     case 'unknown':
-      return IntegrationAction.busy
+      // Not busy and still unknown means the read did not answer — the state a
+      // failed first status call leaves behind, because a failed *attempt* must
+      // not overwrite a connection it learned nothing about. Offering Connect
+      // is the recoverable move: the banner says what went wrong, and
+      // `connectGoogleThunk` re-reads the connection before it navigates, so a
+      // deployment that is in fact `unconfigured` reports that instead of
+      // sending the browser somewhere that can only fail. Returning `busy` here
+      // — the previous behaviour — left the row on a non-interactive "Working…"
+      // indefinitely. (Reported by Copilot on KC-PR-#70.)
+      return IntegrationAction.connect
     case 'unconfigured':
       return IntegrationAction.unavailable
     case 'disconnected':
@@ -141,7 +161,7 @@ export const integrationRows = (
     rows.push({
       id: IntegrationId.google,
       title: 'Google Calendar',
-      subtitle: googleIntegrationSubtitle(input.connection),
+      subtitle: googleIntegrationSubtitle(input.connection, input.isBusy),
       glyph: 'calendar.circle.fill',
       isConnected: input.connection.kind === 'connected',
       action: googleAction(input.connection, input.isBusy),

--- a/packages/app/src/features/settings/SettingsMocks.ts
+++ b/packages/app/src/features/settings/SettingsMocks.ts
@@ -1,0 +1,169 @@
+/**
+ * The settings feature's canned `State` variants (`RC-31`, `UZF-18`).
+ *
+ * Every story and every render test consumes these rather than building state
+ * inline, so the two can never describe different worlds. Each is built from
+ * `settingsSlice.getInitialState()` and from the **schema's own defaults**, not
+ * from a hand-typed value table — a mock that disagreed with
+ * `SettingOptions.ts` would make a green suite prove nothing.
+ */
+import { type SettingValue, allSettingOptions } from '@kro/core'
+import { settingsSlice } from './SettingsFeature'
+import { SettingsExceptions } from './SettingsException'
+import { SettingsSectionId } from './SettingsSection'
+import type { SettingsState } from './SettingsState'
+
+const base: SettingsState = settingsSlice.getInitialState()
+
+/** Every declared option at its declared default — the first-launch snapshot. */
+export const defaultSettingValues: Readonly<
+  Record<string, SettingValue | null>
+> = Object.fromEntries(
+  allSettingOptions.map((option) => [option.key, option.defaultValue]),
+)
+
+/**
+ * The default snapshot with a few keys changed.
+ *
+ * A function rather than an inline spread so the result keeps the *record*
+ * type: an object literal spread narrows to the keys it names, and a consumer
+ * indexing it by a variable key would then have to cast.
+ */
+const withValues = (
+  overrides: Readonly<Record<string, SettingValue | null>>,
+): Readonly<Record<string, SettingValue | null>> => ({
+  ...defaultSettingValues,
+  ...overrides,
+})
+
+const loaded: SettingsState = {
+  ...base,
+  load: { kind: 'loaded' },
+  values: defaultSettingValues,
+  google: { ...base.google, isEnabled: true, connection: { kind: 'disconnected' } },
+}
+
+export const SettingsMocks = {
+  /** Before the snapshot has been asked for. */
+  idle: base,
+
+  /** The snapshot is being read. */
+  loading: { ...base, load: { kind: 'loading' } } satisfies SettingsState,
+
+  /** Loaded, on the hub, Google configured but not connected. */
+  loaded,
+
+  /** The store could not be read; defaults show and the form stays editable. */
+  loadFailed: {
+    ...base,
+    load: {
+      kind: 'failed',
+      exception: SettingsExceptions.preferencesUnavailable('quota exceeded'),
+    },
+    values: defaultSettingValues,
+  } satisfies SettingsState,
+
+  /** The General pane, open. */
+  generalPane: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.general },
+  } satisfies SettingsState,
+
+  /**
+   * The General pane with the end time before the start — canon's inline
+   * warning, with both values persisting exactly as entered.
+   */
+  generalPaneInvalidHours: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.general },
+    values: withValues({
+      'general.workingHoursStart': 18 * 60,
+      'general.workingHoursEnd': 9 * 60,
+    }),
+  } satisfies SettingsState,
+
+  /** The Session pane, tuned away from every default. */
+  sessionPaneTuned: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.sessionPreferences },
+    values: withValues({
+      'session.defaultDuration': 45,
+      'session.defaultBreakDuration': 10,
+      'session.enableStopwatch': false,
+      'session.autoStartBreak': true,
+      'session.soundOnEnd': false,
+    }),
+  } satisfies SettingsState,
+
+  /** Integrations, with Google offering a first connection. */
+  integrationsDisconnected: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.integrations },
+  } satisfies SettingsState,
+
+  /**
+   * Integrations on a deployment with no Google client — the honest state the
+   * epic's `unconfigured` env produces.
+   */
+  integrationsUnconfigured: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.integrations },
+    google: {
+      ...loaded.google,
+      connection: {
+        kind: 'unconfigured',
+        missing: ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'],
+      },
+    },
+  } satisfies SettingsState,
+
+  /** Integrations with a live grant. */
+  integrationsConnected: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.integrations },
+    google: { ...loaded.google, connection: { kind: 'connected' } },
+  } satisfies SettingsState,
+
+  /** A grant that stopped working — KC-IS-#33's fourth state. */
+  integrationsNeedsReconnect: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.integrations },
+    google: { ...loaded.google, connection: { kind: 'needsReconnect' } },
+  } satisfies SettingsState,
+
+  /** A connect attempt in flight — canon's `isConnecting` spinner. */
+  integrationsBusy: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.integrations },
+    google: { ...loaded.google, isBusy: true },
+  } satisfies SettingsState,
+
+  /** The disconnect call failed; the grant is untouched and the row says so. */
+  integrationsFailed: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.integrations },
+    google: {
+      ...loaded.google,
+      connection: { kind: 'connected' },
+      exception: SettingsExceptions.integrationUnavailable('502'),
+    },
+  } satisfies SettingsState,
+
+  /** The Profile pane. */
+  profilePane: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.profile },
+  } satisfies SettingsState,
+
+  /** The Subscription pane — canon's row with no flow. */
+  subscriptionPane: {
+    ...loaded,
+    pane: { kind: 'section', section: SettingsSectionId.subscription },
+  } satisfies SettingsState,
+
+  /** The auth surface, opened from the profile popover. */
+  authPresented: {
+    ...loaded,
+    authPresentation: { kind: 'presented', origin: 'profilePopover' },
+  } satisfies SettingsState,
+} as const

--- a/packages/app/src/features/settings/SettingsProducer.ts
+++ b/packages/app/src/features/settings/SettingsProducer.ts
@@ -1,0 +1,215 @@
+/**
+ * The settings surface's effects (`RC-3`, `RC-25`; implements `UZF-14`,
+ * `UZF-15`).
+ *
+ * Every thunk resolves `Result<T, SettingsException>` and never throws; every
+ * one reads its boundary from `extra` and never imports a Service. The four
+ * boundaries are the on-device preference store, the `googleCalendar` feature
+ * flag, KC-IS-#33's Google service and KC-IS-#13's navigation service.
+ *
+ * ## Why the preference store is read through a Producer at all
+ *
+ * `extra.localStore.preferences` is a **synchronous** `KeyValueStore` — a
+ * `RC-47` Provider — so a reducer could technically read it. It is read here
+ * anyway, for two reasons that outlive the convenience: a component may not
+ * reach `extra` at all (`RC-6`), and a snapshot in state is what lets a
+ * Selector answer a row's value without touching storage on every render. The
+ * same shape `EarnProducer` already uses.
+ */
+import {
+  type Result,
+  type SettingValue,
+  FeatureFlags,
+  allSettingOptions,
+  err,
+  makePreferences,
+  ok,
+  settingOptionForKey,
+} from '@kro/core'
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import type { ThunkExtra } from '../../library/store'
+import {
+  type SettingsException,
+  SettingsExceptions,
+} from './SettingsException'
+import type { GoogleConnectionState } from './SettingsState'
+
+const messageOf = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+/** What one snapshot read produced. */
+export interface SettingsSnapshot {
+  readonly values: Readonly<Record<string, SettingValue | null>>
+  /** The `googleCalendar` flag, resolved in the same pass. */
+  readonly isGoogleEnabled: boolean
+}
+
+/** What one write produced — the value the store actually took. */
+export interface SettingWriteResult {
+  readonly key: string
+  readonly value: SettingValue | null
+}
+
+/**
+ * The Service's connection, narrowed to the feature's own union.
+ *
+ * A feature module may not import from `services/**` (`RC-6`), so the Service's
+ * `GoogleCalendarConnection` type is never named here — `extra.googleCalendar`
+ * carries it through `ThunkExtra`, and this switch reads its discriminant. The
+ * `scopes` and `reason` payloads are deliberately dropped: the pane offers the
+ * same affordance whichever reason Google gave, and a scope list in state would
+ * be a credential-shaped value with no reader (`SEC-5`).
+ */
+const toConnectionState = (connection: {
+  kind: 'unconfigured' | 'disconnected' | 'connected' | 'needsReconnect'
+  missing?: readonly string[]
+}): GoogleConnectionState => {
+  switch (connection.kind) {
+    case 'unconfigured':
+      return { kind: 'unconfigured', missing: connection.missing ?? [] }
+    case 'disconnected':
+      return { kind: 'disconnected' }
+    case 'connected':
+      return { kind: 'connected' }
+    case 'needsReconnect':
+      return { kind: 'needsReconnect' }
+  }
+}
+
+/**
+ * Canon's `.started` — read every declared option's stored value at once.
+ *
+ * `allSettingOptions`, not `allPreferenceOptions`: the three non-preference
+ * options (the two Apple integration flags and the Do visibility filter) are
+ * part of the same store, and a snapshot that omitted them would make a later
+ * reader think they were unset. The *panes* still render only what
+ * `settingOptionsByGroup` declares — see `SettingsElements`.
+ *
+ * A store that cannot be read at all resolves `err`; the surface then shows
+ * declared defaults and stays editable, which is canon's "load failed" state.
+ */
+export const loadSettingsThunk = createAsyncThunk<
+  Result<SettingsSnapshot, SettingsException>,
+  void,
+  { extra: ThunkExtra }
+>('settings/onSettingsLoadCompleted', async (_argument, { extra }) => {
+  try {
+    const preferences = makePreferences(extra.localStore.preferences)
+    const values: Record<string, SettingValue | null> = {}
+    for (const option of allSettingOptions) {
+      values[option.key] = preferences.read(option)
+    }
+    return ok({
+      values,
+      isGoogleEnabled: extra.featureFlags.isEnabled(FeatureFlags.googleCalendar),
+    })
+  } catch (error) {
+    return err(SettingsExceptions.preferencesUnavailable(messageOf(error)))
+  }
+})
+
+/**
+ * One preference changed.
+ *
+ * `Preferences.write` reports `false` for a value that does not fit the
+ * option's declared shape and **does not persist it** — so a refusal is an
+ * `err` here rather than a silent no-op that would leave the form showing a
+ * value the store never took.
+ *
+ * The end-≤-start pair is not a refusal: both times are legal `timeOfDay`
+ * values, canon persists them as entered, and the warning is a *rendered*
+ * state (`selectWorkingHoursValid`), never a rejected write.
+ */
+export const updateSettingThunk = createAsyncThunk<
+  Result<SettingWriteResult, SettingsException>,
+  { key: string; value: SettingValue },
+  { extra: ThunkExtra }
+>('settings/onPreferenceWriteCompleted', async ({ key, value }, { extra }) => {
+  const option = settingOptionForKey(key)
+  if (option === null) {
+    return err(SettingsExceptions.preferenceRejected(`no option declares ${key}`))
+  }
+  try {
+    const preferences = makePreferences(extra.localStore.preferences)
+    if (!preferences.write(option, value)) {
+      return err(
+        SettingsExceptions.preferenceRejected(`${key} refused the given value`),
+      )
+    }
+    return ok({ key, value: preferences.read(option) })
+  } catch (error) {
+    return err(SettingsExceptions.preferencesUnavailable(messageOf(error)))
+  }
+})
+
+/**
+ * Canon's `IntegrationsFeature.onViewAppeared` — ask the deployment what it can
+ * offer.
+ *
+ * Canon asks `googleAuth.loadTokens() != nil`, a two-state answer it can give
+ * synchronously because the credential is on the device. Here the credential is
+ * an `HttpOnly` cookie the browser cannot read (`SEC-5`), so the question goes
+ * to this app's own `/api/google/status` route and comes back with four states.
+ */
+export const loadGoogleConnectionThunk = createAsyncThunk<
+  Result<GoogleConnectionState, SettingsException>,
+  void,
+  { extra: ThunkExtra }
+>('settings/onGoogleConnectionLoadCompleted', async (_argument, { extra, signal }) => {
+  try {
+    return ok(toConnectionState(await extra.googleCalendar.connection({ signal })))
+  } catch (error) {
+    return err(SettingsExceptions.integrationUnavailable(messageOf(error)))
+  }
+})
+
+/**
+ * Canon's `userDidTapConnect("google")` — start (or repeat) authorization.
+ *
+ * Canon opens an `ASWebAuthenticationSession`. The web's equivalent is a
+ * full-page navigation to this app's `/api/google/connect`, which mints the
+ * state cookie and redirects to Google; the browser comes back to
+ * `/api/google/callback`. So the effect is a navigation, and it goes through
+ * `extra.navigation` — never `window.location` from a component (`RC-17`).
+ *
+ * An `unconfigured` deployment resolves `err` **without navigating**: sending
+ * the browser to a route that can only fail is worse than saying so.
+ */
+export const connectGoogleThunk = createAsyncThunk<
+  Result<'started', SettingsException>,
+  void,
+  { extra: ThunkExtra }
+>('settings/onGoogleConnectStarted', async (_argument, { extra, signal }) => {
+  try {
+    const connection = await extra.googleCalendar.connection({ signal })
+    if (connection.kind === 'unconfigured') {
+      return err(
+        SettingsExceptions.integrationUnconfigured(connection.missing.join(', ')),
+      )
+    }
+    extra.navigation.navigate(extra.googleCalendar.authorizationPath())
+    return ok('started')
+  } catch (error) {
+    return err(SettingsExceptions.integrationUnavailable(messageOf(error)))
+  }
+})
+
+/**
+ * Revoke the grant and re-read the state.
+ *
+ * The re-read is what makes the row honest: `disconnect` answers nothing, and
+ * assuming `disconnected` would paint a Connect button over a revocation that
+ * did not actually take.
+ */
+export const disconnectGoogleThunk = createAsyncThunk<
+  Result<GoogleConnectionState, SettingsException>,
+  void,
+  { extra: ThunkExtra }
+>('settings/onGoogleDisconnectCompleted', async (_argument, { extra, signal }) => {
+  try {
+    await extra.googleCalendar.disconnect({ signal })
+    return ok(toConnectionState(await extra.googleCalendar.connection({ signal })))
+  } catch (error) {
+    return err(SettingsExceptions.integrationUnavailable(messageOf(error)))
+  }
+})

--- a/packages/app/src/features/settings/SettingsSection.ts
+++ b/packages/app/src/features/settings/SettingsSection.ts
@@ -1,0 +1,189 @@
+/**
+ * The Settings hub's information architecture — canon
+ * `SettingsFeature.Section` (id, title, `systemImage`) and the three groups
+ * `SettingsHubView` draws them in.
+ *
+ * Canon keeps the section list and its grouping in two different files: the
+ * `Section` enum carries id/title/glyph, and `SettingsHubScreen` decides which
+ * ids go into `profileSection`, `preferencesSections` and `accountSections`.
+ * Both facts are here, because on this stack the hub is one Fragment and a
+ * grouping that lives in the caller is a grouping that drifts.
+ *
+ * ## What is NOT here
+ *
+ * The preference *options* — those come from the schema (`@kro/core`'s
+ * `settingOptionsByGroup`), never from a list typed out again. A section knows
+ * which `SettingGroup` it renders; the rows inside it are whatever that group
+ * declares. See `SettingsElements.ts`.
+ *
+ * ## Appearance
+ *
+ * Canon at `2117efc` has a sixth preferences section, `appearance`, listed only
+ * while the `appearanceThemes` flag is enabled. That flag is not in this repo's
+ * registry (`@kro/core`'s `FeatureFlags` has 28 entries and no
+ * `appearanceThemes`), so porting the section would mean inventing a flag —
+ * and canon's own General pane still renders the Theme and Accent rows when the
+ * flag is off, which is the shipping layout this port reproduces. The
+ * divergence is named in the PR body.
+ */
+import { SettingGroup, assertNever } from '@kro/core'
+
+/** Canon's `SettingsFeature.Section`, by raw value. */
+export const SettingsSectionId = {
+  profile: 'profile',
+  general: 'general',
+  planPreferences: 'planPreferences',
+  doPreferences: 'doPreferences',
+  earnPreferences: 'earnPreferences',
+  sessionPreferences: 'sessionPreferences',
+  integrations: 'integrations',
+  subscription: 'subscription',
+} as const
+
+export type SettingsSectionId =
+  (typeof SettingsSectionId)[keyof typeof SettingsSectionId]
+
+/** Which of the hub's three groups a section is listed under. */
+export const SettingsHubGroup = {
+  /** The lone top row — canon's unlabelled first `Section`. */
+  profile: 'profile',
+  /** Canon's `Section("Preferences")`. */
+  preferences: 'preferences',
+  /** Canon's second unlabelled `Section` — Integrations and Subscription. */
+  account: 'account',
+} as const
+
+export type SettingsHubGroup =
+  (typeof SettingsHubGroup)[keyof typeof SettingsHubGroup]
+
+/** One hub row. `glyph` is canon's SF Symbol name, resolved by the surface. */
+export interface SettingsSection {
+  readonly id: SettingsSectionId
+  readonly title: string
+  readonly glyph: string
+  readonly group: SettingsHubGroup
+  /**
+   * The preference group this section renders from the schema, or `null` for a
+   * section whose content is not schema-driven (Profile, Integrations,
+   * Subscription).
+   */
+  readonly settingGroup: SettingGroup | null
+}
+
+/**
+ * Every section, in canon's hub order: Profile, then the five preference
+ * sections, then Integrations and Subscription.
+ *
+ * Titles and glyphs are transcribed from `SettingsFeature.Section` verbatim.
+ */
+export const settingsSections: readonly SettingsSection[] = [
+  {
+    id: SettingsSectionId.profile,
+    title: 'Profile',
+    glyph: 'person.crop.circle',
+    group: SettingsHubGroup.profile,
+    settingGroup: null,
+  },
+  {
+    id: SettingsSectionId.general,
+    title: 'General',
+    glyph: 'gearshape',
+    group: SettingsHubGroup.preferences,
+    settingGroup: SettingGroup.general,
+  },
+  {
+    id: SettingsSectionId.planPreferences,
+    title: 'Plan Preferences',
+    glyph: 'slider.horizontal.3',
+    group: SettingsHubGroup.preferences,
+    settingGroup: SettingGroup.plan,
+  },
+  {
+    id: SettingsSectionId.doPreferences,
+    title: 'Do Preferences',
+    glyph: 'checkmark.circle',
+    group: SettingsHubGroup.preferences,
+    settingGroup: SettingGroup.do,
+  },
+  {
+    id: SettingsSectionId.earnPreferences,
+    title: 'Earn Preferences',
+    glyph: 'star.circle',
+    group: SettingsHubGroup.preferences,
+    settingGroup: SettingGroup.earn,
+  },
+  {
+    id: SettingsSectionId.sessionPreferences,
+    title: 'Session Preferences',
+    glyph: 'timer',
+    group: SettingsHubGroup.preferences,
+    settingGroup: SettingGroup.session,
+  },
+  {
+    id: SettingsSectionId.integrations,
+    title: 'Integrations',
+    glyph: 'square.stack.3d.up',
+    group: SettingsHubGroup.account,
+    settingGroup: null,
+  },
+  {
+    id: SettingsSectionId.subscription,
+    title: 'Subscription',
+    glyph: 'creditcard',
+    group: SettingsHubGroup.account,
+    settingGroup: null,
+  },
+]
+
+/** The sections of one hub group, in declaration order. */
+export const settingsSectionsIn = (
+  group: SettingsHubGroup,
+): readonly SettingsSection[] =>
+  settingsSections.filter((section) => section.group === group)
+
+/** The section a raw id names, or `null` when nothing declares it. */
+export const settingsSectionForId = (id: string): SettingsSection | null =>
+  settingsSections.find((section) => section.id === id) ?? null
+
+/**
+ * The heading a drill-down pane shows. Canon's `navigationTitle` per screen,
+ * which is the section's own title everywhere except Integrations — whose view
+ * titles itself "Integrations", the same string — so this is the title.
+ */
+export const settingsSectionTitle = (id: SettingsSectionId): string => {
+  const section = settingsSectionForId(id)
+  // Unreachable: `id` is the union of the declared ids. Kept as a total
+  // function so a caller never has to handle a `null` that cannot happen.
+  return section?.title ?? ''
+}
+
+/** Which pane shape a section renders as — the surface's dispatch. */
+export const SettingsPaneKind = {
+  /** Rows built from the preference schema. */
+  preferences: 'preferences',
+  profile: 'profile',
+  integrations: 'integrations',
+  subscription: 'subscription',
+} as const
+
+export type SettingsPaneKind =
+  (typeof SettingsPaneKind)[keyof typeof SettingsPaneKind]
+
+export const settingsPaneKind = (id: SettingsSectionId): SettingsPaneKind => {
+  switch (id) {
+    case SettingsSectionId.profile:
+      return SettingsPaneKind.profile
+    case SettingsSectionId.integrations:
+      return SettingsPaneKind.integrations
+    case SettingsSectionId.subscription:
+      return SettingsPaneKind.subscription
+    case SettingsSectionId.general:
+    case SettingsSectionId.planPreferences:
+    case SettingsSectionId.doPreferences:
+    case SettingsSectionId.earnPreferences:
+    case SettingsSectionId.sessionPreferences:
+      return SettingsPaneKind.preferences
+    default:
+      return assertNever(id)
+  }
+}

--- a/packages/app/src/features/settings/SettingsSelectors.ts
+++ b/packages/app/src/features/settings/SettingsSelectors.ts
@@ -1,0 +1,237 @@
+/**
+ * The settings slice's derived reads (`RC-5`, `UZF-11`).
+ *
+ * Every one is `createSelector` over `RootState` and reads nothing but state —
+ * no clock, no service. A `useAppSelector` callback in a Page may do an O(1)
+ * field read; anything derived is here.
+ *
+ * Two of these compose across slices, which is exactly what `RC-20` sanctions:
+ * the hub's sync footer is `auth`'s `settingsSync` (KC-IS-#31 owns the sync
+ * state machine) and the profile row's identity is `auth`'s session. Neither
+ * reaches into the other slice's shape — both go through the `auth` feature's
+ * own exported Selectors.
+ */
+import {
+  type SettingOption,
+  type SettingValue,
+  assertNever,
+  isWorkingHoursRangeValid,
+  settingOptionForKey,
+  workingHoursEndOption,
+  workingHoursStartOption,
+} from '@kro/core'
+import { createSelector } from '@reduxjs/toolkit'
+import type { RootState } from '../../library/store'
+import { selectSettingsSyncState } from '../auth/AuthSelectors'
+import type { SettingsException } from './SettingsException'
+import { type IntegrationRow, integrationRows } from './SettingsIntegrations'
+import {
+  type SettingsSection,
+  SettingsHubGroup,
+  type SettingsSectionId,
+  settingsSectionsIn,
+} from './SettingsSection'
+import type {
+  AuthPresentationState,
+  GoogleIntegrationState,
+  SettingsLoadState,
+  SettingsState,
+} from './SettingsState'
+
+const slice = (state: RootState): SettingsState => state.settings
+
+export const selectSettingsLoad = createSelector(
+  [slice],
+  (settings): SettingsLoadState => settings.load,
+)
+
+/**
+ * Whether the stored values have arrived.
+ *
+ * Canon disables the whole form until they have, *"so an edit made in the brief
+ * pre-load window isn't dropped by the persistence guard and then overwritten
+ * by the load"*. This is that guard's input.
+ */
+export const selectIsSettingsLoaded = createSelector(
+  [selectSettingsLoad],
+  (load) => load.kind === 'loaded',
+)
+
+export const selectSettingsException = createSelector(
+  [slice],
+  (settings): SettingsException | null =>
+    settings.load.kind === 'failed'
+      ? settings.load.exception
+      : settings.google.exception,
+)
+
+/** The copy a banner shows, derived from `kind` — never read from `message`. */
+export const selectSettingsErrorCopy = createSelector(
+  [selectSettingsException],
+  (exception): string | null => {
+    if (exception === null) return null
+    switch (exception.kind) {
+      case 'preferencesUnavailable':
+        return 'Your preferences could not be read on this device. Defaults are shown.'
+      case 'preferenceRejected':
+        return 'That value could not be saved. The previous one is still in effect.'
+      case 'integrationUnconfigured':
+        return 'Google Calendar is not configured for this deployment.'
+      case 'integrationUnavailable':
+        return 'The connection could not be changed. Please try again.'
+      default:
+        return assertNever(exception)
+    }
+  },
+)
+
+/** The whole snapshot. Consumed by `selectSettingValue` and by the panes. */
+export const selectSettingValues = createSelector(
+  [slice],
+  (settings): Readonly<Record<string, SettingValue | null>> => settings.values,
+)
+
+/**
+ * One option's value for rendering: the snapshot's, or the option's declared
+ * default while the snapshot has not arrived.
+ *
+ * A plain function of the snapshot rather than a selector factory, because a
+ * per-option `createSelector` would build one memoized selector per row and
+ * defeat the memoization it was meant to provide.
+ */
+export const settingValueIn = (
+  values: Readonly<Record<string, SettingValue | null>>,
+  option: SettingOption,
+): SettingValue | null =>
+  option.key in values ? values[option.key] ?? null : option.defaultValue
+
+/**
+ * Canon's *"the section warns when the end time is not after the start time"* —
+ * strictly after, so an empty day is invalid rather than a zero-length edge
+ * case waved through. The rule itself is `@kro/core`'s; this only feeds it the
+ * two current values.
+ */
+export const selectWorkingHoursValid = createSelector(
+  [selectSettingValues],
+  (values): boolean => {
+    const start = settingValueIn(values, workingHoursStartOption)
+    const end = settingValueIn(values, workingHoursEndOption)
+    if (typeof start !== 'number' || typeof end !== 'number') return true
+    return isWorkingHoursRangeValid(start, end)
+  },
+)
+
+export const selectSettingsPane = createSelector([slice], (settings) => settings.pane)
+
+/** Which section is open, or `null` for the hub. */
+export const selectOpenSection = createSelector(
+  [selectSettingsPane],
+  (pane): SettingsSectionId | null =>
+    pane.kind === 'section' ? pane.section : null,
+)
+
+export const selectGoogleIntegration = createSelector(
+  [slice],
+  (settings): GoogleIntegrationState => settings.google,
+)
+
+/** Canon's `IntegrationsFeature.State.items`. */
+export const selectIntegrationRows = createSelector(
+  [selectGoogleIntegration],
+  (google): readonly IntegrationRow[] =>
+    integrationRows({
+      connection: google.connection,
+      isBusy: google.isBusy,
+      isGoogleEnabled: google.isEnabled,
+    }),
+)
+
+export const selectAuthPresentation = createSelector(
+  [slice],
+  (settings): AuthPresentationState => settings.authPresentation,
+)
+
+export const selectIsAuthPresented = createSelector(
+  [selectAuthPresentation],
+  (presentation) => presentation.kind === 'presented',
+)
+
+// ---------------------------------------------------------------------------
+// The hub
+// ---------------------------------------------------------------------------
+
+/*
+ * The hub's three groups are constants, not Selectors: they derive from the
+ * section table and from no state at all, and a `createSelector` with no inputs
+ * would be a memoization wrapper around a value that never changes. `RC-5`
+ * forbids *derived state* read inline in a component, which these are not.
+ */
+
+/** Canon's lone top row. The table declares exactly one; `?? …` is unreachable. */
+export const profileHubSection: SettingsSection = settingsSectionsIn(
+  SettingsHubGroup.profile,
+)[0] ?? {
+  id: 'profile',
+  title: 'Profile',
+  glyph: 'person.crop.circle',
+  group: SettingsHubGroup.profile,
+  settingGroup: null,
+}
+
+export const preferencesHubSections: readonly SettingsSection[] =
+  settingsSectionsIn(SettingsHubGroup.preferences)
+
+export const accountHubSections: readonly SettingsSection[] = settingsSectionsIn(
+  SettingsHubGroup.account,
+)
+
+/**
+ * The hub's sync footer — canon's `SettingsHubSyncStatus`, built from the
+ * `auth` slice's `settingsSync` state (KC-IS-#31).
+ *
+ * `null` hides the footer entirely, which is canon's `syncStatus: nil`: before
+ * anything has been attempted there is nothing truthful to say.
+ */
+export interface SettingsSyncFooter {
+  readonly title: string
+  /** Canon's `isWarning` — the orange tint, paired with its own glyph. */
+  readonly isWarning: boolean
+  /** Canon's SF Symbol per case. */
+  readonly glyph: string
+}
+
+export const selectSettingsSyncFooter = createSelector(
+  [selectSettingsSyncState],
+  (sync): SettingsSyncFooter | null => {
+    switch (sync.kind) {
+      case 'idle':
+        return null
+      case 'syncing':
+        return {
+          title: 'Syncing…',
+          isWarning: false,
+          glyph: 'arrow.triangle.2.circlepath',
+        }
+      case 'synced':
+        return { title: 'Synced', isWarning: false, glyph: 'checkmark.icloud' }
+      case 'offline':
+        return {
+          title: 'Offline — will sync later',
+          isWarning: true,
+          glyph: 'icloud.slash',
+        }
+      case 'signedOut':
+        return {
+          title: 'Sign in to sync across devices',
+          isWarning: false,
+          glyph: 'person.crop.circle.badge.questionmark',
+        }
+      default:
+        return assertNever(sync)
+    }
+  },
+)
+
+/** The option a persisted key names, for a Producer's write path. */
+export const settingOptionForStorageKey = (key: string): SettingOption | null =>
+  settingOptionForKey(key)

--- a/packages/app/src/features/settings/SettingsSelectors.ts
+++ b/packages/app/src/features/settings/SettingsSelectors.ts
@@ -45,16 +45,31 @@ export const selectSettingsLoad = createSelector(
   (settings): SettingsLoadState => settings.load,
 )
 
-/**
- * Whether the stored values have arrived.
- *
- * Canon disables the whole form until they have, *"so an edit made in the brief
- * pre-load window isn't dropped by the persistence guard and then overwritten
- * by the load"*. This is that guard's input.
- */
+/** Whether the stored values arrived. Strictly `loaded` — not `failed`. */
 export const selectIsSettingsLoaded = createSelector(
   [selectSettingsLoad],
   (load) => load.kind === 'loaded',
+)
+
+/**
+ * Whether the form may be edited — canon's `isLoaded` guard, read for what it
+ * is *for*.
+ *
+ * Canon disables the form until the values arrive, *"so an edit made in the
+ * brief pre-load window isn't dropped by the persistence guard and then
+ * overwritten by the load"*. The thing being guarded against is **a load still
+ * in flight**, so the predicate is "the read has settled", not "the read
+ * succeeded".
+ *
+ * That distinction is load-bearing: canon's own *Load failed* state says the
+ * screen *"falls back to defaults and stays fully editable; edits still save"*.
+ * Keying the form off `loaded` alone would contradict it — a device whose
+ * preference store cannot be read would show every default and let the user
+ * change none of them. (Reported by Copilot on KC-PR-#70.)
+ */
+export const selectIsSettingsEditable = createSelector(
+  [selectSettingsLoad],
+  (load) => load.kind === 'loaded' || load.kind === 'failed',
 )
 
 export const selectSettingsException = createSelector(

--- a/packages/app/src/features/settings/SettingsShifters.ts
+++ b/packages/app/src/features/settings/SettingsShifters.ts
@@ -1,0 +1,137 @@
+/**
+ * The settings slice's state transitions (`RC-4`, `UZF-10`) — canon's
+ * `SettingsFeature` mutations and `IntegrationsShifters`' four `apply…`
+ * functions.
+ *
+ * Every one is pure: it takes the current state plus explicit arguments and
+ * returns a brand-new object. No clock, no randomness, no store read — a
+ * timestamp or an id arrives as an argument or not at all.
+ */
+import type { SettingValue } from '@kro/core'
+import type { SettingsException } from './SettingsException'
+import type { SettingsSectionId } from './SettingsSection'
+import type {
+  GoogleConnectionState,
+  SettingsState,
+} from './SettingsState'
+
+/** The snapshot read started. Clears a previous failure so a retry is clean. */
+export const withPreferencesLoading = (state: SettingsState): SettingsState => ({
+  ...state,
+  load: { kind: 'loading' },
+})
+
+/**
+ * The snapshot arrived. Replaces `values` wholesale rather than merging: a
+ * merge would keep a key the store no longer has, which is how a wiped
+ * preference (canon's sign-out clear) survives on screen.
+ */
+export const withPreferencesLoaded = (
+  state: SettingsState,
+  values: Readonly<Record<string, SettingValue | null>>,
+): SettingsState => ({
+  ...state,
+  load: { kind: 'loaded' },
+  values,
+})
+
+export const withPreferencesFailed = (
+  state: SettingsState,
+  exception: SettingsException,
+): SettingsState => ({
+  ...state,
+  load: { kind: 'failed', exception },
+})
+
+/**
+ * One option's value changed.
+ *
+ * Canon's General/Session panes write through a `@Binding` and persist on
+ * change; the value the user sees is the value in the form. Here the write goes
+ * through a Producer and the *accepted* value comes back here — so a rejected
+ * write (a value the option's declared shape refuses) leaves the previous one
+ * on screen rather than showing something the store did not take.
+ *
+ * The end-≤-start case is deliberately **not** a rejection: canon's spec says
+ * the values persist as entered and an inline warning appears, so both times
+ * are stored and `SettingsSelectors.selectWorkingHoursValid` reports the state.
+ */
+export const withSettingValue = (
+  state: SettingsState,
+  key: string,
+  value: SettingValue | null,
+): SettingsState => ({
+  ...state,
+  values: { ...state.values, [key]: value },
+})
+
+/** The user opened a section from the hub. */
+export const withPaneOpened = (
+  state: SettingsState,
+  section: SettingsSectionId,
+): SettingsState => ({
+  ...state,
+  pane: { kind: 'section', section },
+})
+
+/** Back to the hub — canon's `NavigationStack` pop. */
+export const withPaneClosed = (state: SettingsState): SettingsState => ({
+  ...state,
+  pane: { kind: 'hub' },
+})
+
+/**
+ * The Integrations pane learned what this deployment reports.
+ *
+ * Clears `isBusy` and the previous exception together: an answer, whatever it
+ * says, ends the attempt that asked for it.
+ */
+export const withGoogleConnection = (
+  state: SettingsState,
+  connection: GoogleConnectionState,
+): SettingsState => ({
+  ...state,
+  google: { ...state.google, connection, isBusy: false, exception: null },
+})
+
+/** Canon's `applyConnectionStarted` — the row spins and the error clears. */
+export const withGoogleBusy = (state: SettingsState): SettingsState => ({
+  ...state,
+  google: { ...state.google, isBusy: true, exception: null },
+})
+
+/**
+ * Canon's `applyConnectionFailed` — the spinner stops and the error shows. The
+ * connection itself is untouched: a failed *attempt* says nothing about the
+ * grant that was already there.
+ */
+export const withGoogleFailed = (
+  state: SettingsState,
+  exception: SettingsException,
+): SettingsState => ({
+  ...state,
+  google: { ...state.google, isBusy: false, exception },
+})
+
+/** The `googleCalendar` flag, resolved at load. */
+export const withGoogleEnabled = (
+  state: SettingsState,
+  isEnabled: boolean,
+): SettingsState => ({
+  ...state,
+  google: { ...state.google, isEnabled },
+})
+
+/** The auth surface was asked for, from one of its two entry points. */
+export const withAuthPresented = (
+  state: SettingsState,
+  origin: 'profilePopover' | 'settingsHub',
+): SettingsState => ({
+  ...state,
+  authPresentation: { kind: 'presented', origin },
+})
+
+export const withAuthDismissed = (state: SettingsState): SettingsState => ({
+  ...state,
+  authPresentation: { kind: 'hidden' },
+})

--- a/packages/app/src/features/settings/SettingsState.ts
+++ b/packages/app/src/features/settings/SettingsState.ts
@@ -1,0 +1,129 @@
+/**
+ * The settings slice's state — canon `SettingsFeature.State` plus
+ * `IntegrationsFeature.State`, collapsed into one shape.
+ *
+ * Canon composes these as a `StackState` of child reducers because iOS pushes a
+ * pane per section. There is no navigation stack here: `/adjust` is one route
+ * and the open pane is a field, so a deep link and a back step both resolve to
+ * the same value rather than to a stack that has to be replayed.
+ *
+ * ## Four lifecycles, four discriminated fields (`RC-24`, `UZF-9`)
+ *
+ * - `load` — has the preference snapshot arrived?
+ * - `google` — what does this deployment's Google integration report?
+ * - `pane` — which section is open, or the hub.
+ * - `authPresentation` — is the auth surface up, and in which mode was it
+ *   opened?
+ *
+ * A failed Google read must not blank the preference form, and an open auth
+ * sheet must not make the hub think it is loading. Separate fields make that
+ * structural rather than careful.
+ *
+ * ## `values` is a snapshot, not the store
+ *
+ * The preference store is `extra.localStore.preferences` — a synchronous
+ * `KeyValueStore` a Producer reads (`RC-6`: a component never touches a
+ * Service). The slice holds the *snapshot* the Producer read, so a Selector can
+ * answer "what is `session.defaultDuration` right now" without I/O, and every
+ * write goes back out through a Producer. That is the same shape `EarnFeature`
+ * uses for its own preference reads.
+ *
+ * A key absent from `values` means "not loaded yet", never "unset": an unset
+ * option resolves to its declared default at read time, which is exactly what
+ * `Preferences.read` already does.
+ */
+import type { SettingValue } from '@kro/core'
+import type { SettingsException } from './SettingsException'
+import type { SettingsSectionId } from './SettingsSection'
+
+/** The preference snapshot's lifecycle. */
+export type SettingsLoadState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'loaded' }
+  | { readonly kind: 'failed'; readonly exception: SettingsException }
+
+/**
+ * What this deployment's Google integration reports.
+ *
+ * The four connection states are the Service's (`GoogleCalendarConnection`,
+ * KC-IS-#33), re-declared here rather than imported: a feature module may not
+ * import from `services/**` (`RC-6`, enforced by
+ * `scripts/check-uzf-boundaries.mjs`), which is the same reason `DoFeature`
+ * carries `isGoogleCalendarConnected` instead of the Service's type. The
+ * Producer translates at the boundary.
+ *
+ * `unknown` is the pre-read state and is deliberately distinct from
+ * `unconfigured`: a hub that rendered "not set up" before asking would tell
+ * every user their deployment is broken for one frame.
+ */
+export type GoogleConnectionState =
+  | { readonly kind: 'unknown' }
+  | { readonly kind: 'unconfigured'; readonly missing: readonly string[] }
+  | { readonly kind: 'disconnected' }
+  | { readonly kind: 'connected' }
+  | { readonly kind: 'needsReconnect' }
+
+/** The Integrations pane's own lifecycle. */
+export interface GoogleIntegrationState {
+  readonly connection: GoogleConnectionState
+  /** Canon's `IntegrationItem.isConnecting` — a connect or disconnect in flight. */
+  readonly isBusy: boolean
+  /** The `googleCalendar` feature flag. Off ⇒ canon omits the row entirely. */
+  readonly isEnabled: boolean
+  readonly exception: SettingsException | null
+}
+
+/** Which pane the surface is showing. */
+export type SettingsPaneState =
+  | { readonly kind: 'hub' }
+  | { readonly kind: 'section'; readonly section: SettingsSectionId }
+
+/**
+ * Whether the auth surface is presented, and why it was opened.
+ *
+ * Canon's `MainFeature` owns the `authSheet` presentation; there is no Main
+ * slice reachable from here (`RC-20` forbids reaching into one), so the feature
+ * that offers the entry points — the profile popover and the hub's signed-out
+ * row — owns the presentation. `origin` exists so dismissing returns the user
+ * to what they were doing rather than to a fixed place.
+ */
+export type AuthPresentationState =
+  | { readonly kind: 'hidden' }
+  | {
+      readonly kind: 'presented'
+      readonly origin: 'profilePopover' | 'settingsHub'
+    }
+
+export interface SettingsState {
+  readonly load: SettingsLoadState
+  /** The stored value per option key. Absent ⇒ not loaded, never "unset". */
+  readonly values: Readonly<Record<string, SettingValue | null>>
+  readonly pane: SettingsPaneState
+  readonly google: GoogleIntegrationState
+  readonly authPresentation: AuthPresentationState
+}
+
+export const initialSettingsState: SettingsState = {
+  load: { kind: 'idle' },
+  values: {},
+  pane: { kind: 'hub' },
+  google: {
+    connection: { kind: 'unknown' },
+    isBusy: false,
+    isEnabled: false,
+    exception: null,
+  },
+  authPresentation: { kind: 'hidden' },
+}
+
+/**
+ * Canon's Subscription pane, which has a row and no flow.
+ *
+ * `SubscriptionView` takes a plan name and an optional renewal date, and its
+ * "Manage Subscription" button is wired to nothing — there is no store, no
+ * entitlement check and no purchase in KroApple at this tip. Parity is
+ * mirroring that honestly, so the plan name is a constant here rather than a
+ * field a nonexistent service would fill.
+ */
+export const SUBSCRIPTION_PLAN_NAME = 'Free'

--- a/packages/app/src/features/settings/__tests__/SettingsElements.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsElements.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The schema-driven render contract.
+ *
+ * The first test is the issue's acceptance criterion in one assertion: **every
+ * option the schema declares for a group appears exactly once** across that
+ * group's rendered subgroups. It is written as a set comparison over
+ * `settingOptionsByGroup` rather than against a list typed out here, because a
+ * hand-typed expectation would only prove that two copies of the same mistake
+ * agree.
+ */
+import {
+  SettingGroup,
+  accentColorOption,
+  allPreferenceOptions,
+  appearanceOption,
+  doNowThresholdHoursOption,
+  earnPointsFormulaOption,
+  hapticsOption,
+  overdueAlertsOption,
+  planDefaultSlotDurationOption,
+  sessionDefaultDurationOption,
+  settingGroups,
+  settingOptionsByGroup,
+  timezoneOption,
+  workingDaysOption,
+  workingHoursStartOption,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_STEPPER_BOUNDS,
+  OTHER_SUBGROUP_ID,
+  settingChoiceLabel,
+  settingControlFor,
+  settingElementsFor,
+  settingLabel,
+  settingSubgroupsFor,
+} from '../SettingsElements'
+
+describe('every declared option is rendered exactly once', () => {
+  it.each(settingGroups)(
+    'the %s pane offers each of its schema options once and nothing else',
+    (group) => {
+      const rendered = settingElementsFor(group).map(
+        (element) => element.option.key,
+      )
+      const declared = settingOptionsByGroup[group].map((option) => option.key)
+
+      expect([...rendered].sort()).toEqual([...declared].sort())
+      expect(new Set(rendered).size).toBe(rendered.length)
+    },
+  )
+
+  it('covers the whole preference schema across the five panes — nothing is orphaned', () => {
+    const rendered = settingGroups.flatMap((group) =>
+      settingElementsFor(group).map((element) => element.option.key),
+    )
+
+    expect([...rendered].sort()).toEqual(
+      allPreferenceOptions.map((option) => option.key).sort(),
+    )
+  })
+
+  it('excludes the three non-preference options — they describe the device, not the person', () => {
+    const rendered = new Set(
+      settingGroups.flatMap((group) =>
+        settingElementsFor(group).map((element) => element.option.key),
+      ),
+    )
+
+    expect(rendered.has('appleCalendar')).toBe(false)
+    expect(rendered.has('appleReminders')).toBe(false)
+    expect(rendered.has('nowVisibleTypes')).toBe(false)
+  })
+
+  it('needs no "Other" subgroup today — every option is placed by canon copy', () => {
+    for (const group of settingGroups) {
+      const ids = settingSubgroupsFor(group).map((subgroup) => subgroup.id)
+      expect(ids).not.toContain(OTHER_SUBGROUP_ID)
+    }
+  })
+})
+
+describe('subgroups reproduce canon layout', () => {
+  it('opens General with canon Working Hours section, in canon order', () => {
+    const [first] = settingSubgroupsFor(SettingGroup.general)
+
+    expect(first?.title).toBe('Working Hours')
+    expect(first?.elements.map((element) => element.option.key)).toEqual([
+      'general.workingHoursStart',
+      'general.workingHoursEnd',
+      'general.workingDays',
+    ])
+  })
+
+  it("carries canon Session 'During & after' footer about device-local storage", () => {
+    const subgroup = settingSubgroupsFor(SettingGroup.session).find(
+      (candidate) => candidate.id === 'duringAndAfter',
+    )
+
+    expect(subgroup?.footnote).toBe(
+      'Keep-awake and end sound are saved on this device only.',
+    )
+  })
+
+  it('omits no Plan subgroup — Timeline, Lists and Drafts all render', () => {
+    expect(settingSubgroupsFor(SettingGroup.plan).map((s) => s.title)).toEqual([
+      'Timeline',
+      'Lists',
+      'Drafts',
+    ])
+  })
+})
+
+describe('the control is derived from the declared value shape', () => {
+  it('renders a bool option as a toggle — overdue alerts', () => {
+    expect(settingControlFor(overdueAlertsOption)).toEqual({ kind: 'toggle' })
+  })
+
+  it('renders a timeOfDay option as a time field — working-hours start', () => {
+    expect(settingControlFor(workingHoursStartOption)).toEqual({ kind: 'time' })
+  })
+
+  it('renders a daysSet option as the weekday chips — working days', () => {
+    expect(settingControlFor(workingDaysOption)).toEqual({ kind: 'days' })
+  })
+
+  it("carries canon Stepper range for an int option — session length is 5…120 by 5", () => {
+    expect(settingControlFor(sessionDefaultDurationOption)).toEqual({
+      kind: 'stepper',
+      min: 5,
+      max: 120,
+      step: 5,
+      unit: 'min',
+    })
+  })
+
+  it("uses canon own unit for the Do 'now' window — hours, not minutes", () => {
+    const control = settingControlFor(doNowThresholdHoursOption)
+    expect(control.kind === 'stepper' && control.unit).toBe('h')
+  })
+
+  it('renders an enumeration as a picker whose choices are the declared cases', () => {
+    const control = settingControlFor(earnPointsFormulaOption)
+
+    expect(control.kind).toBe('choice')
+    expect(control.kind === 'choice' && control.choices.map((c) => c.value)).toEqual(
+      earnPointsFormulaOption.type.kind === 'enumeration'
+        ? [...earnPointsFormulaOption.type.cases]
+        : [],
+    )
+  })
+
+  it("draws the accent choice as canon swatch row rather than a dropdown", () => {
+    expect(settingControlFor(accentColorOption).kind).toBe('swatches')
+  })
+
+  it('renders the one string preference as the timezone picker', () => {
+    expect(settingControlFor(timezoneOption)).toEqual({ kind: 'timezone' })
+  })
+
+  it('falls back to a wide range for an int option canon has no Stepper for', () => {
+    const invented = {
+      ...sessionDefaultDurationOption,
+      key: 'session.inventedForThisTest',
+    }
+    expect(settingControlFor(invented)).toEqual({
+      kind: 'stepper',
+      ...DEFAULT_STEPPER_BOUNDS,
+    })
+  })
+})
+
+describe('copy comes from canon, never from the key', () => {
+  it("labels the Do 'now' window with canon curly quotes", () => {
+    expect(settingLabel(doNowThresholdHoursOption)).toBe('“Now” window')
+  })
+
+  it('labels the working-hours start "Start", as canon DatePicker does', () => {
+    expect(settingLabel(workingHoursStartOption)).toBe('Start')
+  })
+
+  it('spaces an unknown key into a readable label rather than dropping the row', () => {
+    expect(
+      settingLabel({ ...hapticsOption, key: 'general.someBrandNewThing' }),
+    ).toBe('Some Brand New Thing')
+  })
+
+  it('delegates enumeration copy to the label function @kro/core exports', () => {
+    expect(settingChoiceLabel('general.appearance', 'system')).toBe('System')
+    expect(settingChoiceLabel('earn.pointsFormula', 'slidingScale')).toBe(
+      'Sliding scale',
+    )
+  })
+
+  it('capitalizes a weekday raw value, as canon Picker does', () => {
+    expect(settingChoiceLabel('general.weekStartDay', 'monday')).toBe('Monday')
+  })
+
+  it('falls back to the raw value for an unmapped enumeration key', () => {
+    expect(settingChoiceLabel('general.somethingElse', 'raw-value')).toBe(
+      'raw-value',
+    )
+  })
+})
+
+describe('the schema decides the badges, not the row', () => {
+  it('marks the theme option device-local — canon "On this device"', () => {
+    const element = settingElementsFor(SettingGroup.general).find(
+      (candidate) => candidate.option.key === appearanceOption.key,
+    )
+
+    expect(element?.isDeviceLocal).toBe(true)
+  })
+
+  it('marks a cloud-scoped option as not device-local — the slot duration', () => {
+    const element = settingElementsFor(SettingGroup.plan).find(
+      (candidate) => candidate.option.key === planDefaultSlotDurationOption.key,
+    )
+
+    expect(element?.isDeviceLocal).toBe(false)
+  })
+
+  it('reports the one consumed General option and marks the rest declared', () => {
+    const elements = settingElementsFor(SettingGroup.general)
+    const consumed = elements.filter((element) => element.isConsumed)
+
+    expect(consumed.map((element) => element.option.key)).toEqual([
+      overdueAlertsOption.key,
+    ])
+  })
+})

--- a/packages/app/src/features/settings/__tests__/SettingsException.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsException.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The settings failure union.
+ *
+ * The assertions worth making about a typed exception are its discriminant, its
+ * recoverability (which decides whether a surface offers a retry) and the fact
+ * that a provider message never becomes user copy — the copy is derived per
+ * `kind` in `SettingsSelectors`, and these keep `message` in its place.
+ */
+import { describe, expect, it } from 'vitest'
+import { SettingsExceptions } from '../SettingsException'
+
+describe('the four cases', () => {
+  it('names an unreadable preference store, and offers a retry', () => {
+    const exception = SettingsExceptions.preferencesUnavailable('quota exceeded')
+
+    expect(exception.kind).toBe('preferencesUnavailable')
+    expect(exception.recoverable).toBe(true)
+  })
+
+  it('names a refused write, and offers a retry', () => {
+    expect(SettingsExceptions.preferenceRejected('bad shape').recoverable).toBe(
+      true,
+    )
+  })
+
+  it('marks an unconfigured deployment unrecoverable — retrying supplies no client', () => {
+    const exception = SettingsExceptions.integrationUnconfigured('GOOGLE_CLIENT_ID')
+
+    expect(exception.kind).toBe('integrationUnconfigured')
+    expect(exception.recoverable).toBe(false)
+  })
+
+  it('marks a failed connect attempt recoverable — the next one may work', () => {
+    expect(SettingsExceptions.integrationUnavailable('502').recoverable).toBe(true)
+  })
+})
+
+describe('the developer message stays developer-facing', () => {
+  it('keeps what it was given, for a log', () => {
+    expect(SettingsExceptions.preferencesUnavailable('quota exceeded').message).toBe(
+      'quota exceeded',
+    )
+  })
+
+  it('defaults to empty rather than to a sentence a surface might print', () => {
+    expect(SettingsExceptions.integrationUnavailable().message).toBe('')
+  })
+
+  it('never carries the message into the kind', () => {
+    expect(SettingsExceptions.preferenceRejected('anything').kind).toBe(
+      'preferenceRejected',
+    )
+  })
+})

--- a/packages/app/src/features/settings/__tests__/SettingsFeature.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsFeature.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The settings slice's synchronous reducer arms, called directly against the
+ * slice's own `reducer` — no store, no middleware (`RC-12`).
+ *
+ * The thunk-lifecycle arms are covered by `SettingsProducer.test.ts`, driven
+ * through the real thunks against stubbed Services (`RC-54`), which is where
+ * they belong: an arm asserted with a hand-built action would pass on a payload
+ * the Producer can no longer produce.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  childAuthDelegatedSignedIn,
+  settingsSlice,
+  userDidDismissAuth,
+  userDidTapBackToHub,
+  userDidTapSection,
+  userDidTapSignIn,
+} from '../SettingsFeature'
+import { SettingsMocks } from '../SettingsMocks'
+import { SettingsSectionId } from '../SettingsSection'
+
+const { reducer, getInitialState } = settingsSlice
+
+describe('userDidTapSection', () => {
+  it('opens the pane the row names — a user taps General', () => {
+    const next = reducer(
+      getInitialState(),
+      userDidTapSection(SettingsSectionId.general),
+    )
+
+    expect(next.pane).toEqual({
+      kind: 'section',
+      section: SettingsSectionId.general,
+    })
+  })
+
+  it('replaces an open pane rather than stacking — Settings has one column here', () => {
+    const first = reducer(
+      getInitialState(),
+      userDidTapSection(SettingsSectionId.general),
+    )
+    const second = reducer(first, userDidTapSection(SettingsSectionId.integrations))
+
+    expect(second.pane).toEqual({
+      kind: 'section',
+      section: SettingsSectionId.integrations,
+    })
+  })
+
+  it('leaves the loaded values untouched — opening a pane reads nothing', () => {
+    const next = reducer(
+      SettingsMocks.loaded,
+      userDidTapSection(SettingsSectionId.sessionPreferences),
+    )
+
+    expect(next.values).toBe(SettingsMocks.loaded.values)
+  })
+})
+
+describe('userDidTapBackToHub', () => {
+  it('returns from a pane to the hub — the back affordance', () => {
+    expect(reducer(SettingsMocks.generalPane, userDidTapBackToHub()).pane).toEqual(
+      { kind: 'hub' },
+    )
+  })
+
+  it('is a no-op on the hub — a stray back press changes nothing', () => {
+    expect(reducer(SettingsMocks.loaded, userDidTapBackToHub()).pane).toEqual({
+      kind: 'hub',
+    })
+  })
+
+  it('does not disturb the Google connection on the way back', () => {
+    const next = reducer(
+      SettingsMocks.integrationsConnected,
+      userDidTapBackToHub(),
+    )
+
+    expect(next.google.connection).toEqual({ kind: 'connected' })
+  })
+})
+
+describe('userDidTapSignIn', () => {
+  it('presents the auth surface from the profile popover', () => {
+    const next = reducer(
+      getInitialState(),
+      userDidTapSignIn({ origin: 'profilePopover' }),
+    )
+
+    expect(next.authPresentation).toEqual({
+      kind: 'presented',
+      origin: 'profilePopover',
+    })
+  })
+
+  it("presents it from the hub's signed-out row, remembering that origin", () => {
+    const next = reducer(
+      SettingsMocks.loaded,
+      userDidTapSignIn({ origin: 'settingsHub' }),
+    )
+
+    expect(next.authPresentation).toEqual({
+      kind: 'presented',
+      origin: 'settingsHub',
+    })
+  })
+
+  it('re-presenting from the other entry point updates the origin', () => {
+    const first = reducer(
+      getInitialState(),
+      userDidTapSignIn({ origin: 'profilePopover' }),
+    )
+    const second = reducer(first, userDidTapSignIn({ origin: 'settingsHub' }))
+
+    expect(second.authPresentation).toEqual({
+      kind: 'presented',
+      origin: 'settingsHub',
+    })
+  })
+})
+
+describe('dismissing the auth surface', () => {
+  it('hides it on Cancel', () => {
+    expect(
+      reducer(SettingsMocks.authPresented, userDidDismissAuth()).authPresentation,
+    ).toEqual({ kind: 'hidden' })
+  })
+
+  it('hides it when the session arrives — the delegated sign-in', () => {
+    expect(
+      reducer(SettingsMocks.authPresented, childAuthDelegatedSignedIn())
+        .authPresentation,
+    ).toEqual({ kind: 'hidden' })
+  })
+
+  it('is a no-op when it was never presented', () => {
+    expect(
+      reducer(SettingsMocks.loaded, userDidDismissAuth()).authPresentation,
+    ).toEqual({ kind: 'hidden' })
+  })
+})

--- a/packages/app/src/features/settings/__tests__/SettingsIntegrations.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsIntegrations.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The Integrations pane's rows — canon `applyItemsLoaded` plus the two states
+ * the web adds.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  IntegrationAction,
+  IntegrationId,
+  googleIntegrationSubtitle,
+  integrationRows,
+} from '../SettingsIntegrations'
+import type { GoogleConnectionState } from '../SettingsState'
+
+const rowsFor = (
+  connection: GoogleConnectionState,
+  overrides: { isBusy?: boolean; isGoogleEnabled?: boolean } = {},
+) =>
+  integrationRows({
+    connection,
+    isBusy: overrides.isBusy ?? false,
+    isGoogleEnabled: overrides.isGoogleEnabled ?? true,
+  })
+
+describe('the row list mirrors canon four items', () => {
+  it('lists Kro Cloud, Google and the two Apple rows, in canon order', () => {
+    expect(rowsFor({ kind: 'disconnected' }).map((row) => row.id)).toEqual([
+      IntegrationId.kroCloud,
+      IntegrationId.google,
+      IntegrationId.appleCalendar,
+      IntegrationId.appleReminders,
+    ])
+  })
+
+  it('omits the Google row when the flag is off — canon flag gate', () => {
+    const ids = rowsFor({ kind: 'disconnected' }, { isGoogleEnabled: false }).map(
+      (row) => row.id,
+    )
+
+    expect(ids).not.toContain(IntegrationId.google)
+    expect(ids).toContain(IntegrationId.kroCloud)
+  })
+
+  it('reports Kro Cloud as always-on with nothing to press', () => {
+    const row = rowsFor({ kind: 'connected' }).find(
+      (candidate) => candidate.id === IntegrationId.kroCloud,
+    )
+
+    expect(row?.isConnected).toBe(true)
+    expect(row?.action).toBe(IntegrationAction.none)
+  })
+})
+
+describe('the Apple rows are ported as canon inert Connects', () => {
+  it('offers no working action on either Apple row', () => {
+    const rows = rowsFor({ kind: 'connected' })
+
+    for (const id of [IntegrationId.appleCalendar, IntegrationId.appleReminders]) {
+      const row = rows.find((candidate) => candidate.id === id)
+      expect(row?.action).toBe(IntegrationAction.unavailable)
+      expect(row?.isConnected).toBe(false)
+    }
+  })
+
+  it('says why rather than repeating canon "EventKit on this device"', () => {
+    const row = rowsFor({ kind: 'connected' }).find(
+      (candidate) => candidate.id === IntegrationId.appleCalendar,
+    )
+
+    expect(row?.subtitle).toContain('Not available on the web')
+  })
+
+  it('keeps them listed even when Google is hidden — the list is not conditional', () => {
+    const ids = rowsFor({ kind: 'disconnected' }, { isGoogleEnabled: false }).map(
+      (row) => row.id,
+    )
+
+    expect(ids).toContain(IntegrationId.appleCalendar)
+    expect(ids).toContain(IntegrationId.appleReminders)
+  })
+})
+
+describe('the Google row distinguishes all four connection states', () => {
+  const googleRow = (
+    connection: GoogleConnectionState,
+    isBusy = false,
+  ) =>
+    rowsFor(connection, { isBusy }).find(
+      (row) => row.id === IntegrationId.google,
+    )
+
+  it('offers Connect to a user who has never granted the scope', () => {
+    expect(googleRow({ kind: 'disconnected' })?.action).toBe(
+      IntegrationAction.connect,
+    )
+  })
+
+  it('offers Disconnect on a live grant', () => {
+    const row = googleRow({ kind: 'connected' })
+    expect(row?.action).toBe(IntegrationAction.disconnect)
+    expect(row?.isConnected).toBe(true)
+  })
+
+  it('offers Reconnect — never Connect — after a grant stops working', () => {
+    expect(googleRow({ kind: 'needsReconnect' })?.action).toBe(
+      IntegrationAction.reconnect,
+    )
+  })
+
+  it('offers nothing pressable on a deployment with no Google client', () => {
+    const row = googleRow({ kind: 'unconfigured', missing: ['GOOGLE_CLIENT_ID'] })
+
+    expect(row?.action).toBe(IntegrationAction.unavailable)
+    expect(row?.subtitle).toContain('no Google client is configured')
+  })
+
+  it('shows the busy affordance while an attempt is in flight', () => {
+    expect(googleRow({ kind: 'disconnected' }, true)?.action).toBe(
+      IntegrationAction.busy,
+    )
+  })
+
+  it('shows the busy affordance before the first answer arrives', () => {
+    expect(googleRow({ kind: 'unknown' })?.action).toBe(IntegrationAction.busy)
+  })
+})
+
+describe('the subtitle explains the state rather than repeating the title', () => {
+  it('keeps canon copy for the disconnected case', () => {
+    expect(googleIntegrationSubtitle({ kind: 'disconnected' })).toBe(
+      'See all your events in one place.',
+    )
+  })
+
+  it('names the deployment problem for an unconfigured build', () => {
+    expect(
+      googleIntegrationSubtitle({ kind: 'unconfigured', missing: [] }),
+    ).toContain('no Google client is configured')
+  })
+
+  it('tells a revoked user what to do rather than what happened', () => {
+    expect(googleIntegrationSubtitle({ kind: 'needsReconnect' })).toContain(
+      'Reconnect',
+    )
+  })
+})

--- a/packages/app/src/features/settings/__tests__/SettingsIntegrations.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsIntegrations.test.ts
@@ -119,12 +119,37 @@ describe('the Google row distinguishes all four connection states', () => {
     )
   })
 
-  it('shows the busy affordance before the first answer arrives', () => {
-    expect(googleRow({ kind: 'unknown' })?.action).toBe(IntegrationAction.busy)
+  it('shows the busy affordance while the first read is in flight', () => {
+    expect(googleRow({ kind: 'unknown' }, true)?.action).toBe(
+      IntegrationAction.busy,
+    )
+  })
+
+  it('never strands the row on "Working…" when the first read failed', () => {
+    // Not busy and still unknown: the read did not answer. The row must offer
+    // something pressable rather than a spinner over work that is not running.
+    const row = googleRow({ kind: 'unknown' })
+
+    expect(row?.action).toBe(IntegrationAction.connect)
+    expect(row?.subtitle).toBe(
+      'We could not check your connection. Try connecting again.',
+    )
   })
 })
 
 describe('the subtitle explains the state rather than repeating the title', () => {
+  it('says it is still asking while a read is in flight', () => {
+    expect(googleIntegrationSubtitle({ kind: 'unknown' }, true)).toBe(
+      'Checking your connection…',
+    )
+  })
+
+  it('says the read did not answer once nothing is in flight', () => {
+    expect(googleIntegrationSubtitle({ kind: 'unknown' })).toContain(
+      'could not check your connection',
+    )
+  })
+
   it('keeps canon copy for the disconnected case', () => {
     expect(googleIntegrationSubtitle({ kind: 'disconnected' })).toBe(
       'See all your events in one place.',

--- a/packages/app/src/features/settings/__tests__/SettingsMocks.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsMocks.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The canned `State` variants stories and render tests share (`RC-31`).
+ *
+ * The point of these assertions is that the mocks are built from the schema
+ * rather than typed out: a default that drifted from `SettingOptions.ts` would
+ * make every green story prove nothing.
+ */
+import {
+  allSettingOptions,
+  sessionDefaultDurationOption,
+  workingHoursEndOption,
+  workingHoursStartOption,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { settingsSlice } from '../SettingsFeature'
+import { SettingsMocks, defaultSettingValues } from '../SettingsMocks'
+
+describe('the default snapshot is the schema, not a copy of it', () => {
+  it('carries one entry per declared option', () => {
+    expect(Object.keys(defaultSettingValues).sort()).toEqual(
+      allSettingOptions.map((option) => option.key).sort(),
+    )
+  })
+
+  it('carries each option declared default value', () => {
+    for (const option of allSettingOptions) {
+      expect(defaultSettingValues[option.key]).toBe(option.defaultValue)
+    }
+  })
+
+  it("reproduces canon 09:00–17:00 working day without typing the numbers", () => {
+    expect(defaultSettingValues[workingHoursStartOption.key]).toBe(9 * 60)
+    expect(defaultSettingValues[workingHoursEndOption.key]).toBe(17 * 60)
+  })
+})
+
+describe('the variants describe distinct, reachable worlds', () => {
+  it('starts from the slice own initial state', () => {
+    expect(SettingsMocks.idle).toEqual(settingsSlice.getInitialState())
+  })
+
+  it('keeps both working-hours values in the invalid variant — canon persists as entered', () => {
+    const values = SettingsMocks.generalPaneInvalidHours.values
+
+    expect(values[workingHoursStartOption.key]).toBe(18 * 60)
+    expect(values[workingHoursEndOption.key]).toBe(9 * 60)
+  })
+
+  it('tunes the Session pane away from every default it claims to change', () => {
+    const values = SettingsMocks.sessionPaneTuned.values
+
+    expect(values[sessionDefaultDurationOption.key]).not.toBe(
+      sessionDefaultDurationOption.defaultValue,
+    )
+    expect(values['session.soundOnEnd']).toBe(false)
+  })
+
+  it('gives each integration variant a different connection', () => {
+    expect(SettingsMocks.integrationsDisconnected.google.connection.kind).toBe(
+      'disconnected',
+    )
+    expect(SettingsMocks.integrationsConnected.google.connection.kind).toBe(
+      'connected',
+    )
+    expect(SettingsMocks.integrationsUnconfigured.google.connection.kind).toBe(
+      'unconfigured',
+    )
+    expect(SettingsMocks.integrationsNeedsReconnect.google.connection.kind).toBe(
+      'needsReconnect',
+    )
+  })
+
+  it('keeps the load-failed variant editable — defaults show, form still works', () => {
+    expect(SettingsMocks.loadFailed.load.kind).toBe('failed')
+    expect(Object.keys(SettingsMocks.loadFailed.values).length).toBeGreaterThan(0)
+  })
+})

--- a/packages/app/src/features/settings/__tests__/SettingsProducer.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsProducer.test.ts
@@ -1,0 +1,326 @@
+/**
+ * The settings Producers, driven through the real thunks against stubbed
+ * Services injected via `extra` (`RC-54`, `RC-35`) — never a mocked `fetch`.
+ */
+import {
+  FeatureFlags,
+  allSettingOptions,
+  disabledAssignment,
+  makeHardcodedFeatureFlagService,
+  sessionDefaultDurationOption,
+  workingHoursEndOption,
+} from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  type ThunkExtra,
+  makeStore,
+  stubbedThunkExtra,
+} from '../../../library/store'
+import { GoogleCalendarConnections } from '../../../services/googleCalendar/GoogleCalendarConnection'
+import { makeStubbedGoogleCalendarService } from '../../../services/googleCalendar/GoogleCalendarService'
+import { makeInMemoryLocalStore } from '../../../services/localStore/InMemoryLocalStore'
+import { makeRecordingNavigationService } from '../../../services/navigation/NavigationService'
+import {
+  connectGoogleThunk,
+  disconnectGoogleThunk,
+  loadGoogleConnectionThunk,
+  loadSettingsThunk,
+  updateSettingThunk,
+} from '../SettingsProducer'
+
+const extraWith = (overrides: Partial<ThunkExtra>): ThunkExtra => ({
+  ...stubbedThunkExtra,
+  ...overrides,
+})
+
+describe('loadSettingsThunk', () => {
+  it('reads every declared option, resolving stored values and defaults alike', async () => {
+    const store = makeStore(
+      extraWith({
+        localStore: makeInMemoryLocalStore({
+          preferences: { 'kro:session.defaultDuration': 45 },
+        }),
+      }),
+    )
+
+    await store.dispatch(loadSettingsThunk())
+    const { values, load } = store.getState().settings
+
+    expect(load).toEqual({ kind: 'loaded' })
+    expect(Object.keys(values)).toHaveLength(allSettingOptions.length)
+    expect(values['session.defaultDuration']).toBe(45)
+    // Untouched keys resolve to the schema's own default, not to undefined.
+    expect(values['session.defaultBreakDuration']).toBe(5)
+  })
+
+  it('resolves the googleCalendar flag in the same pass — enabled at statusQuo', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    await store.dispatch(loadSettingsThunk())
+
+    expect(store.getState().settings.google.isEnabled).toBe(true)
+  })
+
+  it('reports the flag as off when the registry says so', async () => {
+    const store = makeStore(
+      extraWith({
+        featureFlags: makeHardcodedFeatureFlagService({
+          overrides: [disabledAssignment(FeatureFlags.googleCalendar)],
+        }),
+      }),
+    )
+
+    await store.dispatch(loadSettingsThunk())
+
+    expect(store.getState().settings.google.isEnabled).toBe(false)
+  })
+
+  it('degrades to a typed failure when the store cannot be read at all', async () => {
+    const broken = makeInMemoryLocalStore({})
+    const store = makeStore(
+      extraWith({
+        localStore: {
+          ...broken,
+          preferences: {
+            ...broken.preferences,
+            get() {
+              throw new Error('storage disabled')
+            },
+          },
+        },
+      }),
+    )
+
+    await store.dispatch(loadSettingsThunk())
+    const { load } = store.getState().settings
+
+    expect(load.kind).toBe('failed')
+    if (load.kind === 'failed') {
+      expect(load.exception.kind).toBe('preferencesUnavailable')
+    }
+  })
+})
+
+describe('updateSettingThunk', () => {
+  it('persists an accepted value and reflects what the store took', async () => {
+    const localStore = makeInMemoryLocalStore({})
+    const store = makeStore(extraWith({ localStore }))
+
+    await store.dispatch(loadSettingsThunk())
+    await store.dispatch(
+      updateSettingThunk({ key: sessionDefaultDurationOption.key, value: 45 }),
+    )
+
+    expect(store.getState().settings.values['session.defaultDuration']).toBe(45)
+    expect(localStore.preferences.get('kro:session.defaultDuration')).toBe(45)
+  })
+
+  it('refuses a value the option declared shape cannot hold, and says why', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    await store.dispatch(loadSettingsThunk())
+    await store.dispatch(
+      // A `timeOfDay` stores minutes from midnight; a string is not one.
+      updateSettingThunk({ key: workingHoursEndOption.key, value: 'noon' }),
+    )
+
+    const { load, values } = store.getState().settings
+    expect(load.kind).toBe('failed')
+    // The previous value is still what the form shows.
+    expect(values[workingHoursEndOption.key]).toBe(17 * 60)
+  })
+
+  it('refuses a key no option declares rather than writing an orphan row', async () => {
+    const localStore = makeInMemoryLocalStore({})
+    const store = makeStore(extraWith({ localStore }))
+
+    await store.dispatch(
+      updateSettingThunk({ key: 'general.notAnOption', value: true }),
+    )
+
+    expect(localStore.preferences.get('kro:general.notAnOption')).toBeNull()
+    expect(store.getState().settings.load.kind).toBe('failed')
+  })
+
+  it('stores an out-of-order working-hours pair — canon persists as entered', async () => {
+    const store = makeStore(stubbedThunkExtra)
+
+    await store.dispatch(loadSettingsThunk())
+    await store.dispatch(
+      updateSettingThunk({ key: workingHoursEndOption.key, value: 8 * 60 }),
+    )
+
+    expect(store.getState().settings.values[workingHoursEndOption.key]).toBe(
+      8 * 60,
+    )
+    expect(store.getState().settings.load.kind).toBe('loaded')
+  })
+})
+
+describe('loadGoogleConnectionThunk', () => {
+  it('reports a live grant', async () => {
+    const store = makeStore(
+      extraWith({
+        googleCalendar: makeStubbedGoogleCalendarService({
+          connection: GoogleCalendarConnections.connected(['calendar.events']),
+        }),
+      }),
+    )
+
+    await store.dispatch(loadGoogleConnectionThunk())
+
+    // The scope list is deliberately dropped — the pane never reads it.
+    expect(store.getState().settings.google.connection).toEqual({
+      kind: 'connected',
+    })
+  })
+
+  it('reports an unconfigured deployment, keeping what is missing', async () => {
+    const store = makeStore(
+      extraWith({
+        googleCalendar: makeStubbedGoogleCalendarService({
+          connection: GoogleCalendarConnections.unconfigured(['GOOGLE_CLIENT_ID']),
+        }),
+      }),
+    )
+
+    await store.dispatch(loadGoogleConnectionThunk())
+
+    expect(store.getState().settings.google.connection).toEqual({
+      kind: 'unconfigured',
+      missing: ['GOOGLE_CLIENT_ID'],
+    })
+  })
+
+  it('degrades to a typed failure when the status call does not complete', async () => {
+    const store = makeStore(
+      extraWith({
+        googleCalendar: makeStubbedGoogleCalendarService({
+          failure: new Error('502'),
+        }),
+      }),
+    )
+
+    await store.dispatch(loadGoogleConnectionThunk())
+
+    expect(store.getState().settings.google.exception?.kind).toBe(
+      'integrationUnavailable',
+    )
+  })
+})
+
+describe('connectGoogleThunk', () => {
+  it('navigates to the authorization route on a configured deployment', async () => {
+    const navigation = makeRecordingNavigationService()
+    const store = makeStore(
+      extraWith({
+        navigation,
+        googleCalendar: makeStubbedGoogleCalendarService({
+          connection: GoogleCalendarConnections.disconnected(),
+        }),
+      }),
+    )
+
+    await store.dispatch(connectGoogleThunk())
+
+    expect(navigation.calls).toEqual([
+      { kind: 'navigate', path: '/api/google/connect' },
+    ])
+  })
+
+  it('refuses to navigate when the deployment has no Google client', async () => {
+    const navigation = makeRecordingNavigationService()
+    const store = makeStore(
+      extraWith({
+        navigation,
+        googleCalendar: makeStubbedGoogleCalendarService({
+          connection: GoogleCalendarConnections.unconfigured(['GOOGLE_CLIENT_ID']),
+        }),
+      }),
+    )
+
+    await store.dispatch(connectGoogleThunk())
+
+    expect(navigation.calls).toEqual([])
+    expect(store.getState().settings.google.exception?.kind).toBe(
+      'integrationUnconfigured',
+    )
+  })
+
+  it('reports a failure rather than navigating when the status call throws', async () => {
+    const navigation = makeRecordingNavigationService()
+    const store = makeStore(
+      extraWith({
+        navigation,
+        googleCalendar: makeStubbedGoogleCalendarService({
+          failure: new Error('offline'),
+        }),
+      }),
+    )
+
+    await store.dispatch(connectGoogleThunk())
+
+    expect(navigation.calls).toEqual([])
+    expect(store.getState().settings.google.exception?.kind).toBe(
+      'integrationUnavailable',
+    )
+  })
+})
+
+describe('disconnectGoogleThunk', () => {
+  it('revokes the grant and re-reads the state rather than assuming it', async () => {
+    const calls: string[] = []
+    const store = makeStore(
+      extraWith({
+        googleCalendar: makeStubbedGoogleCalendarService({
+          calls,
+          connection: GoogleCalendarConnections.connected(),
+        }),
+      }),
+    )
+
+    await store.dispatch(disconnectGoogleThunk())
+
+    expect(calls).toContain('disconnect')
+    expect(calls.filter((call) => call === 'connection')).toHaveLength(1)
+  })
+
+  it('leaves the working grant on screen when the revoke fails', async () => {
+    const store = makeStore(
+      extraWith({
+        googleCalendar: makeStubbedGoogleCalendarService({
+          connection: GoogleCalendarConnections.connected(),
+        }),
+      }),
+    )
+    await store.dispatch(loadGoogleConnectionThunk())
+
+    const failing = makeStore(
+      extraWith({
+        googleCalendar: makeStubbedGoogleCalendarService({
+          connection: GoogleCalendarConnections.connected(),
+          failure: new Error('502'),
+        }),
+      }),
+    )
+    await failing.dispatch(disconnectGoogleThunk())
+
+    expect(failing.getState().settings.google.exception?.kind).toBe(
+      'integrationUnavailable',
+    )
+  })
+
+  it('stops the spinner whatever the outcome', async () => {
+    const store = makeStore(
+      extraWith({
+        googleCalendar: makeStubbedGoogleCalendarService({
+          failure: new Error('502'),
+        }),
+      }),
+    )
+
+    await store.dispatch(disconnectGoogleThunk())
+
+    expect(store.getState().settings.google.isBusy).toBe(false)
+  })
+})

--- a/packages/app/src/features/settings/__tests__/SettingsSection.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsSection.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The hub's information architecture — canon `SettingsFeature.Section` and the
+ * three groups `SettingsHubScreen` sorts them into.
+ */
+import { SettingGroup, settingGroups } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  SettingsHubGroup,
+  SettingsPaneKind,
+  SettingsSectionId,
+  settingsPaneKind,
+  settingsSectionForId,
+  settingsSectionTitle,
+  settingsSections,
+  settingsSectionsIn,
+} from '../SettingsSection'
+
+describe('the hub groups match canon three sections', () => {
+  it('lists Profile alone at the top, as canon unlabelled first Section does', () => {
+    expect(settingsSectionsIn(SettingsHubGroup.profile).map((s) => s.id)).toEqual([
+      SettingsSectionId.profile,
+    ])
+  })
+
+  it('lists the five preference panes under Preferences, in canon order', () => {
+    expect(
+      settingsSectionsIn(SettingsHubGroup.preferences).map((s) => s.title),
+    ).toEqual([
+      'General',
+      'Plan Preferences',
+      'Do Preferences',
+      'Earn Preferences',
+      'Session Preferences',
+    ])
+  })
+
+  it('lists Integrations then Subscription in the account group', () => {
+    expect(settingsSectionsIn(SettingsHubGroup.account).map((s) => s.id)).toEqual([
+      SettingsSectionId.integrations,
+      SettingsSectionId.subscription,
+    ])
+  })
+
+  it('places every declared section in exactly one group', () => {
+    const grouped = [
+      ...settingsSectionsIn(SettingsHubGroup.profile),
+      ...settingsSectionsIn(SettingsHubGroup.preferences),
+      ...settingsSectionsIn(SettingsHubGroup.account),
+    ]
+
+    expect(grouped.map((s) => s.id).sort()).toEqual(
+      settingsSections.map((s) => s.id).sort(),
+    )
+  })
+})
+
+describe('a preferences section names the schema group it renders', () => {
+  it('covers every schema group exactly once across the five panes', () => {
+    const covered = settingsSections
+      .map((section) => section.settingGroup)
+      .filter((group): group is SettingGroup => group !== null)
+
+    expect([...covered].sort()).toEqual([...settingGroups].sort())
+  })
+
+  it('points the General pane at the general group', () => {
+    expect(settingsSectionForId('general')?.settingGroup).toBe(
+      SettingGroup.general,
+    )
+  })
+
+  it('leaves the three non-schema sections without a group', () => {
+    for (const id of ['profile', 'integrations', 'subscription']) {
+      expect(settingsSectionForId(id)?.settingGroup).toBeNull()
+    }
+  })
+})
+
+describe('glyphs and titles are canon own', () => {
+  it("uses canon person glyph for Profile and creditcard for Subscription", () => {
+    expect(settingsSectionForId('profile')?.glyph).toBe('person.crop.circle')
+    expect(settingsSectionForId('subscription')?.glyph).toBe('creditcard')
+  })
+
+  it('titles a pane with the same string its hub row shows', () => {
+    expect(settingsSectionTitle(SettingsSectionId.sessionPreferences)).toBe(
+      'Session Preferences',
+    )
+  })
+
+  it('answers null for an id nothing declares', () => {
+    expect(settingsSectionForId('notASection')).toBeNull()
+  })
+})
+
+describe('pane kinds route the surface', () => {
+  it('routes the five schema panes to the preferences renderer', () => {
+    for (const id of [
+      SettingsSectionId.general,
+      SettingsSectionId.planPreferences,
+      SettingsSectionId.doPreferences,
+      SettingsSectionId.earnPreferences,
+      SettingsSectionId.sessionPreferences,
+    ]) {
+      expect(settingsPaneKind(id)).toBe(SettingsPaneKind.preferences)
+    }
+  })
+
+  it('routes Integrations to its own renderer', () => {
+    expect(settingsPaneKind(SettingsSectionId.integrations)).toBe(
+      SettingsPaneKind.integrations,
+    )
+  })
+
+  it('routes Profile and Subscription to the account renderer', () => {
+    expect(settingsPaneKind(SettingsSectionId.profile)).toBe(
+      SettingsPaneKind.profile,
+    )
+    expect(settingsPaneKind(SettingsSectionId.subscription)).toBe(
+      SettingsPaneKind.subscription,
+    )
+  })
+})

--- a/packages/app/src/features/settings/__tests__/SettingsSelectors.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsSelectors.test.ts
@@ -1,0 +1,247 @@
+/**
+ * The settings Selectors, against a hand-built root state — never a live store
+ * (`RC-55`).
+ *
+ * The root is composed from `makeStore(stubbedThunkExtra).getState()` plus the
+ * two feature mock sets this suite actually asserts on. That is deliberately
+ * not a hand-assembled object literal of twelve `initial…State` values: this
+ * feature's Selectors compose across `settings` and `auth`, and a literal would
+ * have to be edited by every future slice registration for a suite that says
+ * nothing about them. The store is built once, read once, and never dispatched
+ * to — so nothing here depends on reducer behaviour.
+ */
+import { workingHoursEndOption, workingHoursStartOption } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import { AuthMocks } from '../../auth/AuthMocks'
+import type { AuthState } from '../../auth/AuthState'
+import {
+  type RootState,
+  makeStore,
+  stubbedThunkExtra,
+} from '../../../library/store'
+import { SettingsExceptions } from '../SettingsException'
+import { SettingsMocks, defaultSettingValues } from '../SettingsMocks'
+import { IntegrationAction, IntegrationId } from '../SettingsIntegrations'
+import { SettingsSectionId } from '../SettingsSection'
+import {
+  accountHubSections,
+  preferencesHubSections,
+  profileHubSection,
+  selectIntegrationRows,
+  selectIsSettingsLoaded,
+  selectOpenSection,
+  selectSettingValues,
+  selectSettingsErrorCopy,
+  selectSettingsSyncFooter,
+  selectWorkingHoursValid,
+  settingValueIn,
+} from '../SettingsSelectors'
+import type { SettingsState } from '../SettingsState'
+
+const emptyRoot: RootState = makeStore(stubbedThunkExtra).getState()
+
+const rootWith = (settings: SettingsState, auth: AuthState = AuthMocks.signedOut): RootState => ({
+  ...emptyRoot,
+  auth,
+  settings,
+})
+
+describe('the load lifecycle', () => {
+  it('reports not-loaded before the snapshot is asked for', () => {
+    expect(selectIsSettingsLoaded(rootWith(SettingsMocks.idle))).toBe(false)
+  })
+
+  it('reports not-loaded while the read is in flight', () => {
+    expect(selectIsSettingsLoaded(rootWith(SettingsMocks.loading))).toBe(false)
+  })
+
+  it('reports loaded once the values arrive', () => {
+    expect(selectIsSettingsLoaded(rootWith(SettingsMocks.loaded))).toBe(true)
+  })
+})
+
+describe('the failure copy is derived from the kind', () => {
+  it('tells the user defaults are showing when the store cannot be read', () => {
+    expect(selectSettingsErrorCopy(rootWith(SettingsMocks.loadFailed))).toBe(
+      'Your preferences could not be read on this device. Defaults are shown.',
+    )
+  })
+
+  it('reports an integration failure without repeating the transport message', () => {
+    const copy = selectSettingsErrorCopy(
+      rootWith(SettingsMocks.integrationsFailed),
+    )
+
+    expect(copy).toBe('The connection could not be changed. Please try again.')
+    expect(copy).not.toContain('502')
+  })
+
+  it('says nothing when nothing has failed', () => {
+    expect(selectSettingsErrorCopy(rootWith(SettingsMocks.loaded))).toBeNull()
+  })
+
+  it('names the deployment for an unconfigured integration', () => {
+    const settings: SettingsState = {
+      ...SettingsMocks.loaded,
+      google: {
+        ...SettingsMocks.loaded.google,
+        exception: SettingsExceptions.integrationUnconfigured(''),
+      },
+    }
+
+    expect(selectSettingsErrorCopy(rootWith(settings))).toContain(
+      'not configured for this deployment',
+    )
+  })
+})
+
+describe('reading one option value', () => {
+  it('answers the snapshot value when the key is present', () => {
+    const values = selectSettingValues(rootWith(SettingsMocks.sessionPaneTuned))
+    expect(values['session.defaultDuration']).toBe(45)
+  })
+
+  it('falls back to the declared default when the key is absent', () => {
+    expect(settingValueIn({}, workingHoursStartOption)).toBe(9 * 60)
+  })
+
+  it('answers null for a stored null rather than substituting the default', () => {
+    expect(settingValueIn({ 'general.timezone': null }, {
+      ...workingHoursStartOption,
+      key: 'general.timezone',
+    })).toBeNull()
+  })
+})
+
+describe('the working-hours warning', () => {
+  it('is silent on the defaults — 09:00 to 17:00', () => {
+    expect(selectWorkingHoursValid(rootWith(SettingsMocks.loaded))).toBe(true)
+  })
+
+  it('warns when the end is before the start, with both values persisting', () => {
+    const root = rootWith(SettingsMocks.generalPaneInvalidHours)
+
+    expect(selectWorkingHoursValid(root)).toBe(false)
+    expect(selectSettingValues(root)['general.workingHoursStart']).toBe(18 * 60)
+    expect(selectSettingValues(root)['general.workingHoursEnd']).toBe(9 * 60)
+  })
+
+  it('warns on an empty day — canon rule is "not after", not "before"', () => {
+    const settings: SettingsState = {
+      ...SettingsMocks.loaded,
+      values: {
+        ...defaultSettingValues,
+        [workingHoursStartOption.key]: 9 * 60,
+        [workingHoursEndOption.key]: 9 * 60,
+      },
+    }
+
+    expect(selectWorkingHoursValid(rootWith(settings))).toBe(false)
+  })
+
+  it('stays silent while the snapshot has not arrived', () => {
+    expect(selectWorkingHoursValid(rootWith(SettingsMocks.idle))).toBe(true)
+  })
+})
+
+describe('the open pane', () => {
+  it('is null on the hub', () => {
+    expect(selectOpenSection(rootWith(SettingsMocks.loaded))).toBeNull()
+  })
+
+  it('names the General pane when it is open', () => {
+    expect(selectOpenSection(rootWith(SettingsMocks.generalPane))).toBe(
+      SettingsSectionId.general,
+    )
+  })
+
+  it('names the Integrations pane when it is open', () => {
+    expect(
+      selectOpenSection(rootWith(SettingsMocks.integrationsDisconnected)),
+    ).toBe(SettingsSectionId.integrations)
+  })
+})
+
+describe('the integration rows', () => {
+  it('offers Connect on a configured, unconnected deployment', () => {
+    const rows = selectIntegrationRows(
+      rootWith(SettingsMocks.integrationsDisconnected),
+    )
+
+    expect(rows.find((row) => row.id === IntegrationId.google)?.action).toBe(
+      IntegrationAction.connect,
+    )
+  })
+
+  it('offers nothing pressable on an unconfigured deployment', () => {
+    const rows = selectIntegrationRows(
+      rootWith(SettingsMocks.integrationsUnconfigured),
+    )
+
+    expect(rows.find((row) => row.id === IntegrationId.google)?.action).toBe(
+      IntegrationAction.unavailable,
+    )
+  })
+
+  it('offers Disconnect on a live grant', () => {
+    const rows = selectIntegrationRows(
+      rootWith(SettingsMocks.integrationsConnected),
+    )
+
+    expect(rows.find((row) => row.id === IntegrationId.google)?.action).toBe(
+      IntegrationAction.disconnect,
+    )
+  })
+})
+
+describe('the hub sync footer, composed from the auth slice', () => {
+  it('hides itself before anything has been attempted', () => {
+    expect(
+      selectSettingsSyncFooter(rootWith(SettingsMocks.loaded, AuthMocks.signedIn)),
+    ).toBeNull()
+  })
+
+  it('reports a successful sync without a warning tint', () => {
+    const footer = selectSettingsSyncFooter(
+      rootWith(SettingsMocks.loaded, AuthMocks.settingsSynced),
+    )
+
+    expect(footer?.title).toBe('Synced')
+    expect(footer?.isWarning).toBe(false)
+  })
+
+  it('warns, in canon words, when the last attempt had no connection', () => {
+    const footer = selectSettingsSyncFooter(
+      rootWith(SettingsMocks.loaded, AuthMocks.settingsOffline),
+    )
+
+    expect(footer?.title).toBe('Offline — will sync later')
+    expect(footer?.isWarning).toBe(true)
+  })
+
+  it('prompts rather than warns when signed out', () => {
+    const footer = selectSettingsSyncFooter(
+      rootWith(SettingsMocks.loaded, AuthMocks.signedOutWithPendingIntents),
+    )
+
+    expect(footer?.title).toBe('Sign in to sync across devices')
+    expect(footer?.isWarning).toBe(false)
+  })
+})
+
+describe('the hub groups', () => {
+  it('exposes one profile row', () => {
+    expect(profileHubSection.id).toBe(SettingsSectionId.profile)
+  })
+
+  it('exposes the five preference rows', () => {
+    expect(preferencesHubSections).toHaveLength(5)
+  })
+
+  it('exposes the two account rows', () => {
+    expect(accountHubSections.map((section) => section.id)).toEqual([
+      SettingsSectionId.integrations,
+      SettingsSectionId.subscription,
+    ])
+  })
+})

--- a/packages/app/src/features/settings/__tests__/SettingsSelectors.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsSelectors.test.ts
@@ -28,6 +28,7 @@ import {
   preferencesHubSections,
   profileHubSection,
   selectIntegrationRows,
+  selectIsSettingsEditable,
   selectIsSettingsLoaded,
   selectOpenSection,
   selectSettingValues,
@@ -57,6 +58,30 @@ describe('the load lifecycle', () => {
 
   it('reports loaded once the values arrive', () => {
     expect(selectIsSettingsLoaded(rootWith(SettingsMocks.loaded))).toBe(true)
+  })
+
+  it('reports not-loaded when the read failed — the values never arrived', () => {
+    expect(selectIsSettingsLoaded(rootWith(SettingsMocks.loadFailed))).toBe(false)
+  })
+})
+
+describe('whether the form may be edited', () => {
+  it('locks the form before anything has been read', () => {
+    expect(selectIsSettingsEditable(rootWith(SettingsMocks.idle))).toBe(false)
+  })
+
+  it('locks it while a read is in flight — canon own pre-load guard', () => {
+    expect(selectIsSettingsEditable(rootWith(SettingsMocks.loading))).toBe(false)
+  })
+
+  it('unlocks it once the values arrive', () => {
+    expect(selectIsSettingsEditable(rootWith(SettingsMocks.loaded))).toBe(true)
+  })
+
+  it('unlocks it when the read FAILED — canon: defaults show and edits still save', () => {
+    // The guard exists to stop an in-flight load overwriting an edit. A failed
+    // load is not in flight, so there is nothing left to overwrite.
+    expect(selectIsSettingsEditable(rootWith(SettingsMocks.loadFailed))).toBe(true)
   })
 })
 

--- a/packages/app/src/features/settings/__tests__/SettingsShifters.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsShifters.test.ts
@@ -1,0 +1,182 @@
+/**
+ * The settings Shifters — pure, no store, no dispatch, no timers (`RC-56`).
+ */
+import { describe, expect, it } from 'vitest'
+import { SettingsExceptions } from '../SettingsException'
+import { SettingsSectionId } from '../SettingsSection'
+import {
+  withAuthDismissed,
+  withAuthPresented,
+  withGoogleBusy,
+  withGoogleConnection,
+  withGoogleEnabled,
+  withGoogleFailed,
+  withPaneClosed,
+  withPaneOpened,
+  withPreferencesFailed,
+  withPreferencesLoaded,
+  withPreferencesLoading,
+  withSettingValue,
+} from '../SettingsShifters'
+import { initialSettingsState } from '../SettingsState'
+
+const base = initialSettingsState
+
+describe('withPreferencesLoading', () => {
+  it('moves an untouched surface into loading — first open', () => {
+    expect(withPreferencesLoading(base).load).toEqual({ kind: 'loading' })
+  })
+
+  it('clears a previous failure so a retry starts clean', () => {
+    const failed = withPreferencesFailed(
+      base,
+      SettingsExceptions.preferencesUnavailable('quota'),
+    )
+
+    expect(withPreferencesLoading(failed).load).toEqual({ kind: 'loading' })
+  })
+
+  it('leaves the values alone — a reload must not blank the form', () => {
+    const loaded = withPreferencesLoaded(base, { 'general.haptics': true })
+
+    expect(withPreferencesLoading(loaded).values).toEqual({
+      'general.haptics': true,
+    })
+  })
+})
+
+describe('withPreferencesLoaded', () => {
+  it('records the snapshot and reports loaded — the ordinary open', () => {
+    const next = withPreferencesLoaded(base, { 'session.defaultDuration': 20 })
+
+    expect(next.load).toEqual({ kind: 'loaded' })
+    expect(next.values['session.defaultDuration']).toBe(20)
+  })
+
+  it('replaces rather than merges, so a wiped key does not survive on screen', () => {
+    const first = withPreferencesLoaded(base, { 'general.haptics': true })
+    const second = withPreferencesLoaded(first, { 'general.streakReminders': false })
+
+    expect('general.haptics' in second.values).toBe(false)
+  })
+
+  it('accepts an empty snapshot — a store with nothing stored yet', () => {
+    expect(withPreferencesLoaded(base, {}).values).toEqual({})
+  })
+})
+
+describe('withSettingValue', () => {
+  it('records one accepted write without touching its neighbours', () => {
+    const loaded = withPreferencesLoaded(base, {
+      'session.defaultDuration': 20,
+      'session.defaultBreakDuration': 5,
+    })
+    const next = withSettingValue(loaded, 'session.defaultDuration', 45)
+
+    expect(next.values['session.defaultDuration']).toBe(45)
+    expect(next.values['session.defaultBreakDuration']).toBe(5)
+  })
+
+  it('records a null — an option cleared back to "unset"', () => {
+    const next = withSettingValue(base, 'general.timezone', null)
+    expect(next.values['general.timezone']).toBeNull()
+  })
+
+  it('is a no-op in effect when the value is unchanged', () => {
+    const loaded = withPreferencesLoaded(base, { 'general.haptics': true })
+    expect(withSettingValue(loaded, 'general.haptics', true).values).toEqual(
+      loaded.values,
+    )
+  })
+})
+
+describe('pane navigation', () => {
+  it('opens a section from the hub', () => {
+    expect(withPaneOpened(base, SettingsSectionId.general).pane).toEqual({
+      kind: 'section',
+      section: SettingsSectionId.general,
+    })
+  })
+
+  it('replaces one open pane with another rather than stacking', () => {
+    const first = withPaneOpened(base, SettingsSectionId.general)
+    const second = withPaneOpened(first, SettingsSectionId.integrations)
+
+    expect(second.pane).toEqual({
+      kind: 'section',
+      section: SettingsSectionId.integrations,
+    })
+  })
+
+  it('returns to the hub, and is a no-op when already there', () => {
+    const open = withPaneOpened(base, SettingsSectionId.profile)
+
+    expect(withPaneClosed(open).pane).toEqual({ kind: 'hub' })
+    expect(withPaneClosed(base).pane).toEqual({ kind: 'hub' })
+  })
+})
+
+describe('the Google integration', () => {
+  it('records an answer and ends the attempt that asked for it', () => {
+    const busy = withGoogleBusy(base)
+    const next = withGoogleConnection(busy, { kind: 'connected' })
+
+    expect(next.google.connection).toEqual({ kind: 'connected' })
+    expect(next.google.isBusy).toBe(false)
+    expect(next.google.exception).toBeNull()
+  })
+
+  it('spins and clears the previous error when an attempt starts', () => {
+    const failed = withGoogleFailed(
+      base,
+      SettingsExceptions.integrationUnavailable('502'),
+    )
+    const next = withGoogleBusy(failed)
+
+    expect(next.google.isBusy).toBe(true)
+    expect(next.google.exception).toBeNull()
+  })
+
+  it('leaves a working grant untouched when an attempt fails', () => {
+    const connected = withGoogleConnection(base, { kind: 'connected' })
+    const next = withGoogleFailed(
+      connected,
+      SettingsExceptions.integrationUnavailable('502'),
+    )
+
+    expect(next.google.connection).toEqual({ kind: 'connected' })
+    expect(next.google.isBusy).toBe(false)
+    expect(next.google.exception?.kind).toBe('integrationUnavailable')
+  })
+
+  it('records the flag without disturbing the connection', () => {
+    const connected = withGoogleConnection(base, { kind: 'needsReconnect' })
+    const next = withGoogleEnabled(connected, true)
+
+    expect(next.google.isEnabled).toBe(true)
+    expect(next.google.connection).toEqual({ kind: 'needsReconnect' })
+  })
+})
+
+describe('the auth presentation', () => {
+  it('remembers which entry point opened it — the popover', () => {
+    expect(withAuthPresented(base, 'profilePopover').authPresentation).toEqual({
+      kind: 'presented',
+      origin: 'profilePopover',
+    })
+  })
+
+  it('remembers the hub as an origin too', () => {
+    expect(withAuthPresented(base, 'settingsHub').authPresentation).toEqual({
+      kind: 'presented',
+      origin: 'settingsHub',
+    })
+  })
+
+  it('hides it, and is a no-op when already hidden', () => {
+    const shown = withAuthPresented(base, 'settingsHub')
+
+    expect(withAuthDismissed(shown).authPresentation).toEqual({ kind: 'hidden' })
+    expect(withAuthDismissed(base).authPresentation).toEqual({ kind: 'hidden' })
+  })
+})

--- a/packages/app/src/features/settings/__tests__/SettingsState.test.ts
+++ b/packages/app/src/features/settings/__tests__/SettingsState.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The settings slice's initial shape.
+ *
+ * These pin the two decisions the shape encodes: nothing is claimed before it
+ * is known (`unknown`, `idle`, `hidden`), and the four lifecycles are separate
+ * fields so a failure in one cannot describe another.
+ */
+import { describe, expect, it } from 'vitest'
+import { SUBSCRIPTION_PLAN_NAME, initialSettingsState } from '../SettingsState'
+
+describe('the initial state claims nothing it does not know', () => {
+  it('has not read the preference store yet', () => {
+    expect(initialSettingsState.load).toEqual({ kind: 'idle' })
+    expect(initialSettingsState.values).toEqual({})
+  })
+
+  it('reports the Google connection as unknown, never as unconfigured', () => {
+    // The two are different: `unconfigured` says the deployment is broken, and
+    // saying that before asking would be wrong on every correct deployment.
+    expect(initialSettingsState.google.connection).toEqual({ kind: 'unknown' })
+  })
+
+  it('opens on the hub with no auth surface presented', () => {
+    expect(initialSettingsState.pane).toEqual({ kind: 'hub' })
+    expect(initialSettingsState.authPresentation).toEqual({ kind: 'hidden' })
+  })
+
+  it('treats the googleCalendar flag as off until it is resolved', () => {
+    expect(initialSettingsState.google.isEnabled).toBe(false)
+    expect(initialSettingsState.google.isBusy).toBe(false)
+    expect(initialSettingsState.google.exception).toBeNull()
+  })
+})
+
+describe('the subscription plan is a constant, because canon has no flow', () => {
+  it('names the only tier that exists', () => {
+    expect(SUBSCRIPTION_PLAN_NAME).toBe('Free')
+  })
+})

--- a/packages/app/src/features/settings/index.ts
+++ b/packages/app/src/features/settings/index.ts
@@ -79,6 +79,7 @@ export {
   selectGoogleIntegration,
   selectIntegrationRows,
   selectIsAuthPresented,
+  selectIsSettingsEditable,
   selectIsSettingsLoaded,
   selectOpenSection,
   selectSettingValues,

--- a/packages/app/src/features/settings/index.ts
+++ b/packages/app/src/features/settings/index.ts
@@ -1,0 +1,118 @@
+/**
+ * The Settings feature (KC-IS-#32) — the hub, the five schema-driven preference
+ * panes, Integrations, the two Account panes, the profile popover and the auth
+ * surface's presentation.
+ *
+ * A pure re-export barrel. Everything it names is defined in this folder; the
+ * only thing that reaches beyond it is `apps/web`'s `/adjust` route, which
+ * mounts `SettingsHubPage`.
+ */
+export {
+  SettingsHubGroup,
+  SettingsPaneKind,
+  SettingsSectionId,
+  type SettingsSection,
+  settingsPaneKind,
+  settingsSectionForId,
+  settingsSectionTitle,
+  settingsSections,
+  settingsSectionsIn,
+} from './SettingsSection'
+export {
+  DEFAULT_STEPPER_BOUNDS,
+  OTHER_SUBGROUP_ID,
+  type SettingChoice,
+  type SettingControl,
+  type SettingElement,
+  type SettingSubgroup,
+  settingChoiceLabel,
+  settingControlFor,
+  settingElementsFor,
+  settingLabel,
+  settingSubgroupsFor,
+} from './SettingsElements'
+export {
+  IntegrationAction,
+  IntegrationId,
+  type IntegrationRow,
+  type IntegrationRowsInput,
+  googleIntegrationSubtitle,
+  integrationRows,
+} from './SettingsIntegrations'
+export {
+  type SettingsException,
+  SettingsExceptions,
+} from './SettingsException'
+export {
+  SUBSCRIPTION_PLAN_NAME,
+  type AuthPresentationState,
+  type GoogleConnectionState,
+  type GoogleIntegrationState,
+  type SettingsLoadState,
+  type SettingsPaneState,
+  type SettingsState,
+  initialSettingsState,
+} from './SettingsState'
+export {
+  childAuthDelegatedSignedIn,
+  settingsSlice,
+  userDidDismissAuth,
+  userDidTapBackToHub,
+  userDidTapSection,
+  userDidTapSignIn,
+} from './SettingsFeature'
+export {
+  type SettingWriteResult,
+  type SettingsSnapshot,
+  connectGoogleThunk,
+  disconnectGoogleThunk,
+  loadGoogleConnectionThunk,
+  loadSettingsThunk,
+  updateSettingThunk,
+} from './SettingsProducer'
+export {
+  type SettingsSyncFooter,
+  accountHubSections,
+  preferencesHubSections,
+  profileHubSection,
+  selectAuthPresentation,
+  selectGoogleIntegration,
+  selectIntegrationRows,
+  selectIsAuthPresented,
+  selectIsSettingsLoaded,
+  selectOpenSection,
+  selectSettingValues,
+  selectSettingsErrorCopy,
+  selectSettingsException,
+  selectSettingsLoad,
+  selectSettingsPane,
+  selectSettingsSyncFooter,
+  selectWorkingHoursValid,
+  settingValueIn,
+} from './SettingsSelectors'
+export { SettingsMocks, defaultSettingValues } from './SettingsMocks'
+
+// --- the render tier -------------------------------------------------------
+export { SettingsHubPage } from './pages/SettingsHubPage'
+export { ProfileControlPage } from './pages/ProfileControlPage'
+export {
+  type SettingsHubFragmentProps,
+  SettingsHubFragment,
+} from './pages/SettingsHubFragment'
+export {
+  type PreferencesSectionFragmentProps,
+  PreferencesSectionFragment,
+} from './pages/PreferencesSectionFragment'
+export {
+  type IntegrationsSectionFragmentProps,
+  IntegrationsSectionFragment,
+} from './pages/IntegrationsSectionFragment'
+export {
+  type AccountPane,
+  type AccountSectionFragmentProps,
+  AccountSectionFragment,
+} from './pages/AccountSectionFragment'
+export {
+  type ProfilePopoverFragmentProps,
+  ProfilePopoverFragment,
+} from './pages/ProfilePopoverFragment'

--- a/packages/app/src/features/settings/pages/AccountSectionFragment.stories.tsx
+++ b/packages/app/src/features/settings/pages/AccountSectionFragment.stories.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from 'react'
+import { authUserMocks } from '../../auth/AuthMocks'
+import { AccountSectionFragment } from './AccountSectionFragment'
+
+/**
+ * The Profile and Subscription panes.
+ *
+ * The Subscription story is the point of the *"canon has a row, no flow —
+ * mirror it"* instruction: it is one row and one sentence, and it says why
+ * there is nothing to press rather than offering a button wired to nothing.
+ */
+export default {
+  title: 'Settings/Account',
+  component: AccountSectionFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+const noop = () => {}
+
+function Stage({
+  theme = 'light',
+  width = 760,
+  children,
+}: {
+  theme?: 'light' | 'dark'
+  width?: number
+  children: ReactNode
+}) {
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        width,
+        padding: 16,
+        background: 'var(--kro-color-back)',
+        border: '1px solid var(--kro-color-hairline)',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+const pane = (
+  overrides: Partial<Parameters<typeof AccountSectionFragment>[0]> = {},
+) => (
+  <AccountSectionFragment
+    pane="profile"
+    user={authUserMocks.typical}
+    onTapSignIn={noop}
+    onTapSignOut={noop}
+    {...overrides}
+  />
+)
+
+/** The signed-in Profile pane. */
+export const Profile = {
+  render: () => <Stage>{pane()}</Stage>,
+}
+
+/** An account with two connected providers and no personal info set. */
+export const ProfileWithTwoProviders = {
+  render: () => <Stage>{pane({ user: authUserMocks.google })}</Stage>,
+}
+
+/** An account with no display name at all — initials fall back to the email. */
+export const ProfileUnnamed = {
+  render: () => <Stage>{pane({ user: authUserMocks.unnamed })}</Stage>,
+}
+
+/** Signed out — canon's placeholder, with a way out of it. */
+export const ProfileSignedOut = {
+  render: () => <Stage>{pane({ user: null })}</Stage>,
+}
+
+/** Subscription: canon's row, and no flow behind it. */
+export const Subscription = {
+  render: () => <Stage>{pane({ pane: 'subscription' })}</Stage>,
+}
+
+/** Both schemes on the signed-in pane. */
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Stage theme="light" width={520}>
+        {pane()}
+      </Stage>
+      <Stage theme="dark" width={520}>
+        {pane()}
+      </Stage>
+    </div>
+  ),
+}
+
+/** The handheld width. */
+export const Handheld = {
+  render: () => <Stage width={390}>{pane()}</Stage>,
+}

--- a/packages/app/src/features/settings/pages/AccountSectionFragment.tsx
+++ b/packages/app/src/features/settings/pages/AccountSectionFragment.tsx
@@ -1,0 +1,308 @@
+'use client'
+
+/**
+ * The two Account-group panes — canon `ProfileView` and `SubscriptionView`
+ * (`RC-15`: passive; every intent is a callback prop).
+ *
+ * One Fragment for both because neither is schema-driven and both are static
+ * reads of the session: Profile lists what the account says about itself and
+ * offers Sign Out, Subscription lists a plan name. Splitting them would be two
+ * files whose only difference is which four labels they print.
+ *
+ * ## What is deliberately absent
+ *
+ * Canon's Profile pane also offers **Edit Profile** and **Request Data
+ * Deletion**. Both write to the account, and the auth/sync engine (KC-IS-#31)
+ * ships neither a profile update nor a deletion request — so porting the
+ * buttons would mean inventing the flows behind them. Canon's Subscription
+ * pane is the same shape and says so out loud: it has a row, a "Manage
+ * Subscription" button wired to nothing, and no store. This port mirrors that
+ * honestly rather than pretending: the rows are here, the flows are not, and
+ * the pane says which.
+ */
+import {
+  type AuthProvider,
+  type User,
+  authProviderDisplayName,
+  authProviderIcon,
+  primaryEmail,
+  userInitials,
+} from '@kro/core'
+import type { ReactNode } from 'react'
+import { colorVar } from '../../../design/system/tokens/roles'
+import { SurfaceCard } from '../../../design/endeavor/SurfaceCard'
+import { cn } from '../../../design/system/utils/cn'
+import { SUBSCRIPTION_PLAN_NAME } from '../SettingsState'
+import { Avatar } from './SettingsHubFragment'
+import { settingsIcon } from './settingsIcons'
+
+export type AccountPane = 'profile' | 'subscription'
+
+export interface AccountSectionFragmentProps {
+  readonly pane: AccountPane
+  /** `null` is canon's unauthenticated placeholder. */
+  readonly user: User | null
+  readonly onTapSignIn: () => void
+  readonly onTapSignOut: () => void
+}
+
+export function AccountSectionFragment({
+  pane,
+  user,
+  onTapSignIn,
+  onTapSignOut,
+}: AccountSectionFragmentProps) {
+  if (pane === 'subscription') return <SubscriptionPane />
+  if (user === null) return <UnauthenticatedPane onTapSignIn={onTapSignIn} />
+  return <ProfilePane user={user} onTapSignOut={onTapSignOut} />
+}
+
+// ---------------------------------------------------------------------------
+// Profile
+// ---------------------------------------------------------------------------
+
+function ProfilePane({
+  user,
+  onTapSignOut,
+}: {
+  readonly user: User
+  readonly onTapSignOut: () => void
+}) {
+  const email = primaryEmail(user)
+  // `authProviderIcon` answers an `IconRepresentation`; every provider's is a
+  // glyph today, and the `emoji` arm is handled rather than asserted away.
+  const providerIcon = authProviderIcon(user.authProvider)
+  const ProviderIcon = settingsIcon(
+    providerIcon.type === 'glyph' ? providerIcon.name : '',
+  )
+
+  return (
+    <div
+      data-testid="account-section"
+      data-pane="profile"
+      className="flex w-full flex-col gap-kro-large"
+    >
+      <SurfaceCard>
+        <div className="flex w-full flex-col items-center gap-kro-small py-kro-medium">
+          <Avatar initials={userInitials(user)} isSignedIn size={96} />
+          <span
+            className="text-xl font-semibold"
+            style={{ color: colorVar('fore') }}
+          >
+            {user.name ?? 'Kro User'}
+          </span>
+          <span className="text-[15px]" style={{ color: colorVar('foreSecondary') }}>
+            {email}
+          </span>
+        </div>
+      </SurfaceCard>
+
+      <Group title="Account">
+        <Row label="Name" value={user.name ?? '—'} />
+        <Row label="Email" value={email} />
+        {user.username === null ? null : (
+          <Row label="Username" value={`@${user.username}`} />
+        )}
+        <Row label="Member since" value={dateLabel(user.createdAt)} />
+      </Group>
+
+      <Group title="Personal Info">
+        <Row
+          label="Birthday"
+          value={user.birthDate === null ? 'Not set' : dateLabel(user.birthDate)}
+        />
+        <Row label="Nationality" value={user.nationality ?? 'Not set'} />
+      </Group>
+
+      <Group title="Sign-In">
+        <Row
+          label="Method"
+          value={authProviderDisplayName(user.authProvider)}
+          icon={<ProviderIcon size={16} strokeWidth={2} aria-hidden />}
+        />
+        {user.connectedProviders.length === 0 ? null : (
+          <Row
+            label="Connected"
+            value={user.connectedProviders
+              .map((provider: AuthProvider) => authProviderDisplayName(provider))
+              .join(', ')}
+          />
+        )}
+      </Group>
+
+      <SurfaceCard padding={null}>
+        <button
+          type="button"
+          data-testid="sign-out"
+          onClick={onTapSignOut}
+          className={cn(
+            'flex w-full items-center gap-kro-small px-kro-medium py-3 text-left',
+            'text-[15px] font-semibold outline-none focus-visible:shadow-[var(--kro-ring)]',
+          )}
+          style={{ color: colorVar('kroRed') }}
+        >
+          <SignOutGlyph />
+          Sign Out
+        </button>
+      </SurfaceCard>
+
+      <p
+        className="m-0 px-kro-tiny text-[13px] leading-snug"
+        style={{ color: colorVar('foreSecondary') }}
+      >
+        Signing out clears the preferences saved on this device, so the next
+        account starts from defaults.
+      </p>
+    </div>
+  )
+}
+
+function SignOutGlyph() {
+  const Icon = settingsIcon('rectangle.portrait.and.arrow.right')
+  return <Icon size={16} strokeWidth={2} aria-hidden />
+}
+
+function UnauthenticatedPane({
+  onTapSignIn,
+}: {
+  readonly onTapSignIn: () => void
+}) {
+  const Icon = settingsIcon('person.crop.circle.badge.questionmark')
+
+  return (
+    <div
+      data-testid="account-section"
+      data-pane="profile"
+      className="flex w-full flex-col items-center gap-kro-small py-kro-xx-large text-center"
+    >
+      <Icon
+        size={56}
+        strokeWidth={1.5}
+        aria-hidden
+        style={{ color: colorVar('foreSecondary') }}
+      />
+      <span className="text-lg font-medium" style={{ color: colorVar('fore') }}>
+        Not Signed In
+      </span>
+      <span className="text-[15px]" style={{ color: colorVar('foreSecondary') }}>
+        Sign in to view and manage your profile.
+      </span>
+      <button
+        type="button"
+        onClick={onTapSignIn}
+        className={cn(
+          'mt-kro-small inline-flex h-11 items-center rounded-kro-field px-4',
+          'text-[15px] font-semibold outline-none focus-visible:shadow-[var(--kro-ring)]',
+        )}
+        style={{
+          backgroundColor: colorVar('accent'),
+          color: colorVar('onAccent'),
+        }}
+      >
+        Sign In
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Subscription
+// ---------------------------------------------------------------------------
+
+/**
+ * Canon's `SubscriptionView` — a plan row and a button wired to nothing.
+ *
+ * The issue is explicit that subscription content is out of scope and that
+ * canon "has a row, no flow — mirror it". So the row is here and the button is
+ * **absent** rather than present-and-inert: a control that visibly does nothing
+ * is worse than a sentence saying there is nothing to do yet.
+ */
+function SubscriptionPane() {
+  return (
+    <div
+      data-testid="account-section"
+      data-pane="subscription"
+      className="flex w-full flex-col gap-kro-medium"
+    >
+      <Group title="Current plan">
+        <Row label="Plan" value={SUBSCRIPTION_PLAN_NAME} />
+      </Group>
+      <p
+        className="m-0 px-kro-tiny text-[13px] leading-snug"
+        style={{ color: colorVar('foreSecondary') }}
+      >
+        Kro has no paid plan yet. When one exists, managing it will live here.
+      </p>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Shared row shapes
+// ---------------------------------------------------------------------------
+
+function Group({
+  title,
+  children,
+}: {
+  readonly title: string
+  readonly children: ReactNode
+}) {
+  return (
+    <section className="flex w-full flex-col gap-kro-small">
+      <h3
+        className="m-0 px-kro-tiny text-[13px] font-semibold uppercase tracking-wide"
+        style={{ color: colorVar('foreSecondary') }}
+      >
+        {title}
+      </h3>
+      <SurfaceCard padding={null}>
+        <div className="flex w-full flex-col">{children}</div>
+      </SurfaceCard>
+    </section>
+  )
+}
+
+function Row({
+  label,
+  value,
+  icon,
+}: {
+  readonly label: string
+  readonly value: string
+  readonly icon?: ReactNode
+}) {
+  return (
+    <div
+      data-testid="account-row"
+      className="flex w-full items-center gap-kro-small px-kro-medium py-2.5"
+    >
+      <span className="text-[15px]" style={{ color: colorVar('fore') }}>
+        {label}
+      </span>
+      <span className="flex-1" />
+      <span
+        className="flex items-center gap-1.5 truncate text-[15px]"
+        style={{ color: colorVar('foreSecondary') }}
+      >
+        {icon}
+        {value}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * Canon's `Date.formatted(date: .abbreviated, time: .omitted)`.
+ *
+ * `en-US` explicitly rather than the host locale: a snapshot test that read the
+ * runner's locale would pass on one machine and fail on another, and the date
+ * here is a fact about the account, not a formatted quantity the user tunes.
+ */
+const dateLabel = (date: Date): string =>
+  new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(date)

--- a/packages/app/src/features/settings/pages/IntegrationsSectionFragment.stories.tsx
+++ b/packages/app/src/features/settings/pages/IntegrationsSectionFragment.stories.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode } from 'react'
+import { integrationRows } from '../SettingsIntegrations'
+import type { GoogleConnectionState } from '../SettingsState'
+import { IntegrationsSectionFragment } from './IntegrationsSectionFragment'
+
+/**
+ * The Integrations pane, in each of Google's four states plus the two the row
+ * can be in while an attempt runs.
+ *
+ * The `Unconfigured` story is the one the epic's `unconfigured` environment
+ * produces, and the one worth looking at hardest: it is the state a checkout
+ * with no Google client is in, and it must read as "this deployment cannot do
+ * this" rather than as "you have not connected".
+ */
+export default {
+  title: 'Settings/Integrations',
+  component: IntegrationsSectionFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+const noop = () => {}
+
+function Stage({
+  theme = 'light',
+  width = 760,
+  children,
+}: {
+  theme?: 'light' | 'dark'
+  width?: number
+  children: ReactNode
+}) {
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        width,
+        padding: 16,
+        background: 'var(--kro-color-back)',
+        border: '1px solid var(--kro-color-hairline)',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+const pane = (
+  connection: GoogleConnectionState,
+  options: { isBusy?: boolean; errorCopy?: string | null } = {},
+) => (
+  <IntegrationsSectionFragment
+    rows={integrationRows({
+      connection,
+      isBusy: options.isBusy ?? false,
+      isGoogleEnabled: true,
+    })}
+    errorCopy={options.errorCopy ?? null}
+    onTapConnect={noop}
+    onTapDisconnect={noop}
+  />
+)
+
+/** Configured, never connected — canon's Connect. */
+export const Disconnected = {
+  render: () => <Stage>{pane({ kind: 'disconnected' })}</Stage>,
+}
+
+/** A live grant: the connected mark and Disconnect. */
+export const Connected = {
+  render: () => <Stage>{pane({ kind: 'connected' })}</Stage>,
+}
+
+/** No Google client on this deployment — the honest unavailable state. */
+export const Unconfigured = {
+  render: () => (
+    <Stage>
+      {pane({ kind: 'unconfigured', missing: ['GOOGLE_CLIENT_ID'] })}
+    </Stage>
+  ),
+}
+
+/** A grant that stopped working — Reconnect, never Connect. */
+export const NeedsReconnect = {
+  render: () => <Stage>{pane({ kind: 'needsReconnect' })}</Stage>,
+}
+
+/** An attempt in flight — canon's `isConnecting`. */
+export const Connecting = {
+  render: () => (
+    <Stage>{pane({ kind: 'disconnected' }, { isBusy: true })}</Stage>
+  ),
+}
+
+/** A failed attempt: the banner shows and the grant is untouched. */
+export const AttemptFailed = {
+  render: () => (
+    <Stage>
+      {pane(
+        { kind: 'connected' },
+        { errorCopy: 'The connection could not be changed. Please try again.' },
+      )}
+    </Stage>
+  ),
+}
+
+/** Both schemes, on the state a checkout actually starts in. */
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Stage theme="light" width={520}>
+        {pane({ kind: 'unconfigured', missing: ['GOOGLE_CLIENT_ID'] })}
+      </Stage>
+      <Stage theme="dark" width={520}>
+        {pane({ kind: 'unconfigured', missing: ['GOOGLE_CLIENT_ID'] })}
+      </Stage>
+    </div>
+  ),
+}
+
+/** The handheld width, where the subtitle wraps. */
+export const Handheld = {
+  render: () => <Stage width={390}>{pane({ kind: 'disconnected' })}</Stage>,
+}

--- a/packages/app/src/features/settings/pages/IntegrationsSectionFragment.tsx
+++ b/packages/app/src/features/settings/pages/IntegrationsSectionFragment.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+/**
+ * The Integrations pane — canon `IntegrationsView` plus its `IntegrationRowView`
+ * (`RC-15`: passive; every intent is a callback prop).
+ *
+ * Canon's trailing affordance is a three-way: a green check when connected, a
+ * spinner while connecting, an enabled Connect for `google` and a **disabled**
+ * Connect for everything else. That last branch is the interesting one — canon
+ * ships two Apple rows whose buttons are `.disabled(true)` on the platform that
+ * has EventKit. The web keeps the rows and says why, rather than offering a
+ * control that does nothing when pressed.
+ *
+ * The Google row has four states here, not two, because on the web a
+ * deployment can genuinely have no Google client (`unconfigured`) and a grant
+ * can genuinely stop working (`needsReconnect`). See `SettingsIntegrations.ts`.
+ */
+import { colorVar } from '../../../design/system/tokens/roles'
+import { InlineBanner } from '../../../design/endeavor/InlineBanner'
+import { SurfaceCard } from '../../../design/endeavor/SurfaceCard'
+import { cn } from '../../../design/system/utils/cn'
+import {
+  IntegrationAction,
+  type IntegrationRow,
+} from '../SettingsIntegrations'
+import { settingsIcon } from './settingsIcons'
+
+export interface IntegrationsSectionFragmentProps {
+  readonly rows: readonly IntegrationRow[]
+  /** Copy for a failure banner, or `null`. */
+  readonly errorCopy?: string | null
+  readonly onTapConnect: (id: string) => void
+  readonly onTapDisconnect: (id: string) => void
+}
+
+export function IntegrationsSectionFragment({
+  rows,
+  errorCopy = null,
+  onTapConnect,
+  onTapDisconnect,
+}: IntegrationsSectionFragmentProps) {
+  return (
+    <div
+      data-testid="integrations-section"
+      className="flex w-full flex-col gap-kro-medium"
+    >
+      {errorCopy === null ? null : (
+        <InlineBanner kind="warning" message={errorCopy} />
+      )}
+
+      <SurfaceCard padding={null}>
+        <div className="flex w-full flex-col">
+          {rows.map((row, index) => (
+            <Row
+              key={row.id}
+              row={row}
+              isFirst={index === 0}
+              onTapConnect={onTapConnect}
+              onTapDisconnect={onTapDisconnect}
+            />
+          ))}
+        </div>
+      </SurfaceCard>
+    </div>
+  )
+}
+
+function Row({
+  row,
+  isFirst,
+  onTapConnect,
+  onTapDisconnect,
+}: {
+  readonly row: IntegrationRow
+  readonly isFirst: boolean
+  readonly onTapConnect: (id: string) => void
+  readonly onTapDisconnect: (id: string) => void
+}) {
+  const Icon = settingsIcon(row.glyph)
+
+  return (
+    <>
+      {isFirst ? null : (
+        <div
+          aria-hidden
+          style={{
+            height: '0.75px',
+            marginLeft: 'var(--kro-space-medium)',
+            backgroundColor: colorVar('hairline'),
+          }}
+        />
+      )}
+      <div
+        data-testid="integration-row"
+        data-integration={row.id}
+        data-action={row.action}
+        className="flex w-full items-center gap-kro-small px-kro-medium py-3"
+      >
+        <Icon
+          size={22}
+          strokeWidth={1.75}
+          aria-hidden
+          className="shrink-0"
+          style={{ color: colorVar('foreSecondary') }}
+        />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="text-[15px]" style={{ color: colorVar('fore') }}>
+            {row.title}
+          </span>
+          <span
+            className="text-[13px] leading-snug"
+            style={{ color: colorVar('foreSecondary') }}
+          >
+            {row.subtitle}
+          </span>
+        </div>
+        <Trailing
+          row={row}
+          onTapConnect={onTapConnect}
+          onTapDisconnect={onTapDisconnect}
+        />
+      </div>
+    </>
+  )
+}
+
+function Trailing({
+  row,
+  onTapConnect,
+  onTapDisconnect,
+}: {
+  readonly row: IntegrationRow
+  readonly onTapConnect: (id: string) => void
+  readonly onTapDisconnect: (id: string) => void
+}) {
+  switch (row.action) {
+    case IntegrationAction.none:
+      // Canon's green check. Paired with a spoken label, never colour alone.
+      return <ConnectedMark title={row.title} />
+    case IntegrationAction.busy:
+      return (
+        <span
+          data-testid="integration-busy"
+          role="status"
+          aria-label={`${row.title} — working…`}
+          className="shrink-0 text-[13px]"
+          style={{ color: colorVar('foreSecondary') }}
+        >
+          Working…
+        </span>
+      )
+    case IntegrationAction.connect:
+      return (
+        <RowButton
+          label={`Connect ${row.title}`}
+          title="Connect"
+          onClick={() => onTapConnect(row.id)}
+        />
+      )
+    case IntegrationAction.reconnect:
+      return (
+        <RowButton
+          label={`Reconnect ${row.title}`}
+          title="Reconnect"
+          onClick={() => onTapConnect(row.id)}
+        />
+      )
+    case IntegrationAction.disconnect:
+      return (
+        <div className="flex shrink-0 items-center gap-kro-small">
+          <ConnectedMark title={row.title} />
+          <RowButton
+            label={`Disconnect ${row.title}`}
+            title="Disconnect"
+            onClick={() => onTapDisconnect(row.id)}
+          />
+        </div>
+      )
+    case IntegrationAction.unavailable:
+      return (
+        <RowButton
+          label={`Connect ${row.title}`}
+          title="Connect"
+          isDisabled
+          onClick={() => onTapConnect(row.id)}
+        />
+      )
+  }
+}
+
+function ConnectedMark({ title }: { readonly title: string }) {
+  const Icon = settingsIcon('checkmark.circle.fill')
+  return (
+    <span
+      data-testid="integration-connected"
+      className="flex shrink-0 items-center gap-1 text-[13px] font-medium"
+      style={{ color: colorVar('badgeGreen') }}
+    >
+      <Icon size={16} strokeWidth={2.5} aria-hidden />
+      <span className="sr-only">{`${title} — `}</span>
+      Connected
+    </span>
+  )
+}
+
+function RowButton({
+  label,
+  title,
+  isDisabled = false,
+  onClick,
+}: {
+  readonly label: string
+  readonly title: string
+  readonly isDisabled?: boolean
+  readonly onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      disabled={isDisabled}
+      onClick={onClick}
+      className={cn(
+        'inline-flex h-9 shrink-0 items-center rounded-kro-small border px-3',
+        'text-[13px] font-semibold outline-none focus-visible:shadow-[var(--kro-ring)]',
+        'disabled:cursor-not-allowed',
+      )}
+      style={{
+        borderColor: colorVar('hairline'),
+        color: colorVar('accent'),
+        // The one place disabled opacity is applied for this control (UX: once
+        // per control, never stacked).
+        opacity: isDisabled ? 0.62 : undefined,
+      }}
+    >
+      {title}
+    </button>
+  )
+}

--- a/packages/app/src/features/settings/pages/PreferencesSectionFragment.stories.tsx
+++ b/packages/app/src/features/settings/pages/PreferencesSectionFragment.stories.tsx
@@ -1,0 +1,140 @@
+import { SettingGroup } from '@kro/core'
+import type { ReactNode } from 'react'
+import { SettingsMocks, defaultSettingValues } from '../SettingsMocks'
+import { PreferencesSectionFragment } from './PreferencesSectionFragment'
+
+/**
+ * The schema-driven panes, one story per section plus the three states worth
+ * seeing: the working-hours warning, the pre-load disabled form, and a section
+ * tuned away from its defaults.
+ *
+ * Every row on screen comes from `settingOptionsByGroup`, so these stories are
+ * also the visual proof of the acceptance criterion the render test asserts:
+ * every declared option is offered, exactly once, with the control its declared
+ * type implies.
+ */
+export default {
+  title: 'Settings/Preferences',
+  component: PreferencesSectionFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+const noop = () => {}
+
+function Stage({
+  theme = 'light',
+  width = 760,
+  children,
+}: {
+  theme?: 'light' | 'dark'
+  width?: number
+  children: ReactNode
+}) {
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        width,
+        padding: 16,
+        background: 'var(--kro-color-back)',
+        border: '1px solid var(--kro-color-hairline)',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+const pane = (
+  overrides: Partial<Parameters<typeof PreferencesSectionFragment>[0]> = {},
+) => (
+  <PreferencesSectionFragment
+    group={SettingGroup.general}
+    values={defaultSettingValues}
+    isLoaded
+    onChangeSetting={noop}
+    {...overrides}
+  />
+)
+
+/** General, on canon's first-launch defaults. */
+export const GeneralDefaults = {
+  render: () => <Stage>{pane()}</Stage>,
+}
+
+/** General with the end before the start — canon's inline warning. */
+export const GeneralInvalidWorkingHours = {
+  render: () => (
+    <Stage>
+      {pane({
+        values: SettingsMocks.generalPaneInvalidHours.values,
+        isWorkingHoursValid: false,
+      })}
+    </Stage>
+  ),
+}
+
+/** Session, tuned away from every default it can be. */
+export const SessionTuned = {
+  render: () => (
+    <Stage>
+      {pane({
+        group: SettingGroup.session,
+        values: SettingsMocks.sessionPaneTuned.values,
+      })}
+    </Stage>
+  ),
+}
+
+/** Plan — three subgroups, two pickers and a stepper. */
+export const PlanDefaults = {
+  render: () => <Stage>{pane({ group: SettingGroup.plan })}</Stage>,
+}
+
+/** Do — the smallest pane, and the one whose stepper counts in hours. */
+export const DoDefaults = {
+  render: () => <Stage>{pane({ group: SettingGroup.do })}</Stage>,
+}
+
+/** Earn — the section with the most "declared, not yet consumed" rows. */
+export const EarnDefaults = {
+  render: () => <Stage>{pane({ group: SettingGroup.earn })}</Stage>,
+}
+
+/** Before the stored values arrive — canon's `.disabled(!isLoaded)`. */
+export const NotLoadedYet = {
+  render: () => (
+    <Stage>{pane({ group: SettingGroup.session, isLoaded: false })}</Stage>
+  ),
+}
+
+/** The store could not be read: defaults show and the form stays editable. */
+export const LoadFailed = {
+  render: () => (
+    <Stage>
+      {pane({
+        errorCopy:
+          'Your preferences could not be read on this device. Defaults are shown.',
+      })}
+    </Stage>
+  ),
+}
+
+/** Both schemes at the section that exercises every control type. */
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Stage theme="light" width={520}>
+        {pane()}
+      </Stage>
+      <Stage theme="dark" width={520}>
+        {pane()}
+      </Stage>
+    </div>
+  ),
+}
+
+/** The handheld width, where the stacked controls have to fit. */
+export const Handheld = {
+  render: () => <Stage width={390}>{pane()}</Stage>,
+}

--- a/packages/app/src/features/settings/pages/PreferencesSectionFragment.tsx
+++ b/packages/app/src/features/settings/pages/PreferencesSectionFragment.tsx
@@ -1,0 +1,682 @@
+'use client'
+
+/**
+ * One preferences pane, rendered **from the schema** — canon's five
+ * `…PreferencesView`s as a single passive Fragment (`RC-15`: it reads nothing
+ * and dispatches nothing; every value and every intent is a prop).
+ *
+ * ## Why one Fragment and not five
+ *
+ * Canon has five views because SwiftUI has no way to say "a row per declared
+ * option": each `@Binding` is typed, so each form is hand-written. Here the
+ * rows come from `settingSubgroupsFor(group)`, which is derived from
+ * `@kro/core`'s `settingOptionsByGroup` — so a schema option cannot be declared
+ * and then silently not offered, and the five panes cannot drift apart. The
+ * *copy* is still canon's, per key (`SettingsElements`).
+ *
+ * ## Canon behaviours ported here rather than invented
+ *
+ * - **Disabled until loaded.** Canon: `.disabled(!isLoaded)` on every form,
+ *   *"so an edit made in the brief pre-load window isn't dropped by the
+ *   persistence guard and then overwritten by the load"*.
+ * - **The working-hours warning.** Canon's `footer:` on the Working Hours
+ *   section, shown when the end is not after the start, **while the values
+ *   persist as entered**. So it is rendered state, never a rejected write.
+ * - **"On this device".** Canon's `SettingScopeBadge` / `LocalBadge`, driven
+ *   off `syncScope` in the schema rather than a per-row flag.
+ * - **"Declared, not yet consumed".** Canon says this only in prose;
+ *   KC-IS-#11 moved it into the schema, so the row can say it. Parity means
+ *   not inventing a consumer — and telling the user which controls are inert
+ *   is more honest than a control that silently does nothing.
+ */
+import type { SettingValue, WeekDay } from '@kro/core'
+import { type SettingGroup, weekDays } from '@kro/core'
+import { colorVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import { SurfaceCard } from '../../../design/endeavor/SurfaceCard'
+import { InlineBanner } from '../../../design/endeavor/InlineBanner'
+import type {
+  SettingControl,
+  SettingElement,
+  SettingSubgroup,
+} from '../SettingsElements'
+import { settingSubgroupsFor } from '../SettingsElements'
+import { settingValueIn } from '../SettingsSelectors'
+import { settingsIcon } from './settingsIcons'
+import {
+  accentSwatchColor,
+  deviceTimeZone,
+  knownTimeZones,
+  timeInputMinutes,
+  timeInputValue,
+  timeZoneLabel,
+  weekDayLetter,
+  weekDayName,
+  weekDaysBitmaskHas,
+  weekDaysBitmaskToggling,
+} from './settingsFormatting'
+
+export interface PreferencesSectionFragmentProps {
+  /** Which schema group this pane renders. */
+  readonly group: SettingGroup
+  /** The current snapshot. A missing key falls back to the declared default. */
+  readonly values: Readonly<Record<string, SettingValue | null>>
+  /** Canon's `isLoaded` — the whole form is inert until the values arrive. */
+  readonly isLoaded: boolean
+  /**
+   * Whether the working day ends after it starts. Only the General pane draws
+   * anything for it; every other pane passes the default.
+   */
+  readonly isWorkingHoursValid?: boolean
+  /** Copy for a failure banner above the form, or `null`. */
+  readonly errorCopy?: string | null
+  readonly onChangeSetting: (key: string, value: SettingValue) => void
+}
+
+/** The subgroup whose footer carries canon's working-hours warning. */
+const WORKING_HOURS_SUBGROUP = 'workingHours'
+
+export function PreferencesSectionFragment({
+  group,
+  values,
+  isLoaded,
+  isWorkingHoursValid = true,
+  errorCopy = null,
+  onChangeSetting,
+}: PreferencesSectionFragmentProps) {
+  const subgroups = settingSubgroupsFor(group)
+
+  return (
+    <div
+      data-testid="preferences-section"
+      data-group={group}
+      className="flex w-full flex-col gap-kro-large"
+    >
+      {errorCopy === null ? null : (
+        <InlineBanner kind="warning" message={errorCopy} />
+      )}
+
+      {subgroups.map((subgroup) => (
+        <Subgroup
+          key={subgroup.id}
+          subgroup={subgroup}
+          values={values}
+          isLoaded={isLoaded}
+          isWorkingHoursValid={isWorkingHoursValid}
+          onChangeSetting={onChangeSetting}
+        />
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Subgroup — canon's `Section { … } header: … footer: …`
+// ---------------------------------------------------------------------------
+
+function Subgroup({
+  subgroup,
+  values,
+  isLoaded,
+  isWorkingHoursValid,
+  onChangeSetting,
+}: {
+  readonly subgroup: SettingSubgroup
+  readonly values: Readonly<Record<string, SettingValue | null>>
+  readonly isLoaded: boolean
+  readonly isWorkingHoursValid: boolean
+  readonly onChangeSetting: (key: string, value: SettingValue) => void
+}) {
+  const showsWorkingHoursWarning =
+    subgroup.id === WORKING_HOURS_SUBGROUP && !isWorkingHoursValid
+
+  return (
+    <section
+      data-testid="preferences-subgroup"
+      data-subgroup={subgroup.id}
+      className="flex w-full flex-col gap-kro-small"
+    >
+      {subgroup.title === null ? null : (
+        <h3
+          className="m-0 px-kro-tiny text-[13px] font-semibold uppercase tracking-wide"
+          style={{ color: colorVar('foreSecondary') }}
+        >
+          {subgroup.title}
+        </h3>
+      )}
+
+      <SurfaceCard padding={null}>
+        <div className="flex w-full flex-col">
+          {subgroup.elements.map((element, index) => (
+            <SettingRow
+              key={element.option.key}
+              element={element}
+              value={settingValueIn(values, element.option)}
+              isLoaded={isLoaded}
+              isFirst={index === 0}
+              onChangeSetting={onChangeSetting}
+            />
+          ))}
+        </div>
+      </SurfaceCard>
+
+      {showsWorkingHoursWarning ? (
+        // Canon: `Label("End time must be after start time.", systemImage:
+        // "exclamationmark.triangle").foregroundStyle(.orange)`. Paired glyph +
+        // text, never colour alone (UX: every coloured signal carries both).
+        <p
+          role="status"
+          data-testid="working-hours-warning"
+          className="m-0 flex items-center gap-kro-tiny px-kro-tiny text-[13px] font-medium"
+          style={{ color: colorVar('badgeOrange') }}
+        >
+          <WarningGlyph />
+          End time must be after start time.
+        </p>
+      ) : null}
+
+      {subgroup.footnote === null ? null : (
+        <p
+          className="m-0 px-kro-tiny text-[13px] leading-snug"
+          style={{ color: colorVar('foreSecondary') }}
+        >
+          {subgroup.footnote}
+        </p>
+      )}
+    </section>
+  )
+}
+
+function WarningGlyph() {
+  const Icon = settingsIcon('exclamationmark.triangle')
+  return <Icon size={14} strokeWidth={2.5} aria-hidden />
+}
+
+// ---------------------------------------------------------------------------
+// One row
+// ---------------------------------------------------------------------------
+
+function SettingRow({
+  element,
+  value,
+  isLoaded,
+  isFirst,
+  onChangeSetting,
+}: {
+  readonly element: SettingElement
+  readonly value: SettingValue | null
+  readonly isLoaded: boolean
+  readonly isFirst: boolean
+  readonly onChangeSetting: (key: string, value: SettingValue) => void
+}) {
+  const Icon = settingsIcon(element.option.glyph ?? '')
+  const controlId = `setting-${element.option.key.split('.').join('-')}`
+  const isStacked =
+    element.control.kind === 'days' ||
+    element.control.kind === 'swatches' ||
+    element.control.kind === 'timezone'
+
+  return (
+    <div
+      data-testid="setting-row"
+      data-setting-key={element.option.key}
+      className="flex w-full flex-col"
+    >
+      {isFirst ? null : (
+        <div
+          aria-hidden
+          style={{
+            height: '0.75px',
+            marginLeft: 'var(--kro-space-medium)',
+            backgroundColor: colorVar('hairline'),
+          }}
+        />
+      )}
+      <div
+        className={cn(
+          'flex w-full gap-kro-small px-kro-medium py-2.5',
+          isStacked ? 'flex-col items-stretch' : 'flex-row items-center',
+        )}
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-kro-small">
+          <Icon
+            size={16}
+            strokeWidth={2}
+            aria-hidden
+            className="shrink-0"
+            style={{ color: colorVar('foreSecondary') }}
+          />
+          <label
+            htmlFor={controlId}
+            className="min-w-0 text-[15px]"
+            style={{ color: colorVar('fore') }}
+          >
+            {element.label}
+          </label>
+          {element.isDeviceLocal ? <ScopeBadge /> : null}
+          {element.isConsumed ? null : <DeclaredBadge />}
+        </div>
+
+        <div className={cn('flex', isStacked ? 'w-full' : 'shrink-0')}>
+          <SettingControlView
+            controlId={controlId}
+            label={element.label}
+            control={element.control}
+            optionKey={element.option.key}
+            value={value}
+            isDisabled={!isLoaded}
+            onChangeSetting={onChangeSetting}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Canon's `SettingScopeBadge` / `LocalBadge` — "On this device". */
+function ScopeBadge() {
+  return (
+    <span
+      data-testid="scope-badge"
+      className="shrink-0 rounded-kro-pill px-1.5 py-0.5 text-[11px] font-medium"
+      style={{
+        backgroundColor: colorVar('backInner'),
+        color: colorVar('foreSecondary'),
+      }}
+    >
+      On this device
+    </span>
+  )
+}
+
+/**
+ * The schema's `consumption: 'declared'`.
+ *
+ * Canon records this in prose only, so a KroApple user meets a control that
+ * quietly changes nothing. Saying it is the honest port — and the epic's rule
+ * is that parity means not inventing a consumer, not hiding the option.
+ */
+function DeclaredBadge() {
+  return (
+    <span
+      data-testid="declared-badge"
+      title="Stored, but nothing reads it yet."
+      className="shrink-0 rounded-kro-pill px-1.5 py-0.5 text-[11px] font-medium"
+      style={{
+        backgroundColor: colorVar('backInner'),
+        color: colorVar('foreSecondary'),
+      }}
+    >
+      Not used yet
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Controls
+// ---------------------------------------------------------------------------
+
+interface ControlProps {
+  readonly controlId: string
+  readonly label: string
+  readonly control: SettingControl
+  readonly optionKey: string
+  readonly value: SettingValue | null
+  readonly isDisabled: boolean
+  readonly onChangeSetting: (key: string, value: SettingValue) => void
+}
+
+function SettingControlView(props: ControlProps) {
+  switch (props.control.kind) {
+    case 'toggle':
+      return <ToggleControl {...props} />
+    case 'time':
+      return <TimeControl {...props} />
+    case 'days':
+      return <DaysControl {...props} />
+    case 'stepper':
+      return <StepperControl {...props} bounds={props.control} />
+    case 'choice':
+      return <ChoiceControl {...props} choices={props.control.choices} />
+    case 'swatches':
+      return <SwatchControl {...props} choices={props.control.choices} />
+    case 'timezone':
+      return <TimeZoneControl {...props} />
+  }
+}
+
+const FIELD_CLASSES = cn(
+  'h-9 rounded-kro-field border px-2 text-[15px]',
+  'outline-none focus-visible:shadow-[var(--kro-ring)]',
+  'disabled:cursor-not-allowed',
+)
+
+const fieldStyle = {
+  backgroundColor: colorVar('backInner'),
+  borderColor: colorVar('hairline'),
+  color: colorVar('fore'),
+}
+
+/** Canon's `Toggle`. A `role="switch"` button — the accessible equivalent. */
+function ToggleControl({
+  controlId,
+  label,
+  optionKey,
+  value,
+  isDisabled,
+  onChangeSetting,
+}: ControlProps) {
+  const isOn = value === true
+  return (
+    <button
+      id={controlId}
+      type="button"
+      role="switch"
+      aria-checked={isOn}
+      aria-label={label}
+      disabled={isDisabled}
+      onClick={() => onChangeSetting(optionKey, !isOn)}
+      className={cn(
+        'relative inline-flex h-7 w-12 shrink-0 items-center rounded-kro-pill p-0.5',
+        'transition-colors outline-none focus-visible:shadow-[var(--kro-ring)]',
+        'disabled:cursor-not-allowed',
+      )}
+      style={{
+        backgroundColor: isOn ? colorVar('accent') : colorVar('hairline'),
+        opacity: isDisabled ? 0.62 : undefined,
+      }}
+    >
+      <span
+        aria-hidden
+        className="block size-6 rounded-full transition-transform"
+        style={{
+          backgroundColor: colorVar('absolute'),
+          transform: isOn ? 'translateX(20px)' : 'translateX(0)',
+        }}
+      />
+    </button>
+  )
+}
+
+/** Canon's `DatePicker(displayedComponents: .hourAndMinute)`. */
+function TimeControl({
+  controlId,
+  label,
+  optionKey,
+  value,
+  isDisabled,
+  onChangeSetting,
+}: ControlProps) {
+  const minutes = typeof value === 'number' ? value : 0
+  return (
+    <input
+      id={controlId}
+      type="time"
+      aria-label={label}
+      disabled={isDisabled}
+      value={timeInputValue(minutes)}
+      onChange={(event) => {
+        const next = timeInputMinutes(event.target.value)
+        // `null` is a half-typed field, not midnight — see `timeInputMinutes`.
+        if (next !== null) onChangeSetting(optionKey, next)
+      }}
+      className={FIELD_CLASSES}
+      style={{ ...fieldStyle, opacity: isDisabled ? 0.62 : undefined }}
+    />
+  )
+}
+
+/** Canon's seven-chip `WeekDayPicker`. */
+function DaysControl({
+  controlId,
+  label,
+  optionKey,
+  value,
+  isDisabled,
+  onChangeSetting,
+}: ControlProps) {
+  const mask = typeof value === 'number' ? value : 0
+  return (
+    <div
+      id={controlId}
+      role="group"
+      aria-label={label}
+      className="flex w-full items-center gap-1.5"
+    >
+      {weekDays.map((day: WeekDay) => {
+        const isOn = weekDaysBitmaskHas(mask, day)
+        return (
+          <button
+            key={day}
+            type="button"
+            aria-pressed={isOn}
+            aria-label={weekDayName(day)}
+            disabled={isDisabled}
+            onClick={() =>
+              onChangeSetting(optionKey, weekDaysBitmaskToggling(mask, day))
+            }
+            className={cn(
+              'flex h-9 flex-1 items-center justify-center rounded-full text-[13px] font-semibold',
+              'outline-none focus-visible:shadow-[var(--kro-ring)]',
+              'disabled:cursor-not-allowed',
+            )}
+            style={{
+              backgroundColor: isOn ? colorVar('accent') : colorVar('backInner'),
+              color: isOn ? colorVar('onAccent') : colorVar('fore'),
+              opacity: isDisabled ? 0.62 : undefined,
+            }}
+          >
+            {weekDayLetter(day)}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Canon's `Stepper(… in: … step: …)`. */
+function StepperControl({
+  controlId,
+  label,
+  optionKey,
+  value,
+  isDisabled,
+  bounds,
+  onChangeSetting,
+}: ControlProps & {
+  readonly bounds: { min: number; max: number; step: number; unit: string | null }
+}) {
+  const current = typeof value === 'number' ? value : bounds.min
+  const summary = bounds.unit === null ? `${current}` : `${current} ${bounds.unit}`
+  const step = (delta: number) => {
+    const next = Math.min(
+      Math.max(current + delta * bounds.step, bounds.min),
+      bounds.max,
+    )
+    if (next !== current) onChangeSetting(optionKey, next)
+  }
+
+  return (
+    <div id={controlId} className="flex items-center gap-kro-small">
+      <output
+        data-testid="stepper-value"
+        className="min-w-16 text-right text-[15px] tabular-nums"
+        style={{ color: colorVar('foreSecondary') }}
+      >
+        {summary}
+      </output>
+      <div
+        className="flex items-center overflow-hidden rounded-kro-field border"
+        style={{ borderColor: colorVar('hairline') }}
+      >
+        <StepperButton
+          label={`Decrease ${label}`}
+          glyph="−"
+          isDisabled={isDisabled || current <= bounds.min}
+          onClick={() => step(-1)}
+        />
+        <div
+          aria-hidden
+          style={{ width: '0.75px', height: 28, backgroundColor: colorVar('hairline') }}
+        />
+        <StepperButton
+          label={`Increase ${label}`}
+          glyph="+"
+          isDisabled={isDisabled || current >= bounds.max}
+          onClick={() => step(1)}
+        />
+      </div>
+    </div>
+  )
+}
+
+function StepperButton({
+  label,
+  glyph,
+  isDisabled,
+  onClick,
+}: {
+  readonly label: string
+  readonly glyph: string
+  readonly isDisabled: boolean
+  readonly onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      disabled={isDisabled}
+      onClick={onClick}
+      className={cn(
+        'flex h-9 w-9 items-center justify-center text-[17px] leading-none',
+        'outline-none focus-visible:shadow-[var(--kro-ring)]',
+        'disabled:cursor-not-allowed',
+      )}
+      style={{
+        backgroundColor: colorVar('backInner'),
+        color: colorVar('fore'),
+        opacity: isDisabled ? 0.62 : undefined,
+      }}
+    >
+      {glyph}
+    </button>
+  )
+}
+
+/** Canon's `Picker`. */
+function ChoiceControl({
+  controlId,
+  label,
+  optionKey,
+  value,
+  isDisabled,
+  choices,
+  onChangeSetting,
+}: ControlProps & { readonly choices: readonly { value: string; label: string }[] }) {
+  return (
+    <select
+      id={controlId}
+      aria-label={label}
+      disabled={isDisabled}
+      value={typeof value === 'string' ? value : ''}
+      onChange={(event) => onChangeSetting(optionKey, event.target.value)}
+      className={FIELD_CLASSES}
+      style={{ ...fieldStyle, opacity: isDisabled ? 0.62 : undefined }}
+    >
+      {choices.map((choice) => (
+        <option key={choice.value} value={choice.value}>
+          {choice.label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+/** Canon's `AccentColorPicker` — a swatch per choice, the current one ringed. */
+function SwatchControl({
+  controlId,
+  label,
+  optionKey,
+  value,
+  isDisabled,
+  choices,
+  onChangeSetting,
+}: ControlProps & { readonly choices: readonly { value: string; label: string }[] }) {
+  return (
+    <div
+      id={controlId}
+      role="radiogroup"
+      aria-label={label}
+      className="flex w-full items-center gap-kro-small"
+    >
+      {choices.map((choice) => {
+        const isSelected = value === choice.value
+        return (
+          <button
+            key={choice.value}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            aria-label={choice.label}
+            disabled={isDisabled}
+            onClick={() => onChangeSetting(optionKey, choice.value)}
+            className={cn(
+              'size-7 rounded-full outline-none focus-visible:shadow-[var(--kro-ring)]',
+              'disabled:cursor-not-allowed',
+            )}
+            style={{
+              backgroundColor: accentSwatchColor(choice.value),
+              boxShadow: isSelected
+                ? `0 0 0 2px ${colorVar('absolute')}, 0 0 0 4px ${colorVar('fore')}`
+                : undefined,
+              opacity: isDisabled ? 0.62 : undefined,
+            }}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+/**
+ * Canon's timezone `Picker` over the known identifiers.
+ *
+ * The empty value is a real choice, not a placeholder: the schema's default for
+ * `general.timezone` is `null`, which canon documents as *"defaults to the
+ * device's current zone until changed"*. So the first option names the device's
+ * zone and writing it stores that identifier, which is what "until changed"
+ * means.
+ */
+function TimeZoneControl({
+  controlId,
+  label,
+  optionKey,
+  value,
+  isDisabled,
+  onChangeSetting,
+}: ControlProps) {
+  const zones = knownTimeZones()
+  const device = deviceTimeZone()
+  const current = typeof value === 'string' && value.length > 0 ? value : device
+
+  return (
+    <select
+      id={controlId}
+      aria-label={label}
+      disabled={isDisabled}
+      value={zones.includes(current) ? current : ''}
+      onChange={(event) => onChangeSetting(optionKey, event.target.value)}
+      className={cn(FIELD_CLASSES, 'w-full')}
+      style={{ ...fieldStyle, opacity: isDisabled ? 0.62 : undefined }}
+    >
+      {zones.includes(current) ? null : (
+        <option value="">{timeZoneLabel(current)}</option>
+      )}
+      {zones.map((zone) => (
+        <option key={zone} value={zone}>
+          {timeZoneLabel(zone)}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/packages/app/src/features/settings/pages/ProfileControlPage.stories.tsx
+++ b/packages/app/src/features/settings/pages/ProfileControlPage.stories.tsx
@@ -1,0 +1,101 @@
+import { StoreProvider } from '../../../library/StoreProvider'
+import { type ThunkExtra, makeStore, stubbedThunkExtra } from '../../../library/store'
+import { makeStubbedAuthService } from '../../../services/auth/AuthService'
+import { authUserMocks } from '../../auth/AuthMocks'
+import { ToolbarOutlet, ToolbarSlotsProvider } from '../../main/ToolbarSlots'
+import { userDidTapSignIn } from '../SettingsFeature'
+import { ProfileControlPage } from './ProfileControlPage'
+
+/**
+ * The shell-wide profile control, in the slot it fills.
+ *
+ * The stage renders the shell's own `profile` outlet so the control appears
+ * where the app puts it rather than floating on its own — which is also the
+ * proof that the slot mechanism works end to end.
+ */
+export default {
+  title: 'Settings/Profile control',
+  component: ProfileControlPage,
+  parameters: { layout: 'centered' },
+}
+
+function Stage({
+  theme = 'light',
+  extra = stubbedThunkExtra,
+  presentsAuth = false,
+}: {
+  theme?: 'light' | 'dark'
+  extra?: ThunkExtra
+  presentsAuth?: boolean
+}) {
+  const store = makeStore(extra)
+  if (presentsAuth) {
+    store.dispatch(userDidTapSignIn({ origin: 'profilePopover' }))
+  }
+
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        width: 420,
+        minHeight: 220,
+        padding: 16,
+        background: 'var(--kro-color-back)',
+        border: '1px solid var(--kro-color-hairline)',
+      }}
+    >
+      <StoreProvider store={store}>
+        <ToolbarSlotsProvider>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: 8,
+              background: 'var(--kro-color-absolute)',
+              borderRadius: 'var(--kro-radius-small)',
+            }}
+          >
+            <span style={{ color: 'var(--kro-color-fore-secondary)' }}>
+              Toolbar →
+            </span>
+            <ToolbarOutlet placement="profile" />
+          </div>
+          <ProfileControlPage />
+        </ToolbarSlotsProvider>
+      </StoreProvider>
+    </div>
+  )
+}
+
+/** Signed out: the neutral glyph in the shell's slot. */
+export const SignedOut = {
+  render: () => <Stage />,
+}
+
+/** Signed in: the initials avatar replaces the glyph. */
+export const SignedIn = {
+  render: () => (
+    <Stage
+      extra={{
+        ...stubbedThunkExtra,
+        authService: makeStubbedAuthService({ initialUser: authUserMocks.typical }),
+      }}
+    />
+  ),
+}
+
+/** The auth surface, presented from the popover's sign-in entry. */
+export const AuthPresented = {
+  render: () => <Stage presentsAuth />,
+}
+
+/** Both schemes. */
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Stage theme="light" />
+      <Stage theme="dark" />
+    </div>
+  ),
+}

--- a/packages/app/src/features/settings/pages/ProfileControlPage.tsx
+++ b/packages/app/src/features/settings/pages/ProfileControlPage.tsx
@@ -1,0 +1,291 @@
+'use client'
+
+/**
+ * The Profile control, and the two surfaces that must be reachable from
+ * anywhere (`RC-37`; implements `UZF-4`).
+ *
+ * Three things live here because all three are shell-wide rather than
+ * destination-scoped:
+ *
+ * 1. **The profile popover** — canon's `macProfileButton` + `ProfilePopoverView`,
+ *    portalled into the shell's `profile` toolbar slot. Desktop gets canon's
+ *    popover at width 300; a handheld gets a sheet, because canon's own rule is
+ *    that a popover on a narrow surface "would adapt into a full-screen sheet
+ *    and cost more than it gives". The decision comes from
+ *    `presentationFor(...)`, the same table the rest of the shell reads.
+ * 2. **The auth sheet** — reachable from the popover *and* from the Settings
+ *    hub's signed-out row, so it cannot live inside either.
+ * 3. **The existing-local-data dialog** — it appears after a sign-in that may
+ *    have completed through an OAuth redirect landing on any route, so it has
+ *    no destination to belong to.
+ *
+ * The Page reads across three slices — `settings` for the presentation,
+ * `auth` for the session and the dialog, `main` for the surface — and does so
+ * through each feature's own named Selectors, never by reaching into a shape
+ * (`RC-20`).
+ */
+import { primaryEmail } from '@kro/core'
+import { type ComponentPropsWithoutRef, useCallback, useEffect } from 'react'
+import { AuthSurfacePage } from '../../auth/pages/AuthSurfacePage'
+import { LocalDataDialogFragment } from '../../auth/pages/LocalDataDialogFragment'
+import { onLocalDataDialogDismissed } from '../../auth/AuthFeature'
+import type { LocalDataChoice } from '../../auth/LocalDataDialog'
+import {
+  resolveLocalDataChoiceThunk,
+  restoreSessionThunk,
+  signOutThunk,
+} from '../../auth/AuthProducer'
+import {
+  selectCurrentUser,
+  selectLocalDataDialog,
+  selectUserInitials,
+} from '../../auth/AuthSelectors'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '../../../design/system/primitives/dialog'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '../../../design/system/primitives/popover'
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from '../../../design/system/primitives/sheet'
+import { ICON_SIZE } from '../../../design/system/icons/icons'
+import { colorVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import { useAppDispatch, useAppSelector } from '../../../library/hooks'
+import { PRESENTATION_SIZE, PresentationSurface, presentationFor } from '../../main/MainPresentation'
+import { navigateToDestinationThunk } from '../../main/MainProducer'
+import { selectSurface } from '../../main/MainSelectors'
+import { DestinationKind } from '../../main/SidebarDestination'
+import { ToolbarSlot } from '../../main/ToolbarSlots'
+import { userDidDismissAuth, userDidTapSignIn } from '../SettingsFeature'
+import { selectAuthPresentation } from '../SettingsSelectors'
+import { SUBSCRIPTION_PLAN_NAME } from '../SettingsState'
+import { Avatar } from './SettingsHubFragment'
+import { ProfilePopoverFragment } from './ProfilePopoverFragment'
+
+export function ProfileControlPage() {
+  const dispatch = useAppDispatch()
+
+  const user = useAppSelector(selectCurrentUser)
+  const initials = useAppSelector(selectUserInitials)
+  const localData = useAppSelector(selectLocalDataDialog)
+  const authPresentation = useAppSelector(selectAuthPresentation)
+  const surface = useAppSelector(selectSurface)
+
+  const presentation = presentationFor(PresentationSurface.profile, surface)
+  const isSheet = presentation.kind === 'sheet'
+
+  /*
+    The silent launch restore (KC-IS-#31's `restoreSessionThunk`).
+
+    Fired here because this is the one artifact mounted once, shell-wide, that
+    *renders* the session — so the surface that shows who you are is the surface
+    that asks. Without it `session` stays `unknown` forever in the running app
+    and every reload would render the signed-out control for an account that is
+    in fact signed in.
+
+    `observeAuthState` — the `onAuthStateChange` subscription that catches a
+    token refresh or a sign-out in a second tab — is deliberately NOT wired
+    here: it needs `ThunkExtra`, which a component may not reach (`RC-6`), so it
+    belongs to `apps/web`'s composition root. Named in the PR body as an open
+    cross-lane need.
+  */
+  useEffect(() => {
+    const effect = dispatch(restoreSessionThunk({ now: new Date() }))
+    return () => effect.abort()
+  }, [dispatch])
+
+  const goTo = useCallback(
+    (kind: 'tasks' | 'settings') => {
+      void dispatch(
+        navigateToDestinationThunk({
+          destination:
+            kind === 'tasks'
+              ? { kind: DestinationKind.allTasks }
+              : { kind: DestinationKind.settings },
+        }),
+      )
+    },
+    [dispatch],
+  )
+
+  const content = (
+    <ProfilePopoverFragment
+      accountName={user?.name ?? null}
+      accountEmail={user === null ? null : primaryEmail(user)}
+      accountInitials={initials}
+      planName={SUBSCRIPTION_PLAN_NAME}
+      onTapSignIn={() => dispatch(userDidTapSignIn({ origin: 'profilePopover' }))}
+      onTapAllEndeavors={() => goTo('tasks')}
+      onTapSettings={() => goTo('settings')}
+      onTapSignOut={() => {
+        void dispatch(signOutThunk())
+      }}
+    />
+  )
+
+  return (
+    <>
+      <ToolbarSlot placement="profile">
+        {isSheet ? (
+          <Sheet>
+            <SheetTrigger asChild>
+              <ProfileTrigger initials={initials} isSignedIn={user !== null} />
+            </SheetTrigger>
+            {/* Same `.kro-glass` position override as the auth modal below. */}
+            <SheetContent
+              side="bottom"
+              style={{ position: 'fixed' }}
+              className="p-0"
+            >
+              <SheetTitle className="sr-only">Profile</SheetTitle>
+              {content}
+            </SheetContent>
+          </Sheet>
+        ) : (
+          <Popover>
+            <PopoverTrigger asChild>
+              <ProfileTrigger initials={initials} isSignedIn={user !== null} />
+            </PopoverTrigger>
+            <PopoverContent
+              align="start"
+              className="p-0"
+              // Canon's `.frame(width: 300)` on `ProfilePopoverView`, read from
+              // the design system's own table so a second surface cannot
+              // disagree about what "the profile popover" is.
+              style={{ width: PRESENTATION_SIZE.profile.width }}
+            >
+              {content}
+            </PopoverContent>
+          </Popover>
+        )}
+      </ToolbarSlot>
+
+      {/*
+        The auth surface. A modal on every shell — canon presents it with
+        `.fullScreenCover` on the phone and a sheet on the Mac, which are the
+        same thing here: a centred panel over a scrim, sized to the content.
+      */}
+      <Dialog
+        open={authPresentation.kind === 'presented'}
+        onOpenChange={(next) => {
+          if (!next) dispatch(userDidDismissAuth())
+        }}
+      >
+        <DialogContent
+          hideClose
+          data-testid="auth-modal"
+          /*
+            Two local overrides, both measured on the built app rather than
+            guessed:
+
+            1. `position: fixed` inline. The kit's `DialogContent` asks for it
+               with Tailwind's `fixed` utility, but `.kro-glass` sets
+               `position: relative` from an UNLAYERED stylesheet, and unlayered
+               CSS beats `@layer utilities` — so every glass dialog in the app
+               computes to `relative` and lands after the shell in normal flow
+               (measured: `top: 869px` in an 844px viewport). An inline style is
+               the one declaration that outranks both. The fix belongs in
+               `design/system/` — outside this issue's lane — and is named in the
+               PR body as a cross-lane finding.
+            2. A height cap, a scroll and top-anchoring, so the panel cannot run
+               off the bottom on a short viewport (a laptop in landscape, a
+               phone with the keyboard up).
+          */
+          style={{ position: 'fixed' }}
+          className={cn(
+            'top-[3dvh] max-h-[94dvh] translate-y-0 overflow-y-auto',
+            'max-w-[420px] border-0 bg-transparent p-0 shadow-none',
+          )}
+        >
+          <DialogTitle className="sr-only">Sign in to Kro</DialogTitle>
+          <DialogDescription className="sr-only">
+            Sign in with your email, with Apple, or with Google.
+          </DialogDescription>
+          <AuthSurfacePage onDismiss={() => dispatch(userDidDismissAuth())} />
+        </DialogContent>
+      </Dialog>
+
+      <LocalDataDialogFragment
+        isPresented={localData.kind === 'shown'}
+        anonymousCount={localData.kind === 'shown' ? localData.anonymousCount : 0}
+        isResolving={localData.kind === 'resolving'}
+        onChoose={(choice: LocalDataChoice) => {
+          void dispatch(resolveLocalDataChoiceThunk({ choice, now: new Date() }))
+        }}
+        // Canon routes swipe-to-dismiss into the same arm as Cancel; this only
+        // hides the prompt and touches no rows, which is what the slice's own
+        // `onLocalDataDialogDismissed` does.
+        onDismiss={() => dispatch(onLocalDataDialogDismissed())}
+      />
+
+      <AuthDismissOnSignIn />
+    </>
+  )
+}
+
+/**
+ * Closes the auth surface once a session exists.
+ *
+ * A one-line effect rather than a reducer matching `auth`'s thunk: a slice that
+ * reacted to another feature's lifecycle would be reaching into it (`RC-20`),
+ * and the Page is the artifact allowed to bridge the two (`RC-37`).
+ */
+function AuthDismissOnSignIn() {
+  const dispatch = useAppDispatch()
+  const user = useAppSelector(selectCurrentUser)
+  const authPresentation = useAppSelector(selectAuthPresentation)
+  const isPresented = authPresentation.kind === 'presented'
+
+  useEffect(() => {
+    if (user !== null && isPresented) dispatch(userDidDismissAuth())
+  }, [dispatch, isPresented, user])
+
+  return null
+}
+
+/**
+ * The toolbar button itself.
+ *
+ * Signed in it is the initials avatar, which is what makes the control read as
+ * *your* account at a glance; signed out it is the neutral person glyph the
+ * shell drew before. `forwardRef` is not needed — Radix's `asChild` clones the
+ * element and React 19 passes `ref` as an ordinary prop.
+ */
+function ProfileTrigger({
+  initials,
+  isSignedIn,
+  ...rest
+}: {
+  readonly initials: string
+  readonly isSignedIn: boolean
+} & ComponentPropsWithoutRef<'button'>) {
+  return (
+    <button
+      type="button"
+      aria-label="Profile"
+      data-testid="profile-control"
+      className={cn(
+        'flex items-center justify-center rounded-kro-pill',
+        'outline-none focus-visible:shadow-[var(--kro-ring)]',
+      )}
+      style={{
+        minWidth: ICON_SIZE.large,
+        minHeight: ICON_SIZE.large,
+        color: colorVar('fore'),
+      }}
+      {...rest}
+    >
+      <Avatar initials={initials} isSignedIn={isSignedIn} size={28} />
+    </button>
+  )
+}

--- a/packages/app/src/features/settings/pages/ProfilePopoverFragment.stories.tsx
+++ b/packages/app/src/features/settings/pages/ProfilePopoverFragment.stories.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from 'react'
+import { PRESENTATION_SIZE } from '../../main/MainPresentation'
+import { authUserMocks } from '../../auth/AuthMocks'
+import { ProfilePopoverFragment } from './ProfilePopoverFragment'
+
+/**
+ * The profile popover's content, at canon's own width.
+ *
+ * The stage is `PRESENTATION_SIZE.profile.width` rather than a number typed
+ * here, so a story cannot show the popover at a width the app never presents
+ * it at — canon's `.frame(width: 300)`.
+ */
+export default {
+  title: 'Settings/Profile popover',
+  component: ProfilePopoverFragment,
+  parameters: { layout: 'centered' },
+}
+
+const noop = () => {}
+
+function Stage({
+  theme = 'light',
+  children,
+}: {
+  theme?: 'light' | 'dark'
+  children: ReactNode
+}) {
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        width: PRESENTATION_SIZE.profile.width,
+        background: 'var(--kro-color-absolute)',
+        border: '1px solid var(--kro-color-hairline)',
+        borderRadius: 'var(--kro-radius-surface)',
+        overflow: 'hidden',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+const popover = (
+  overrides: Partial<Parameters<typeof ProfilePopoverFragment>[0]> = {},
+) => (
+  <ProfilePopoverFragment
+    accountName={null}
+    accountEmail={null}
+    accountInitials=""
+    planName="Free"
+    onTapSignIn={noop}
+    onTapAllEndeavors={noop}
+    onTapSettings={noop}
+    onTapSignOut={noop}
+    {...overrides}
+  />
+)
+
+/** Signed out — canon's "Sign In to Kro" invitation, no Sign Out row. */
+export const SignedOut = {
+  render: () => <Stage>{popover()}</Stage>,
+}
+
+/** Signed in — identity, initials avatar, the Free badge and Sign Out. */
+export const SignedIn = {
+  render: () => (
+    <Stage>
+      {popover({
+        accountName: authUserMocks.typical.name,
+        accountEmail: authUserMocks.typical.emails[0] ?? null,
+        accountInitials: 'AL',
+      })}
+    </Stage>
+  ),
+}
+
+/** An unnamed account, whose initials come from the email. */
+export const SignedInUnnamed = {
+  render: () => (
+    <Stage>
+      {popover({
+        accountName: null,
+        accountEmail: authUserMocks.unnamed.emails[0] ?? null,
+        accountInitials: 'S',
+      })}
+    </Stage>
+  ),
+}
+
+/** Both schemes and both sessions — the four states in one frame. */
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Stage theme="light">
+        {popover({
+          accountName: authUserMocks.typical.name,
+          accountEmail: authUserMocks.typical.emails[0] ?? null,
+          accountInitials: 'AL',
+        })}
+      </Stage>
+      <Stage theme="dark">
+        {popover({
+          accountName: authUserMocks.typical.name,
+          accountEmail: authUserMocks.typical.emails[0] ?? null,
+          accountInitials: 'AL',
+        })}
+      </Stage>
+      <Stage theme="light">{popover()}</Stage>
+      <Stage theme="dark">{popover()}</Stage>
+    </div>
+  ),
+}

--- a/packages/app/src/features/settings/pages/ProfilePopoverFragment.tsx
+++ b/packages/app/src/features/settings/pages/ProfilePopoverFragment.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+/**
+ * The profile popover's content — canon `ProfilePopoverView` (`RC-15`: passive;
+ * every intent is a callback prop).
+ *
+ * Canon's structure, kept: a header that is either the signed-in identity (with
+ * avatar, email and the Free badge) or the *"Sign In to Kro"* invitation, a
+ * divider, and a menu below it. Width 300 is the shell's, not this Fragment's —
+ * `POPOVER_SIZE.profile` fixes it once and `ProfileControlPage` applies it, so
+ * a story can render this content at any width without disagreeing with the app.
+ *
+ * ## Which menu rows are here, and why the others are not
+ *
+ * Canon's menu has seven rows: All Endeavors, Sources, Sync History,
+ * Notifications (flag-gated, off by default), Subscription, Settings, and
+ * Help & Feedback. Four of them target destinations this repo has: All
+ * Endeavors is `/tasks`, Subscription and Settings are the hub, and the
+ * signed-in case adds Sign Out. **Sources**, **Sync History** and **Help &
+ * Feedback** have no destination in kro-pwa at this tip — porting them would be
+ * three rows that navigate nowhere, which is exactly the "control that does
+ * nothing" this port refuses elsewhere. Notifications is flag-gated off in
+ * canon too (`showsNotifications`), and the flag registry here agrees.
+ */
+import { colorVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import { Avatar } from './SettingsHubFragment'
+import { settingsIcon } from './settingsIcons'
+
+export interface ProfilePopoverFragmentProps {
+  /** `null` is canon's unauthenticated header. */
+  readonly accountName: string | null
+  readonly accountEmail: string | null
+  readonly accountInitials: string
+  /** Canon's `Free` capsule under the email. */
+  readonly planName: string
+  readonly onTapSignIn: () => void
+  readonly onTapAllEndeavors: () => void
+  readonly onTapSettings: () => void
+  readonly onTapSignOut: () => void
+}
+
+export function ProfilePopoverFragment({
+  accountName,
+  accountEmail,
+  accountInitials,
+  planName,
+  onTapSignIn,
+  onTapAllEndeavors,
+  onTapSettings,
+  onTapSignOut,
+}: ProfilePopoverFragmentProps) {
+  const isSignedIn = accountEmail !== null
+
+  return (
+    <div
+      data-testid="profile-popover"
+      data-signed-in={isSignedIn}
+      className="flex w-full flex-col"
+    >
+      {isSignedIn ? (
+        <button
+          type="button"
+          data-testid="profile-popover-identity"
+          onClick={onTapSettings}
+          className={cn(
+            'flex w-full items-center gap-3 px-kro-medium py-3.5 text-left',
+            'outline-none focus-visible:shadow-[var(--kro-ring)]',
+          )}
+        >
+          <Avatar initials={accountInitials} isSignedIn size={48} />
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span
+              className="truncate text-[15px] font-semibold"
+              style={{ color: colorVar('fore') }}
+            >
+              {accountName ?? 'Kro User'}
+            </span>
+            <span
+              className="truncate text-[12px]"
+              style={{ color: colorVar('foreSecondary') }}
+            >
+              {accountEmail}
+            </span>
+            <span
+              data-testid="profile-plan-badge"
+              className="mt-0.5 w-fit rounded-kro-pill px-1.5 py-0.5 text-[11px] font-medium"
+              style={{
+                backgroundColor: colorVar('badgeIndigo'),
+                color: colorVar('onAccent'),
+              }}
+            >
+              {planName}
+            </span>
+          </span>
+          <Chevron />
+        </button>
+      ) : (
+        <button
+          type="button"
+          data-testid="profile-popover-sign-in"
+          onClick={onTapSignIn}
+          className={cn(
+            'flex w-full items-center gap-3 px-kro-medium py-3.5 text-left',
+            'outline-none focus-visible:shadow-[var(--kro-ring)]',
+          )}
+        >
+          <Avatar initials="" isSignedIn={false} size={44} />
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span
+              className="text-[15px] font-semibold"
+              style={{ color: colorVar('fore') }}
+            >
+              Sign In to Kro
+            </span>
+            <span
+              className="text-[12px]"
+              style={{ color: colorVar('foreSecondary') }}
+            >
+              Sync your data across devices
+            </span>
+          </span>
+          <Chevron />
+        </button>
+      )}
+
+      <Divider />
+
+      <div className="flex w-full flex-col py-1.5">
+        <MenuRow
+          glyph="checklist"
+          label="All Endeavors"
+          onClick={onTapAllEndeavors}
+        />
+        <MenuRow glyph="creditcard" label="Subscription" onClick={onTapSettings} />
+        <MenuRow glyph="gearshape" label="Settings" onClick={onTapSettings} />
+        {isSignedIn ? (
+          <>
+            <Divider inset />
+            <MenuRow
+              glyph="rectangle.portrait.and.arrow.right"
+              label="Sign Out"
+              tone="danger"
+              onClick={onTapSignOut}
+            />
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function Divider({ inset = false }: { readonly inset?: boolean }) {
+  return (
+    <div
+      aria-hidden
+      style={{
+        height: '0.75px',
+        marginLeft: inset ? 44 : 0,
+        marginTop: inset ? 4 : 0,
+        marginBottom: inset ? 4 : 0,
+        backgroundColor: colorVar('hairline'),
+      }}
+    />
+  )
+}
+
+function Chevron() {
+  const Icon = settingsIcon('chevron.right')
+  return (
+    <Icon
+      size={14}
+      strokeWidth={2.5}
+      aria-hidden
+      className="shrink-0"
+      style={{ color: colorVar('foreSecondary') }}
+    />
+  )
+}
+
+function MenuRow({
+  glyph,
+  label,
+  tone = 'normal',
+  onClick,
+}: {
+  readonly glyph: string
+  readonly label: string
+  readonly tone?: 'normal' | 'danger'
+  readonly onClick: () => void
+}) {
+  const Icon = settingsIcon(glyph)
+  const color = tone === 'danger' ? colorVar('kroRed') : colorVar('fore')
+
+  return (
+    <button
+      type="button"
+      data-testid="profile-menu-row"
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center gap-3 px-kro-medium py-2.5 text-left text-[15px]',
+        'outline-none focus-visible:shadow-[var(--kro-ring)]',
+      )}
+      style={{ color }}
+    >
+      <Icon size={16} strokeWidth={2} aria-hidden className="w-5 shrink-0" />
+      {label}
+    </button>
+  )
+}

--- a/packages/app/src/features/settings/pages/SettingsHubFragment.stories.tsx
+++ b/packages/app/src/features/settings/pages/SettingsHubFragment.stories.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from 'react'
+import { authUserMocks } from '../../auth/AuthMocks'
+import {
+  type SettingsSyncFooter,
+  accountHubSections,
+  preferencesHubSections,
+  profileHubSection,
+} from '../SettingsSelectors'
+import { SettingsHubFragment } from './SettingsHubFragment'
+
+/**
+ * The hub, in both sessions, at both widths and in both schemes.
+ *
+ * These are the stories the acceptance criteria are read against: canon's three
+ * groups, the profile row in each of its two states, and the sync footer's
+ * three reportable states plus the hidden one. Every one is built from the same
+ * section table the app renders, so a story cannot show a hub the surface could
+ * not produce.
+ */
+export default {
+  title: 'Settings/Hub',
+  component: SettingsHubFragment,
+  parameters: { layout: 'fullscreen' },
+}
+
+const noop = () => {}
+
+function Stage({
+  theme = 'light',
+  width,
+  children,
+}: {
+  theme?: 'light' | 'dark'
+  width: number
+  children: ReactNode
+}) {
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        width,
+        padding: 16,
+        background: 'var(--kro-color-back)',
+        border: '1px solid var(--kro-color-hairline)',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+const signedIn = {
+  accountName: authUserMocks.typical.name,
+  accountEmail: authUserMocks.typical.emails[0] ?? null,
+  accountInitials: 'AL',
+}
+
+const hub = (
+  overrides: Partial<Parameters<typeof SettingsHubFragment>[0]> = {},
+) => (
+  <SettingsHubFragment
+    profileSection={profileHubSection}
+    preferencesSections={preferencesHubSections}
+    accountSections={accountHubSections}
+    syncFooter={null}
+    accountName={null}
+    accountEmail={null}
+    accountInitials=""
+    onTapSection={noop}
+    onTapSignIn={noop}
+    onTapDone={noop}
+    {...overrides}
+  />
+)
+
+const SYNCED: SettingsSyncFooter = {
+  title: 'Synced',
+  isWarning: false,
+  glyph: 'checkmark.icloud',
+}
+const OFFLINE: SettingsSyncFooter = {
+  title: 'Offline — will sync later',
+  isWarning: true,
+  glyph: 'icloud.slash',
+}
+const SIGNED_OUT: SettingsSyncFooter = {
+  title: 'Sign in to sync across devices',
+  isWarning: false,
+  glyph: 'person.crop.circle.badge.questionmark',
+}
+
+/** Signed out: the row is an invitation and the footer prompts. */
+export const SignedOut = {
+  render: () => (
+    <Stage width={760}>{hub({ syncFooter: SIGNED_OUT })}</Stage>
+  ),
+}
+
+/** Signed in with a healthy sync — the ordinary desktop hub. */
+export const SignedInSynced = {
+  render: () => (
+    <Stage width={760}>{hub({ ...signedIn, syncFooter: SYNCED })}</Stage>
+  ),
+}
+
+/** The offline footer, which is the only one canon tints. */
+export const OfflineFooter = {
+  render: () => (
+    <Stage width={760}>{hub({ ...signedIn, syncFooter: OFFLINE })}</Stage>
+  ),
+}
+
+/** No footer at all — canon's `syncStatus: nil`, before anything is attempted. */
+export const NoFooter = {
+  render: () => <Stage width={760}>{hub(signedIn)}</Stage>,
+}
+
+/** Both schemes, side by side — the pairing the tokens are read against. */
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Stage theme="light" width={520}>
+        {hub({ ...signedIn, syncFooter: SYNCED })}
+      </Stage>
+      <Stage theme="dark" width={520}>
+        {hub({ ...signedIn, syncFooter: SYNCED })}
+      </Stage>
+    </div>
+  ),
+}
+
+/** The handheld width, where the hub is the whole destination. */
+export const Handheld = {
+  render: () => (
+    <Stage width={390}>{hub({ ...signedIn, syncFooter: OFFLINE })}</Stage>
+  ),
+}

--- a/packages/app/src/features/settings/pages/SettingsHubFragment.tsx
+++ b/packages/app/src/features/settings/pages/SettingsHubFragment.tsx
@@ -1,0 +1,304 @@
+'use client'
+
+/**
+ * The Settings hub — canon `SettingsHubView`, ported row for row (`RC-15`: it
+ * dispatches nothing; every intent is a callback prop).
+ *
+ * Canon's three `Section`s become three groups here: the lone Profile row, the
+ * labelled *Preferences* group, and the unlabelled Account group (Integrations,
+ * Subscription). The sync footer is canon's fourth section — *"a small footer
+ * reflecting the last sync"* — and, exactly as canon does, it is **hidden
+ * entirely** when there is nothing truthful to report yet.
+ *
+ * The Profile row carries the signed-in identity when there is one, because the
+ * hub is where a user looks for it; canon reaches the same place through
+ * `ProfileScreen(store:)` one push in. Signed out it is an invitation, and its
+ * callback is the auth entry point rather than a push into an empty pane.
+ */
+import { colorVar } from '../../../design/system/tokens/roles'
+import { SurfaceCard } from '../../../design/endeavor/SurfaceCard'
+import { cn } from '../../../design/system/utils/cn'
+import type { SettingsSyncFooter } from '../SettingsSelectors'
+import type { SettingsSection, SettingsSectionId } from '../SettingsSection'
+import { settingsIcon } from './settingsIcons'
+
+export interface SettingsHubFragmentProps {
+  readonly profileSection: SettingsSection
+  readonly preferencesSections: readonly SettingsSection[]
+  readonly accountSections: readonly SettingsSection[]
+  /** `null` hides the footer entirely — canon's `syncStatus: nil`. */
+  readonly syncFooter: SettingsSyncFooter | null
+  /** The signed-in account's display name, or `null` when signed out. */
+  readonly accountName: string | null
+  readonly accountEmail: string | null
+  readonly accountInitials: string
+  readonly onTapSection: (id: SettingsSectionId) => void
+  /** The signed-out Profile row's action — canon's `Sign In to Kro`. */
+  readonly onTapSignIn: () => void
+  /** Canon's toolbar `Done`. */
+  readonly onTapDone: () => void
+}
+
+export function SettingsHubFragment({
+  profileSection,
+  preferencesSections,
+  accountSections,
+  syncFooter,
+  accountName,
+  accountEmail,
+  accountInitials,
+  onTapSection,
+  onTapSignIn,
+  onTapDone,
+}: SettingsHubFragmentProps) {
+  const isSignedIn = accountEmail !== null
+
+  return (
+    <div
+      data-testid="settings-hub"
+      className="flex w-full flex-col gap-kro-large"
+    >
+      {/*
+        The header sits inside the shell's `indigoGrape` slab, so its two pieces
+        take `headerDate` rather than `fore`/`accent`: that is the role the
+        contrast suite asserts against **both** gradient stops in **both**
+        schemes, and it is the only text colour in the system with that
+        guarantee. `accent` here would be the Done button reading as a smudge on
+        the purple, which is exactly what it did before this note existed.
+      */}
+      <header className="flex items-center justify-between gap-kro-small">
+        <h2
+          className="m-0 text-xl font-semibold"
+          style={{ color: colorVar('headerDate') }}
+        >
+          Settings
+        </h2>
+        <button
+          type="button"
+          onClick={onTapDone}
+          className={cn(
+            'inline-flex h-9 items-center rounded-kro-small px-3 text-[15px] font-semibold',
+            'outline-none focus-visible:shadow-[var(--kro-ring)]',
+          )}
+          style={{ color: colorVar('headerDate') }}
+        >
+          Done
+        </button>
+      </header>
+
+      {/* Canon's first Section: the profile row, alone and unlabelled. */}
+      <SurfaceCard padding={null}>
+        <button
+          type="button"
+          data-testid="hub-profile-row"
+          onClick={() =>
+            isSignedIn ? onTapSection(profileSection.id) : onTapSignIn()
+          }
+          className={cn(
+            'flex w-full items-center gap-kro-small px-kro-medium py-3 text-left',
+            'outline-none focus-visible:shadow-[var(--kro-ring)]',
+          )}
+        >
+          <Avatar initials={accountInitials} isSignedIn={isSignedIn} />
+          <span className="flex min-w-0 flex-1 flex-col">
+            <span
+              className="truncate text-[15px] font-semibold"
+              style={{ color: colorVar('fore') }}
+            >
+              {isSignedIn ? accountName ?? 'Kro User' : 'Sign In to Kro'}
+            </span>
+            <span
+              className="truncate text-[13px]"
+              style={{ color: colorVar('foreSecondary') }}
+            >
+              {isSignedIn ? accountEmail : 'Sync your data across devices'}
+            </span>
+          </span>
+          <Chevron />
+        </button>
+      </SurfaceCard>
+
+      <HubGroup
+        title="Preferences"
+        sections={preferencesSections}
+        onTapSection={onTapSection}
+      />
+
+      <HubGroup title={null} sections={accountSections} onTapSection={onTapSection} />
+
+      {syncFooter === null ? null : (
+        <p
+          data-testid="sync-footer"
+          data-warning={syncFooter.isWarning}
+          role="status"
+          className="m-0 flex items-center justify-center gap-kro-tiny text-[13px]"
+          style={{
+            color: syncFooter.isWarning
+              ? colorVar('badgeOrange')
+              : colorVar('foreSecondary'),
+          }}
+        >
+          <FooterGlyph glyph={syncFooter.glyph} />
+          {syncFooter.title}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function FooterGlyph({ glyph }: { readonly glyph: string }) {
+  const Icon = settingsIcon(glyph)
+  return <Icon size={14} strokeWidth={2} aria-hidden />
+}
+
+function HubGroup({
+  title,
+  sections,
+  onTapSection,
+}: {
+  readonly title: string | null
+  readonly sections: readonly SettingsSection[]
+  readonly onTapSection: (id: SettingsSectionId) => void
+}) {
+  if (sections.length === 0) return null
+
+  return (
+    <section className="flex w-full flex-col gap-kro-small">
+      {title === null ? null : (
+        <h3
+          className="m-0 px-kro-tiny text-[13px] font-semibold uppercase tracking-wide"
+          style={{ color: colorVar('foreSecondary') }}
+        >
+          {title}
+        </h3>
+      )}
+      <SurfaceCard padding={null}>
+        <div className="flex w-full flex-col">
+          {sections.map((section, index) => (
+            <HubRow
+              key={section.id}
+              section={section}
+              isFirst={index === 0}
+              onTap={() => onTapSection(section.id)}
+            />
+          ))}
+        </div>
+      </SurfaceCard>
+    </section>
+  )
+}
+
+function HubRow({
+  section,
+  isFirst,
+  onTap,
+}: {
+  readonly section: SettingsSection
+  readonly isFirst: boolean
+  readonly onTap: () => void
+}) {
+  const Icon = settingsIcon(section.glyph)
+
+  return (
+    <>
+      {isFirst ? null : (
+        <div
+          aria-hidden
+          style={{
+            height: '0.75px',
+            marginLeft: 'var(--kro-space-medium)',
+            backgroundColor: colorVar('hairline'),
+          }}
+        />
+      )}
+      <button
+        type="button"
+        data-testid="hub-row"
+        data-section={section.id}
+        onClick={onTap}
+        className={cn(
+          'flex w-full items-center gap-kro-small px-kro-medium py-2.5 text-left',
+          'outline-none focus-visible:shadow-[var(--kro-ring)]',
+        )}
+      >
+        <Icon
+          size={18}
+          strokeWidth={2}
+          aria-hidden
+          className="shrink-0"
+          style={{ color: colorVar('foreSecondary') }}
+        />
+        <span
+          className="min-w-0 flex-1 truncate text-[15px]"
+          style={{ color: colorVar('fore') }}
+        >
+          {section.title}
+        </span>
+        <Chevron />
+      </button>
+    </>
+  )
+}
+
+function Chevron() {
+  const Icon = settingsIcon('chevron.right')
+  return (
+    <Icon
+      size={16}
+      strokeWidth={2.5}
+      aria-hidden
+      className="shrink-0"
+      style={{ color: colorVar('foreSecondary') }}
+    />
+  )
+}
+
+/**
+ * Canon's `initialsAvatar` — the indigo→grape gradient disc.
+ *
+ * Signed out it is the neutral person glyph canon draws instead, because there
+ * are no initials to show and `?` would read as an error.
+ */
+export function Avatar({
+  initials,
+  isSignedIn,
+  size = 40,
+}: {
+  readonly initials: string
+  readonly isSignedIn: boolean
+  readonly size?: number
+}) {
+  if (!isSignedIn) {
+    const Icon = settingsIcon('person.crop.circle')
+    return (
+      <span
+        data-testid="avatar-signed-out"
+        className="flex shrink-0 items-center justify-center rounded-full"
+        style={{
+          width: size,
+          height: size,
+          backgroundColor: colorVar('backInner'),
+          color: colorVar('foreSecondary'),
+        }}
+      >
+        <Icon size={Math.round(size * 0.55)} strokeWidth={2} aria-hidden />
+      </span>
+    )
+  }
+
+  return (
+    <span
+      data-testid="avatar-initials"
+      className="flex shrink-0 items-center justify-center rounded-full font-semibold"
+      style={{
+        width: size,
+        height: size,
+        fontSize: Math.round(size * 0.36),
+        color: colorVar('onAccent'),
+        backgroundImage: `linear-gradient(135deg, ${colorVar('headerGradientIndigo')}, ${colorVar('headerGradientGrape')})`,
+      }}
+    >
+      {initials.length === 0 ? '?' : initials}
+    </span>
+  )
+}

--- a/packages/app/src/features/settings/pages/SettingsHubPage.stories.tsx
+++ b/packages/app/src/features/settings/pages/SettingsHubPage.stories.tsx
@@ -1,0 +1,129 @@
+import type { ReactNode } from 'react'
+import { StoreProvider } from '../../../library/StoreProvider'
+import { type ThunkExtra, makeStore, stubbedThunkExtra } from '../../../library/store'
+import { GoogleCalendarConnections } from '../../../services/googleCalendar/GoogleCalendarConnection'
+import { makeStubbedGoogleCalendarService } from '../../../services/googleCalendar/GoogleCalendarService'
+import { makeInMemoryLocalStore } from '../../../services/localStore/InMemoryLocalStore'
+import { userDidTapSection } from '../SettingsFeature'
+import { SettingsSectionId } from '../SettingsSection'
+import { SettingsHubPage } from './SettingsHubPage'
+
+/**
+ * The whole surface, wired to a real store built with `makeStore(extra)`
+ * (`RC-22`) and fixture-backed Services (`RC-35`).
+ *
+ * The Fragment stories above show each pane in isolation; these show the
+ * surface a user actually meets — the hub on open, a pane after a tap, and the
+ * Integrations pane on the deployment a checkout starts as.
+ */
+export default {
+  title: 'Settings/Surface',
+  component: SettingsHubPage,
+  parameters: { layout: 'fullscreen' },
+}
+
+function Stage({
+  theme = 'light',
+  width = 900,
+  extra = stubbedThunkExtra,
+  section,
+  children,
+}: {
+  theme?: 'light' | 'dark'
+  width?: number
+  extra?: ThunkExtra
+  section?: SettingsSectionId
+  children?: ReactNode
+}) {
+  const store = makeStore(extra)
+  if (section !== undefined) store.dispatch(userDidTapSection(section))
+
+  return (
+    <div
+      data-theme={theme}
+      style={{
+        width,
+        minHeight: 620,
+        background: 'var(--kro-color-back)',
+        border: '1px solid var(--kro-color-hairline)',
+      }}
+    >
+      <StoreProvider store={store}>{children ?? <SettingsHubPage />}</StoreProvider>
+    </div>
+  )
+}
+
+const seededExtra: ThunkExtra = {
+  ...stubbedThunkExtra,
+  localStore: makeInMemoryLocalStore({
+    preferences: {
+      'kro:session.defaultDuration': 45,
+      'kro:session.soundOnEnd': false,
+    },
+  }),
+}
+
+/** The hub, as `/adjust` opens. */
+export const Hub = {
+  render: () => <Stage />,
+}
+
+/** The General pane, with every schema row on it. */
+export const GeneralPane = {
+  render: () => <Stage section={SettingsSectionId.general} />,
+}
+
+/** The Session pane over stored values rather than defaults. */
+export const SessionPane = {
+  render: () => (
+    <Stage extra={seededExtra} section={SettingsSectionId.sessionPreferences} />
+  ),
+}
+
+/** Integrations on a deployment with no Google client — the honest state. */
+export const IntegrationsUnconfigured = {
+  render: () => (
+    <Stage
+      section={SettingsSectionId.integrations}
+      extra={{
+        ...stubbedThunkExtra,
+        googleCalendar: makeStubbedGoogleCalendarService({
+          connection: GoogleCalendarConnections.unconfigured([
+            'GOOGLE_CLIENT_ID',
+            'GOOGLE_CLIENT_SECRET',
+          ]),
+        }),
+      }}
+    />
+  ),
+}
+
+/** Integrations with a live grant. */
+export const IntegrationsConnected = {
+  render: () => (
+    <Stage
+      section={SettingsSectionId.integrations}
+      extra={{
+        ...stubbedThunkExtra,
+        googleCalendar: makeStubbedGoogleCalendarService({
+          connection: GoogleCalendarConnections.connected(),
+        }),
+      }}
+    />
+  ),
+}
+
+/** The handheld width, where the surface fills the destination. */
+export const Handheld = {
+  render: () => <Stage width={390} />,
+}
+
+/** Both schemes at the desktop frame. */
+export const BothSchemes = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Stage theme="light" width={520} />
+      <Stage theme="dark" width={520} />
+    </div>
+  ),
+}

--- a/packages/app/src/features/settings/pages/SettingsHubPage.tsx
+++ b/packages/app/src/features/settings/pages/SettingsHubPage.tsx
@@ -1,0 +1,299 @@
+'use client'
+
+/**
+ * The Settings surface's stateful container (`RC-37`; implements `UZF-4`).
+ *
+ * The `/adjust` destination's body: the hub, or one drill-down pane. It is the
+ * only artifact in this feature that calls both `useAppSelector` and
+ * `useAppDispatch`, and it owns no markup of its own beyond the frame and the
+ * one Fragment call per pane.
+ *
+ * ## The two sync triggers, and which one is the acceptance criterion
+ *
+ * KC-IS-#31 declares four `SettingsSyncTrigger`s and the rules over them.
+ * Two are this surface's:
+ *
+ * - **`settingsOpened`** fires on mount. It resolves `skipped` by design —
+ *   canon is emphatic that opening Settings does **not** pull, *"so a change
+ *   made while offline isn't overwritten just because the user reopened
+ *   Settings"* — and firing it anyway is what keeps that rule exercised rather
+ *   than merely written down.
+ * - **`settingsClosed`** fires when the surface goes away. That is the push
+ *   canon describes: *"On closing Settings, it sends the current synced values
+ *   back to the account."*
+ *
+ * "Closing" is unmount, not the Done button, and deliberately: leaving
+ * `/adjust` through the sidebar, the tab bar, the browser's back button or Done
+ * are all the same event to the user, and hanging the push off one of them
+ * would drop the other three.
+ *
+ * ## The desktop frame
+ *
+ * Canon presents the hub as a sheet with `.frame(minWidth: 760, minHeight:
+ * 620)` on the Mac and full-bleed on the phone. `presentationFor(...)` is the
+ * ported decision table, so the frame comes from the same cell the rest of the
+ * shell reads rather than from a media query written here.
+ */
+import type { SettingValue } from '@kro/core'
+import { useCallback, useEffect } from 'react'
+import { syncSettingsThunk } from '../../auth/AuthProducer'
+import { SettingsSyncTrigger } from '../../auth/CloudSettings'
+import { signOutThunk } from '../../auth/AuthProducer'
+import { selectCurrentUser, selectUserInitials } from '../../auth/AuthSelectors'
+import { colorVar } from '../../../design/system/tokens/roles'
+import { cn } from '../../../design/system/utils/cn'
+import { useAppDispatch, useAppSelector } from '../../../library/hooks'
+import { onDestinationRouteMounted } from '../../main/MainFeature'
+import {
+  PresentationSurface,
+  presentationFor,
+  presentationStyle,
+} from '../../main/MainPresentation'
+import { navigateToDestinationThunk } from '../../main/MainProducer'
+import { selectSurface } from '../../main/MainSelectors'
+import { DestinationKind } from '../../main/SidebarDestination'
+import {
+  userDidTapBackToHub,
+  userDidTapSection,
+  userDidTapSignIn,
+} from '../SettingsFeature'
+import {
+  connectGoogleThunk,
+  disconnectGoogleThunk,
+  loadGoogleConnectionThunk,
+  loadSettingsThunk,
+  updateSettingThunk,
+} from '../SettingsProducer'
+import {
+  accountHubSections,
+  preferencesHubSections,
+  profileHubSection,
+  selectIntegrationRows,
+  selectIsSettingsLoaded,
+  selectOpenSection,
+  selectSettingValues,
+  selectSettingsErrorCopy,
+  selectSettingsSyncFooter,
+  selectWorkingHoursValid,
+} from '../SettingsSelectors'
+import {
+  SettingsPaneKind,
+  type SettingsSectionId,
+  settingsPaneKind,
+  settingsSectionForId,
+  settingsSectionTitle,
+} from '../SettingsSection'
+import { AccountSectionFragment } from './AccountSectionFragment'
+import { IntegrationsSectionFragment } from './IntegrationsSectionFragment'
+import { PreferencesSectionFragment } from './PreferencesSectionFragment'
+import { SettingsHubFragment } from './SettingsHubFragment'
+import { settingsIcon } from './settingsIcons'
+
+export function SettingsHubPage() {
+  const dispatch = useAppDispatch()
+
+  const openSection = useAppSelector(selectOpenSection)
+  const values = useAppSelector(selectSettingValues)
+  const isLoaded = useAppSelector(selectIsSettingsLoaded)
+  const isWorkingHoursValid = useAppSelector(selectWorkingHoursValid)
+  const errorCopy = useAppSelector(selectSettingsErrorCopy)
+  const syncFooter = useAppSelector(selectSettingsSyncFooter)
+  const integrationRows = useAppSelector(selectIntegrationRows)
+  const user = useAppSelector(selectCurrentUser)
+  const initials = useAppSelector(selectUserInitials)
+  const surface = useAppSelector(selectSurface)
+
+  const presentation = presentationFor(PresentationSurface.settings, surface)
+
+  // Open: tell the shell which destination this is (the job the shared
+  // `DestinationPage` did before this Page replaced it — it is what keeps the
+  // URL the authority for the sidebar's highlight), read the snapshot, ask the
+  // deployment about Google, and fire the trigger canon defines for this
+  // moment (which correctly does nothing).
+  useEffect(() => {
+    dispatch(
+      onDestinationRouteMounted({
+        destination: { kind: DestinationKind.settings },
+      }),
+    )
+    const load = dispatch(loadSettingsThunk())
+    const google = dispatch(loadGoogleConnectionThunk())
+    void dispatch(
+      syncSettingsThunk({
+        trigger: SettingsSyncTrigger.settingsOpened,
+        now: new Date(),
+      }),
+    )
+    return () => {
+      load.abort()
+      google.abort()
+    }
+  }, [dispatch])
+
+  // Close: the push. Separate from the load effect so a re-run of one can never
+  // fire the other, and so the cleanup reads as what it is.
+  useEffect(
+    () => () => {
+      void dispatch(
+        syncSettingsThunk({
+          trigger: SettingsSyncTrigger.settingsClosed,
+          now: new Date(),
+        }),
+      )
+    },
+    [dispatch],
+  )
+
+  const onChangeSetting = useCallback(
+    (key: string, value: SettingValue) => {
+      void dispatch(updateSettingThunk({ key, value }))
+    },
+    [dispatch],
+  )
+
+  const onTapDone = useCallback(() => {
+    void dispatch(
+      navigateToDestinationThunk({ destination: { kind: DestinationKind.myDay } }),
+    )
+  }, [dispatch])
+
+  const section =
+    openSection === null ? null : settingsSectionForId(openSection)
+
+  return (
+    <div className="flex w-full justify-center p-kro-medium">
+      <div
+        data-testid="settings-surface"
+        data-presentation={presentation.kind}
+        className="flex w-full max-w-[760px] flex-col gap-kro-medium"
+        style={presentationStyle(presentation)}
+      >
+        {section === null ? (
+          <SettingsHubFragment
+            profileSection={profileHubSection}
+            preferencesSections={preferencesHubSections}
+            accountSections={accountHubSections}
+            syncFooter={syncFooter}
+            accountName={user?.name ?? null}
+            accountEmail={user === null ? null : (user.emails[0] ?? '')}
+            accountInitials={initials}
+            onTapSection={(id: SettingsSectionId) =>
+              dispatch(userDidTapSection(id))
+            }
+            onTapSignIn={() =>
+              dispatch(userDidTapSignIn({ origin: 'settingsHub' }))
+            }
+            onTapDone={onTapDone}
+          />
+        ) : (
+          <>
+            <PaneHeader
+              title={settingsSectionTitle(section.id)}
+              onTapBack={() => dispatch(userDidTapBackToHub())}
+            />
+
+            {/*
+              The shell's `indigoGrape` slab is 180px tall and a pane opens
+              inside it. The header is legible on it and so is a white card, but
+              a *subgroup label* — small, secondary, uppercase — is not: without
+              this spacer "WORKING HOURS" landed in the solid part of the
+              gradient and disappeared. The hub needs none because its profile
+              card already pushes the first label past the fade.
+            */}
+            <div className="pt-kro-large" />
+
+            {settingsPaneKind(section.id) === SettingsPaneKind.preferences &&
+            section.settingGroup !== null ? (
+              <PreferencesSectionFragment
+                group={section.settingGroup}
+                values={values}
+                isLoaded={isLoaded}
+                isWorkingHoursValid={isWorkingHoursValid}
+                errorCopy={errorCopy}
+                onChangeSetting={onChangeSetting}
+              />
+            ) : null}
+
+            {settingsPaneKind(section.id) === SettingsPaneKind.integrations ? (
+              <IntegrationsSectionFragment
+                rows={integrationRows}
+                errorCopy={errorCopy}
+                onTapConnect={() => {
+                  void dispatch(connectGoogleThunk())
+                }}
+                onTapDisconnect={() => {
+                  void dispatch(disconnectGoogleThunk())
+                }}
+              />
+            ) : null}
+
+            {settingsPaneKind(section.id) === SettingsPaneKind.profile ? (
+              <AccountSectionFragment
+                pane="profile"
+                user={user}
+                onTapSignIn={() =>
+                  dispatch(userDidTapSignIn({ origin: 'settingsHub' }))
+                }
+                onTapSignOut={() => {
+                  void dispatch(signOutThunk())
+                }}
+              />
+            ) : null}
+
+            {settingsPaneKind(section.id) === SettingsPaneKind.subscription ? (
+              <AccountSectionFragment
+                pane="subscription"
+                user={user}
+                onTapSignIn={() =>
+                  dispatch(userDidTapSignIn({ origin: 'settingsHub' }))
+                }
+                onTapSignOut={() => {
+                  void dispatch(signOutThunk())
+                }}
+              />
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Canon's pushed-pane navigation bar: a back affordance and the title. */
+function PaneHeader({
+  title,
+  onTapBack,
+}: {
+  readonly title: string
+  readonly onTapBack: () => void
+}) {
+  const Icon = settingsIcon('chevron.left')
+
+  // Both pieces sit inside the shell's `indigoGrape` slab, so both take
+  // `headerDate` — the one text role with a contrast assertion against both
+  // gradient stops in both schemes. See `SettingsHubFragment`'s header note.
+  return (
+    <header className="flex items-center gap-kro-small">
+      <button
+        type="button"
+        data-testid="pane-back"
+        aria-label="Back to Settings"
+        onClick={onTapBack}
+        className={cn(
+          'inline-flex h-9 items-center gap-1 rounded-kro-small px-2 text-[15px] font-medium',
+          'outline-none focus-visible:shadow-[var(--kro-ring)]',
+        )}
+        style={{ color: colorVar('headerDate') }}
+      >
+        <Icon size={16} strokeWidth={2.5} aria-hidden />
+        Settings
+      </button>
+      <h2
+        className="m-0 text-lg font-semibold"
+        style={{ color: colorVar('headerDate') }}
+      >
+        {title}
+      </h2>
+    </header>
+  )
+}

--- a/packages/app/src/features/settings/pages/SettingsHubPage.tsx
+++ b/packages/app/src/features/settings/pages/SettingsHubPage.tsx
@@ -69,7 +69,7 @@ import {
   preferencesHubSections,
   profileHubSection,
   selectIntegrationRows,
-  selectIsSettingsLoaded,
+  selectIsSettingsEditable,
   selectOpenSection,
   selectSettingValues,
   selectSettingsErrorCopy,
@@ -94,7 +94,7 @@ export function SettingsHubPage() {
 
   const openSection = useAppSelector(selectOpenSection)
   const values = useAppSelector(selectSettingValues)
-  const isLoaded = useAppSelector(selectIsSettingsLoaded)
+  const isEditable = useAppSelector(selectIsSettingsEditable)
   const isWorkingHoursValid = useAppSelector(selectWorkingHoursValid)
   const errorCopy = useAppSelector(selectSettingsErrorCopy)
   const syncFooter = useAppSelector(selectSettingsSyncFooter)
@@ -207,7 +207,7 @@ export function SettingsHubPage() {
               <PreferencesSectionFragment
                 group={section.settingGroup}
                 values={values}
-                isLoaded={isLoaded}
+                isLoaded={isEditable}
                 isWorkingHoursValid={isWorkingHoursValid}
                 errorCopy={errorCopy}
                 onChangeSetting={onChangeSetting}

--- a/packages/app/src/features/settings/pages/__tests__/AccountSectionFragment.test.tsx
+++ b/packages/app/src/features/settings/pages/__tests__/AccountSectionFragment.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * The two account panes' render tests, mirroring
+ * `AccountSectionFragment.stories.tsx` (`RC-11`).
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { authUserMocks } from '../../../auth/AuthMocks'
+import { AccountSectionFragment } from '../AccountSectionFragment'
+
+afterEach(cleanup)
+
+const renderPane = (
+  overrides: Partial<Parameters<typeof AccountSectionFragment>[0]> = {},
+) =>
+  render(
+    <AccountSectionFragment
+      pane="profile"
+      user={authUserMocks.typical}
+      onTapSignIn={() => {}}
+      onTapSignOut={() => {}}
+      {...overrides}
+    />,
+  )
+
+describe('the signed-in Profile pane', () => {
+  it('leads with the identity and the initials avatar', () => {
+    renderPane()
+
+    expect(screen.getByTestId('avatar-initials').textContent).toBe('AL')
+    expect(screen.getAllByText('Ada Lovelace').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('ada@example.com').length).toBeGreaterThan(0)
+  })
+
+  it("names canon Account rows, including the sign-in method", () => {
+    renderPane()
+
+    expect(screen.getByText('Account')).toBeTruthy()
+    expect(screen.getByText('Member since')).toBeTruthy()
+    // The typical fixture signed in with email/password AND lists it as a
+    // connected provider, so the string is on screen twice by design.
+    expect(screen.getAllByText('Email & Password')).toHaveLength(2)
+  })
+
+  it('shows "Not set" rather than an empty row for absent personal info', () => {
+    renderPane()
+
+    expect(screen.getAllByText('Not set').length).toBeGreaterThan(0)
+  })
+
+  it('lists a second connected provider by name', () => {
+    renderPane({ user: authUserMocks.google })
+
+    expect(screen.getByText('Google, Email & Password')).toBeTruthy()
+  })
+
+  it('offers Sign Out and reports the tap', async () => {
+    const onTapSignOut = vi.fn()
+    renderPane({ onTapSignOut })
+
+    await userEvent.click(screen.getByTestId('sign-out'))
+
+    expect(onTapSignOut).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns that signing out clears this device preferences', () => {
+    renderPane()
+
+    expect(
+      screen.getByText(/clears the preferences saved on this device/),
+    ).toBeTruthy()
+  })
+})
+
+describe('the signed-out Profile pane', () => {
+  it("shows canon Not Signed In placeholder", () => {
+    renderPane({ user: null })
+
+    expect(screen.getByText('Not Signed In')).toBeTruthy()
+    expect(
+      screen.getByText('Sign in to view and manage your profile.'),
+    ).toBeTruthy()
+  })
+
+  it('offers a way out of the placeholder rather than a dead end', async () => {
+    const onTapSignIn = vi.fn()
+    renderPane({ user: null, onTapSignIn })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Sign In' }))
+
+    expect(onTapSignIn).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers no Sign Out when there is no session', () => {
+    renderPane({ user: null })
+
+    expect(screen.queryByTestId('sign-out')).toBeNull()
+  })
+})
+
+describe('the Subscription pane mirrors canon row-with-no-flow', () => {
+  it('names the current plan', () => {
+    renderPane({ pane: 'subscription' })
+
+    expect(screen.getByText('Current plan')).toBeTruthy()
+    expect(screen.getByText('Free')).toBeTruthy()
+  })
+
+  it('offers no management control, because there is nothing behind one', () => {
+    renderPane({ pane: 'subscription' })
+
+    expect(
+      screen.queryByRole('button', { name: /Manage Subscription/ }),
+    ).toBeNull()
+  })
+
+  it('says why rather than leaving the absence unexplained', () => {
+    renderPane({ pane: 'subscription' })
+
+    expect(screen.getByText(/Kro has no paid plan yet/)).toBeTruthy()
+  })
+
+  it('renders the same content whether or not anyone is signed in', () => {
+    const signedIn = renderPane({ pane: 'subscription' })
+    const withPlan = screen.getByText('Free')
+    expect(withPlan).toBeTruthy()
+    signedIn.unmount()
+
+    renderPane({ pane: 'subscription', user: null })
+    expect(screen.getByText('Free')).toBeTruthy()
+  })
+})

--- a/packages/app/src/features/settings/pages/__tests__/IntegrationsSectionFragment.test.tsx
+++ b/packages/app/src/features/settings/pages/__tests__/IntegrationsSectionFragment.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * The Integrations pane's render tests, mirroring
+ * `IntegrationsSectionFragment.stories.tsx` (`RC-11`).
+ */
+import { cleanup, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { IntegrationId, integrationRows } from '../../SettingsIntegrations'
+import type { GoogleConnectionState } from '../../SettingsState'
+import { IntegrationsSectionFragment } from '../IntegrationsSectionFragment'
+
+afterEach(cleanup)
+
+const renderPane = (
+  connection: GoogleConnectionState,
+  overrides: {
+    isBusy?: boolean
+    errorCopy?: string | null
+    onTapConnect?: (id: string) => void
+    onTapDisconnect?: (id: string) => void
+  } = {},
+) =>
+  render(
+    <IntegrationsSectionFragment
+      rows={integrationRows({
+        connection,
+        isBusy: overrides.isBusy ?? false,
+        isGoogleEnabled: true,
+      })}
+      errorCopy={overrides.errorCopy ?? null}
+      onTapConnect={overrides.onTapConnect ?? (() => {})}
+      onTapDisconnect={overrides.onTapDisconnect ?? (() => {})}
+    />,
+  )
+
+const rowFor = (id: string) =>
+  screen
+    .getAllByTestId('integration-row')
+    .find((row) => row.getAttribute('data-integration') === id) as HTMLElement
+
+describe('the pane lists canon four rows', () => {
+  it('renders Kro Cloud, Google and the two Apple rows', () => {
+    renderPane({ kind: 'disconnected' })
+
+    expect(screen.getByText('Kro Cloud')).toBeTruthy()
+    expect(screen.getByText('Google Calendar')).toBeTruthy()
+    expect(screen.getByText('Apple Calendar')).toBeTruthy()
+    expect(screen.getByText('Apple Reminders')).toBeTruthy()
+  })
+
+  it('marks Kro Cloud connected, with the state spoken as well as tinted', () => {
+    renderPane({ kind: 'disconnected' })
+
+    const mark = within(rowFor(IntegrationId.kroCloud)).getByTestId(
+      'integration-connected',
+    )
+    expect(mark.textContent).toContain('Connected')
+  })
+
+  it('renders the two Apple rows with a disabled Connect and says why', () => {
+    renderPane({ kind: 'connected' })
+
+    const button = within(rowFor(IntegrationId.appleCalendar)).getByRole('button', {
+      name: 'Connect Apple Calendar',
+    }) as HTMLButtonElement
+
+    expect(button.disabled).toBe(true)
+    expect(rowFor(IntegrationId.appleCalendar).textContent).toContain(
+      'Not available on the web',
+    )
+  })
+})
+
+describe('the Google row offers the affordance its state implies', () => {
+  it('offers Connect to a user who has never granted the scope', async () => {
+    const onTapConnect = vi.fn()
+    renderPane({ kind: 'disconnected' }, { onTapConnect })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Connect Google Calendar' }),
+    )
+
+    expect(onTapConnect).toHaveBeenCalledWith(IntegrationId.google)
+  })
+
+  it('offers Disconnect beside the connected mark on a live grant', async () => {
+    const onTapDisconnect = vi.fn()
+    renderPane({ kind: 'connected' }, { onTapDisconnect })
+
+    expect(
+      within(rowFor(IntegrationId.google)).getByTestId('integration-connected'),
+    ).toBeTruthy()
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Disconnect Google Calendar' }),
+    )
+
+    expect(onTapDisconnect).toHaveBeenCalledWith(IntegrationId.google)
+  })
+
+  it('offers Reconnect — never Connect — after a grant stops working', () => {
+    renderPane({ kind: 'needsReconnect' })
+
+    expect(
+      screen.getByRole('button', { name: 'Reconnect Google Calendar' }),
+    ).toBeTruthy()
+    expect(
+      screen.queryByRole('button', { name: 'Connect Google Calendar' }),
+    ).toBeNull()
+  })
+
+  it('offers a disabled Connect on a deployment with no Google client, and explains', () => {
+    renderPane({ kind: 'unconfigured', missing: ['GOOGLE_CLIENT_ID'] })
+
+    const button = within(rowFor(IntegrationId.google)).getByRole('button', {
+      name: 'Connect Google Calendar',
+    }) as HTMLButtonElement
+
+    expect(button.disabled).toBe(true)
+    expect(rowFor(IntegrationId.google).textContent).toContain(
+      'no Google client is configured',
+    )
+  })
+
+  it('replaces the affordance with a busy state while an attempt is in flight', () => {
+    renderPane({ kind: 'disconnected' }, { isBusy: true })
+
+    expect(
+      within(rowFor(IntegrationId.google)).getByTestId('integration-busy'),
+    ).toBeTruthy()
+    expect(
+      screen.queryByRole('button', { name: 'Connect Google Calendar' }),
+    ).toBeNull()
+  })
+})
+
+describe('a failure is reported without hiding the rows', () => {
+  it('renders the banner above the list', () => {
+    renderPane(
+      { kind: 'connected' },
+      { errorCopy: 'The connection could not be changed. Please try again.' },
+    )
+
+    expect(
+      screen.getByText('The connection could not be changed. Please try again.'),
+    ).toBeTruthy()
+  })
+
+  it('keeps every row on screen while it warns', () => {
+    renderPane({ kind: 'connected' }, { errorCopy: 'Something went wrong.' })
+
+    expect(screen.getAllByTestId('integration-row')).toHaveLength(4)
+  })
+
+  it('renders nothing extra when there is no failure', () => {
+    renderPane({ kind: 'connected' })
+
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+})

--- a/packages/app/src/features/settings/pages/__tests__/PreferencesSectionFragment.test.tsx
+++ b/packages/app/src/features/settings/pages/__tests__/PreferencesSectionFragment.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * The schema-driven pane's render tests, mirroring
+ * `PreferencesSectionFragment.stories.tsx` (`RC-11`).
+ *
+ * The first block is the acceptance criterion rendered: every option the schema
+ * declares for a group is on screen, exactly once, with the control its
+ * declared type implies.
+ */
+import { SettingGroup, settingGroups, settingOptionsByGroup } from '@kro/core'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SettingsMocks, defaultSettingValues } from '../../SettingsMocks'
+import { PreferencesSectionFragment } from '../PreferencesSectionFragment'
+
+afterEach(cleanup)
+
+const renderPane = (
+  overrides: Partial<Parameters<typeof PreferencesSectionFragment>[0]> = {},
+) =>
+  render(
+    <PreferencesSectionFragment
+      group={SettingGroup.general}
+      values={defaultSettingValues}
+      isLoaded
+      onChangeSetting={() => {}}
+      {...overrides}
+    />,
+  )
+
+describe('every schema option renders exactly once', () => {
+  it.each(settingGroups)('renders one row per declared %s option', (group) => {
+    renderPane({ group })
+
+    const rows = screen.getAllByTestId('setting-row')
+    const keys = rows.map((row) => row.getAttribute('data-setting-key'))
+
+    expect(keys.sort()).toEqual(
+      settingOptionsByGroup[group].map((option) => option.key).sort(),
+    )
+  })
+
+  it('gives each row canon copy rather than the key', () => {
+    renderPane({ group: SettingGroup.do })
+
+    expect(screen.getByText('“Now” window')).toBeTruthy()
+    expect(screen.getByText('Auto-advance after complete')).toBeTruthy()
+  })
+
+  it('groups them into canon sections, with canon footers', () => {
+    renderPane({ group: SettingGroup.session })
+
+    expect(screen.getByText('Durations')).toBeTruthy()
+    expect(screen.getByText('Modes')).toBeTruthy()
+    expect(
+      screen.getByText(
+        'Stopwatch and breaks also depend on their feature flags being enabled.',
+      ),
+    ).toBeTruthy()
+  })
+})
+
+describe('the control matches the declared value shape', () => {
+  it('renders a bool as a switch and reports the flip', async () => {
+    const onChangeSetting = vi.fn()
+    renderPane({ onChangeSetting })
+
+    const toggle = screen.getByRole('switch', { name: 'Overdue alerts' })
+    expect(toggle.getAttribute('aria-checked')).toBe('true')
+
+    await userEvent.click(toggle)
+    expect(onChangeSetting).toHaveBeenCalledWith('general.overdueAlerts', false)
+  })
+
+  it('renders a timeOfDay as a time field showing canon default', () => {
+    renderPane()
+
+    const start = screen.getByLabelText('Start') as HTMLInputElement
+    expect(start.type).toBe('time')
+    expect(start.value).toBe('09:00')
+  })
+
+  it('renders a daysSet as seven pressable chips with the default week selected', () => {
+    renderPane()
+
+    const group = screen.getByRole('group', { name: 'Working days' })
+    const chips = within(group).getAllByRole('button')
+
+    expect(chips).toHaveLength(7)
+    expect(
+      within(group).getByRole('button', { name: 'Monday' }).getAttribute('aria-pressed'),
+    ).toBe('true')
+    expect(
+      within(group).getByRole('button', { name: 'Sunday' }).getAttribute('aria-pressed'),
+    ).toBe('false')
+  })
+
+  it('adds a day to the mask when a chip is pressed', async () => {
+    const onChangeSetting = vi.fn()
+    renderPane({ onChangeSetting })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Saturday' }))
+
+    const [key, value] = onChangeSetting.mock.calls[0] ?? []
+    expect(key).toBe('general.workingDays')
+    expect(typeof value).toBe('number')
+    expect(value).not.toBe(defaultSettingValues['general.workingDays'])
+  })
+
+  it("renders an int as canon Stepper, stepping by canon step", async () => {
+    const onChangeSetting = vi.fn()
+    renderPane({ group: SettingGroup.session, onChangeSetting })
+
+    expect(screen.getAllByTestId('stepper-value')[0]?.textContent).toBe('20 min')
+    await userEvent.click(screen.getByRole('button', { name: 'Increase Session' }))
+
+    expect(onChangeSetting).toHaveBeenCalledWith('session.defaultDuration', 25)
+  })
+
+  it('renders an enumeration as a picker whose options carry canon labels', async () => {
+    const onChangeSetting = vi.fn()
+    renderPane({ group: SettingGroup.earn, onChangeSetting })
+
+    const picker = screen.getByRole('combobox', { name: 'Points formula' })
+    expect(within(picker).getByText('Sliding scale')).toBeTruthy()
+
+    await userEvent.selectOptions(picker, 'legacy')
+    expect(onChangeSetting).toHaveBeenCalledWith('earn.pointsFormula', 'legacy')
+  })
+
+  it("renders the accent choice as canon swatch radio group", () => {
+    renderPane()
+
+    const swatches = screen.getByRole('radiogroup', { name: 'Accent color' })
+    expect(within(swatches).getAllByRole('radio')).toHaveLength(6)
+    expect(
+      within(swatches).getByRole('radio', { name: 'Blue' }).getAttribute('aria-checked'),
+    ).toBe('true')
+  })
+})
+
+describe('the working-hours warning', () => {
+  it('is silent on a valid day', () => {
+    renderPane({ isWorkingHoursValid: true })
+    expect(screen.queryByTestId('working-hours-warning')).toBeNull()
+  })
+
+  it("shows canon sentence when the end is not after the start", () => {
+    renderPane({
+      values: SettingsMocks.generalPaneInvalidHours.values,
+      isWorkingHoursValid: false,
+    })
+
+    expect(screen.getByTestId('working-hours-warning').textContent).toContain(
+      'End time must be after start time.',
+    )
+  })
+
+  it('leaves both entered values on screen while it warns', () => {
+    renderPane({
+      values: SettingsMocks.generalPaneInvalidHours.values,
+      isWorkingHoursValid: false,
+    })
+
+    expect((screen.getByLabelText('Start') as HTMLInputElement).value).toBe('18:00')
+    expect((screen.getByLabelText('End') as HTMLInputElement).value).toBe('09:00')
+  })
+})
+
+describe('the schema drives the badges', () => {
+  it("marks the device-local options with canon On this device", () => {
+    renderPane()
+
+    const themeRow = screen
+      .getAllByTestId('setting-row')
+      .find((row) => row.getAttribute('data-setting-key') === 'general.appearance')
+
+    expect(within(themeRow as HTMLElement).getByTestId('scope-badge')).toBeTruthy()
+  })
+
+  it('does not badge a cloud-scoped option', () => {
+    renderPane({ group: SettingGroup.plan })
+
+    const row = screen
+      .getAllByTestId('setting-row')
+      .find((candidate) => candidate.getAttribute('data-setting-key') === 'plan.listSort')
+
+    expect(within(row as HTMLElement).queryByTestId('scope-badge')).toBeNull()
+  })
+
+  it('says out loud which options canon stores but never reads', () => {
+    renderPane({ group: SettingGroup.earn })
+
+    const row = screen
+      .getAllByTestId('setting-row')
+      .find(
+        (candidate) =>
+          candidate.getAttribute('data-setting-key') === 'earn.showWeeklyChallenge',
+      )
+
+    expect(within(row as HTMLElement).getByTestId('declared-badge')).toBeTruthy()
+  })
+})
+
+describe('the pre-load guard', () => {
+  it("disables every control until the values arrive — canon disabled(!isLoaded)", () => {
+    renderPane({ isLoaded: false })
+
+    expect(
+      (screen.getByRole('switch', { name: 'Overdue alerts' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true)
+    expect((screen.getByLabelText('Start') as HTMLInputElement).disabled).toBe(true)
+  })
+
+  it('re-enables them once loaded', () => {
+    renderPane({ isLoaded: true })
+
+    expect(
+      (screen.getByRole('switch', { name: 'Overdue alerts' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false)
+  })
+
+  it('surfaces a failure banner above the form without hiding it', () => {
+    renderPane({ errorCopy: 'Your preferences could not be read on this device.' })
+
+    expect(
+      screen.getByText('Your preferences could not be read on this device.'),
+    ).toBeTruthy()
+    expect(screen.getAllByTestId('setting-row').length).toBeGreaterThan(0)
+  })
+})

--- a/packages/app/src/features/settings/pages/__tests__/ProfileControlPage.test.tsx
+++ b/packages/app/src/features/settings/pages/__tests__/ProfileControlPage.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * The shell-wide profile control's container, against a real store built with
+ * `makeStore(stubbedThunkExtra)` (`RC-22`, `RC-35`).
+ *
+ * The popover's *panel* is not opened here on purpose: mounting a Radix popper
+ * under jsdom costs seconds (the measurement is in the design system's own
+ * `radixEnvironment` note), and the panel's content is
+ * `ProfilePopoverFragment`, which has its own render tests. What this suite
+ * owns is the wiring — the trigger, the slot, and the two dialogs.
+ */
+import { epochMillisFromDate } from '@kro/core'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+import { StoreProvider } from '../../../../library/StoreProvider'
+import {
+  type ThunkExtra,
+  makeStore,
+  stubbedThunkExtra,
+} from '../../../../library/store'
+import {
+  restoreSessionThunk,
+  signInWithEmailThunk,
+} from '../../../auth/AuthProducer'
+import { makeStubbedAuthService } from '../../../../services/auth/AuthService'
+import { makeInMemoryLocalStore } from '../../../../services/localStore/InMemoryLocalStore'
+import { authUserMocks } from '../../../auth/AuthMocks'
+import { ToolbarOutlet, ToolbarSlotsProvider } from '../../../main/ToolbarSlots'
+import { userDidTapSignIn } from '../../SettingsFeature'
+import { ProfileControlPage } from '../ProfileControlPage'
+
+afterEach(cleanup)
+
+const renderControl = (extra: ThunkExtra = stubbedThunkExtra) => {
+  const store = makeStore(extra)
+  const view = render(
+    <StoreProvider store={store}>
+      <ToolbarSlotsProvider>
+        <ToolbarOutlet placement="profile" />
+        <ProfileControlPage />
+      </ToolbarSlotsProvider>
+    </StoreProvider>,
+  )
+  return { store, view }
+}
+
+describe('the toolbar control', () => {
+  it("fills the shell's profile slot rather than rendering in place", async () => {
+    renderControl()
+
+    const outlet = document.querySelector('[data-toolbar-outlet="profile"]')
+    await waitFor(() => {
+      expect(outlet?.querySelector('[data-testid="profile-control"]')).toBeTruthy()
+    })
+  })
+
+  it('is labelled Profile, so the shell control keeps its accessible name', async () => {
+    renderControl()
+
+    expect(await screen.findByRole('button', { name: 'Profile' })).toBeTruthy()
+  })
+
+  it('draws the neutral glyph while signed out', async () => {
+    renderControl()
+
+    await screen.findByTestId('profile-control')
+    expect(screen.getByTestId('avatar-signed-out')).toBeTruthy()
+  })
+
+  it('draws the initials avatar once a session exists', async () => {
+    renderControl({
+      ...stubbedThunkExtra,
+      authService: makeStubbedAuthService({ initialUser: authUserMocks.typical }),
+    })
+
+    // No explicit dispatch: the control fires the launch restore itself, which
+    // is the behaviour a reload depends on.
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar-initials').textContent).toBe('AL')
+    })
+  })
+
+  it('fires the launch restore itself, so a reload resolves the session', async () => {
+    const { store } = renderControl({
+      ...stubbedThunkExtra,
+      authService: makeStubbedAuthService({}),
+    })
+
+    await waitFor(() => {
+      expect(store.getState().auth.session.kind).not.toBe('unknown')
+    })
+  })
+})
+
+describe('the auth surface', () => {
+  it('is absent until an entry point asks for it', async () => {
+    renderControl()
+
+    await screen.findByTestId('profile-control')
+    expect(screen.queryByTestId('auth-modal')).toBeNull()
+  })
+
+  it('presents on the hub sign-in intent, from anywhere in the app', async () => {
+    const { store } = renderControl()
+
+    store.dispatch(userDidTapSignIn({ origin: 'settingsHub' }))
+
+    expect(await screen.findByTestId('auth-surface')).toBeTruthy()
+  })
+
+  it('dismisses on Cancel', async () => {
+    const { store } = renderControl()
+
+    store.dispatch(userDidTapSignIn({ origin: 'profilePopover' }))
+    await screen.findByTestId('auth-surface')
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(store.getState().settings.authPresentation.kind).toBe('hidden')
+    })
+  })
+
+  it('closes itself once a session exists rather than sitting over the app', async () => {
+    const { store } = renderControl({
+      ...stubbedThunkExtra,
+      authService: makeStubbedAuthService({ initialUser: authUserMocks.typical }),
+    })
+
+    store.dispatch(userDidTapSignIn({ origin: 'profilePopover' }))
+    await screen.findByTestId('auth-surface')
+
+    await store.dispatch(restoreSessionThunk({ now: new Date() }))
+
+    await waitFor(() => {
+      expect(store.getState().settings.authPresentation.kind).toBe('hidden')
+    })
+  })
+})
+
+/**
+ * The dialog is hosted here — not inside a destination — because a sign-in can
+ * complete through an OAuth redirect that lands on any route. These drive a
+ * real sign-in against a store seeded with anonymous rows, which is the only
+ * way the dialog becomes reachable.
+ */
+describe('the existing-local-data dialog', () => {
+  const NOW = new Date('2026-08-31T09:00:00.000Z')
+
+  const anonymousRow = (id: string) => ({
+    id,
+    title: 'Local only',
+    kind: 'task',
+    status: 'planned',
+    isDraft: false,
+    tagsCsv: '',
+    shadowsJson: null,
+    repeatConfigJson: null,
+    start: null,
+    due: null,
+    duration: null,
+    minimumDuration: null,
+    maximumDuration: null,
+    projectId: null,
+    ownerUserId: null,
+    ownerGroupId: null,
+    completed: null,
+    createdAt: NOW,
+    updatedAt: null,
+    value: null,
+    effort: null,
+    expiry: null,
+    associatedColor: null,
+    sessionPoints: null,
+    updatedAtEpochMillis: epochMillisFromDate(NOW),
+    lastSyncedAtEpochMillis: null,
+    deletedAtEpochMillis: null,
+  })
+
+  const signedInWithLocalData = async () => {
+    const localStore = makeInMemoryLocalStore({
+      endeavors: [anonymousRow('a'), anonymousRow('b')],
+    })
+    const context = renderControl({
+      ...stubbedThunkExtra,
+      localStore,
+      authService: makeStubbedAuthService({}),
+    })
+    await context.store.dispatch(
+      signInWithEmailThunk({
+        email: 'ada@example.com',
+        password: 'secret',
+        now: NOW,
+      }),
+    )
+    return { ...context, localStore }
+  }
+
+  it('is absent when nothing is pending', async () => {
+    renderControl()
+
+    await screen.findByTestId('profile-control')
+    expect(screen.queryByTestId('local-data-dialog')).toBeNull()
+  })
+
+  it('appears after a sign-in that found local rows, with the count in it', async () => {
+    await signedInWithLocalData()
+
+    expect(await screen.findByTestId('local-data-dialog')).toBeTruthy()
+    expect(screen.getByText(/You have 2 local endeavors/)).toBeTruthy()
+  })
+
+  it('adopts the rows when the user signs them to the account', async () => {
+    const { store, localStore } = await signedInWithLocalData()
+
+    await screen.findByTestId('local-data-dialog')
+    await userEvent.click(screen.getByTestId('local-data-sign-all'))
+
+    await waitFor(() => {
+      expect(store.getState().auth.localData.kind).toBe('hidden')
+    })
+    expect(await localStore.endeavors.countAnonymous()).toBe(0)
+  })
+
+  it('clears the rows when the user starts over', async () => {
+    const { store, localStore } = await signedInWithLocalData()
+
+    await screen.findByTestId('local-data-dialog')
+    await userEvent.click(screen.getByTestId('local-data-clear-all'))
+
+    await waitFor(() => {
+      expect(store.getState().auth.localData.kind).toBe('hidden')
+    })
+    expect(await localStore.endeavors.countAnonymous()).toBe(0)
+    expect((await localStore.endeavors.all()).length).toBe(0)
+  })
+
+  it('leaves the rows unowned and untouched on Cancel', async () => {
+    const { store, localStore } = await signedInWithLocalData()
+
+    await screen.findByTestId('local-data-dialog')
+    await userEvent.click(screen.getByTestId('local-data-cancel'))
+
+    await waitFor(() => {
+      expect(store.getState().auth.localData.kind).toBe('hidden')
+    })
+    expect(await localStore.endeavors.countAnonymous()).toBe(2)
+  })
+})

--- a/packages/app/src/features/settings/pages/__tests__/ProfilePopoverFragment.test.tsx
+++ b/packages/app/src/features/settings/pages/__tests__/ProfilePopoverFragment.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * The profile popover's render tests, mirroring
+ * `ProfilePopoverFragment.stories.tsx` (`RC-11`).
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { authUserMocks } from '../../../auth/AuthMocks'
+import { ProfilePopoverFragment } from '../ProfilePopoverFragment'
+
+afterEach(cleanup)
+
+const renderPopover = (
+  overrides: Partial<Parameters<typeof ProfilePopoverFragment>[0]> = {},
+) =>
+  render(
+    <ProfilePopoverFragment
+      accountName={null}
+      accountEmail={null}
+      accountInitials=""
+      planName="Free"
+      onTapSignIn={() => {}}
+      onTapAllEndeavors={() => {}}
+      onTapSettings={() => {}}
+      onTapSignOut={() => {}}
+      {...overrides}
+    />,
+  )
+
+const signedIn = {
+  accountName: authUserMocks.typical.name,
+  accountEmail: authUserMocks.typical.emails[0] ?? null,
+  accountInitials: 'AL',
+}
+
+describe('the signed-out header', () => {
+  it("invites the user in, in canon words", () => {
+    renderPopover()
+
+    expect(screen.getByText('Sign In to Kro')).toBeTruthy()
+    expect(screen.getByText('Sync your data across devices')).toBeTruthy()
+  })
+
+  it('draws the neutral person glyph rather than an empty initials disc', () => {
+    renderPopover()
+
+    expect(screen.getByTestId('avatar-signed-out')).toBeTruthy()
+    expect(screen.queryByTestId('avatar-initials')).toBeNull()
+  })
+
+  it('opens the auth surface when the header is pressed', async () => {
+    const onTapSignIn = vi.fn()
+    renderPopover({ onTapSignIn })
+
+    await userEvent.click(screen.getByTestId('profile-popover-sign-in'))
+
+    expect(onTapSignIn).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers no Sign Out when there is no session', () => {
+    renderPopover()
+
+    expect(screen.queryByRole('button', { name: 'Sign Out' })).toBeNull()
+  })
+})
+
+describe('the signed-in header', () => {
+  it('shows the identity, the initials avatar and canon plan badge', () => {
+    renderPopover(signedIn)
+
+    expect(screen.getByText('Ada Lovelace')).toBeTruthy()
+    expect(screen.getByText('ada@example.com')).toBeTruthy()
+    expect(screen.getByTestId('avatar-initials').textContent).toBe('AL')
+    expect(screen.getByTestId('profile-plan-badge').textContent).toBe('Free')
+  })
+
+  it('opens Settings when the identity is pressed — canon primary action', async () => {
+    const onTapSettings = vi.fn()
+    renderPopover({ ...signedIn, onTapSettings })
+
+    await userEvent.click(screen.getByTestId('profile-popover-identity'))
+
+    expect(onTapSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers Sign Out, and reports the tap', async () => {
+    const onTapSignOut = vi.fn()
+    renderPopover({ ...signedIn, onTapSignOut })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Sign Out' }))
+
+    expect(onTapSignOut).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('the menu carries only rows with a destination', () => {
+  it('offers All Endeavors, Subscription and Settings', () => {
+    renderPopover(signedIn)
+
+    const labels = screen
+      .getAllByTestId('profile-menu-row')
+      .map((row) => row.textContent)
+
+    expect(labels).toContain('All Endeavors')
+    expect(labels).toContain('Subscription')
+    expect(labels).toContain('Settings')
+  })
+
+  it('omits the three canon rows this app has no destination for', () => {
+    renderPopover(signedIn)
+
+    for (const absent of ['Sources', 'Sync History', 'Help & Feedback']) {
+      expect(screen.queryByText(absent)).toBeNull()
+    }
+  })
+
+  it('routes All Endeavors to its own handler', async () => {
+    const onTapAllEndeavors = vi.fn()
+    renderPopover({ ...signedIn, onTapAllEndeavors })
+
+    await userEvent.click(screen.getByRole('button', { name: /All Endeavors/ }))
+
+    expect(onTapAllEndeavors).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/src/features/settings/pages/__tests__/SettingsHubFragment.test.tsx
+++ b/packages/app/src/features/settings/pages/__tests__/SettingsHubFragment.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * The hub's render tests, mirroring `SettingsHubFragment.stories.tsx`
+ * (`RC-11`) — same states, same fixtures, queried by role and text rather than
+ * by markup shape.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { authUserMocks } from '../../../auth/AuthMocks'
+import {
+  accountHubSections,
+  preferencesHubSections,
+  profileHubSection,
+} from '../../SettingsSelectors'
+import type { SettingsSyncFooter } from '../../SettingsSelectors'
+import { SettingsHubFragment } from '../SettingsHubFragment'
+
+afterEach(cleanup)
+
+const noop = () => {}
+
+const renderHub = (
+  overrides: Partial<Parameters<typeof SettingsHubFragment>[0]> = {},
+) =>
+  render(
+    <SettingsHubFragment
+      profileSection={profileHubSection}
+      preferencesSections={preferencesHubSections}
+      accountSections={accountHubSections}
+      syncFooter={null}
+      accountName={null}
+      accountEmail={null}
+      accountInitials=""
+      onTapSection={noop}
+      onTapSignIn={noop}
+      onTapDone={noop}
+      {...overrides}
+    />,
+  )
+
+describe('the hub lists canon three groups', () => {
+  it('offers a row for every preference section and every account section', () => {
+    renderHub()
+
+    for (const section of [...preferencesHubSections, ...accountHubSections]) {
+      expect(
+        screen.getByRole('button', { name: new RegExp(section.title) }),
+      ).toBeTruthy()
+    }
+  })
+
+  it('labels the Preferences group and leaves the account group unlabelled', () => {
+    renderHub()
+
+    expect(screen.getByText('Preferences')).toBeTruthy()
+    // Canon's second Section has no header; the only headings are the surface
+    // title and the one group label.
+    expect(screen.getAllByRole('heading')).toHaveLength(2)
+  })
+
+  it('opens the section a row names', async () => {
+    const onTapSection = vi.fn()
+    renderHub({ onTapSection })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /Session Preferences/ }),
+    )
+
+    expect(onTapSection).toHaveBeenCalledWith('sessionPreferences')
+  })
+})
+
+describe('the profile row reflects the session', () => {
+  it('invites a signed-out user to sign in, in canon words', () => {
+    renderHub()
+
+    expect(screen.getByText('Sign In to Kro')).toBeTruthy()
+    expect(screen.getByText('Sync your data across devices')).toBeTruthy()
+    expect(screen.getByTestId('avatar-signed-out')).toBeTruthy()
+  })
+
+  it('shows the identity and the initials avatar once signed in', () => {
+    renderHub({
+      accountName: authUserMocks.typical.name,
+      accountEmail: authUserMocks.typical.emails[0] ?? null,
+      accountInitials: 'AL',
+    })
+
+    expect(screen.getByText('Ada Lovelace')).toBeTruthy()
+    expect(screen.getByText('ada@example.com')).toBeTruthy()
+    expect(screen.getByTestId('avatar-initials').textContent).toBe('AL')
+  })
+
+  it('routes a signed-out tap to sign-in and a signed-in tap to the Profile pane', async () => {
+    const onTapSignIn = vi.fn()
+    const onTapSection = vi.fn()
+
+    const view = renderHub({ onTapSignIn, onTapSection })
+    await userEvent.click(screen.getByTestId('hub-profile-row'))
+    expect(onTapSignIn).toHaveBeenCalledTimes(1)
+    expect(onTapSection).not.toHaveBeenCalled()
+
+    view.unmount()
+    renderHub({
+      onTapSignIn,
+      onTapSection,
+      accountEmail: 'ada@example.com',
+      accountName: 'Ada Lovelace',
+      accountInitials: 'AL',
+    })
+    await userEvent.click(screen.getByTestId('hub-profile-row'))
+    expect(onTapSection).toHaveBeenCalledWith('profile')
+  })
+})
+
+describe('the sync footer reports the three states', () => {
+  const footer = (value: SettingsSyncFooter | null) => renderHub({ syncFooter: value })
+
+  it('is hidden entirely when there is nothing to report — canon syncStatus nil', () => {
+    footer(null)
+    expect(screen.queryByTestId('sync-footer')).toBeNull()
+  })
+
+  it('reports a successful sync without the warning tint', () => {
+    footer({ title: 'Synced', isWarning: false, glyph: 'checkmark.icloud' })
+
+    const element = screen.getByTestId('sync-footer')
+    expect(element.textContent).toContain('Synced')
+    expect(element.getAttribute('data-warning')).toBe('false')
+  })
+
+  it('warns, in canon words, when the last attempt had no connection', () => {
+    footer({
+      title: 'Offline — will sync later',
+      isWarning: true,
+      glyph: 'icloud.slash',
+    })
+
+    const element = screen.getByTestId('sync-footer')
+    expect(element.textContent).toContain('Offline — will sync later')
+    expect(element.getAttribute('data-warning')).toBe('true')
+  })
+
+  it('prompts a signed-out user rather than warning them', () => {
+    footer({
+      title: 'Sign in to sync across devices',
+      isWarning: false,
+      glyph: 'person.crop.circle.badge.questionmark',
+    })
+
+    expect(screen.getByTestId('sync-footer').textContent).toContain(
+      'Sign in to sync across devices',
+    )
+  })
+})
+
+describe('the Done affordance', () => {
+  it("carries canon toolbar label", () => {
+    renderHub()
+    expect(screen.getByRole('button', { name: 'Done' })).toBeTruthy()
+  })
+
+  it('reports the tap to its owner', async () => {
+    const onTapDone = vi.fn()
+    renderHub({ onTapDone })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(onTapDone).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not double as a section tap', async () => {
+    const onTapSection = vi.fn()
+    renderHub({ onTapSection })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(onTapSection).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/features/settings/pages/__tests__/SettingsHubPage.test.tsx
+++ b/packages/app/src/features/settings/pages/__tests__/SettingsHubPage.test.tsx
@@ -191,6 +191,35 @@ describe('drilling into a pane', () => {
     expect(screen.getByTestId('settings-hub')).toBeTruthy()
   })
 
+  it('keeps the form editable when the preference store cannot be read', async () => {
+    // Canon's "load failed" state: defaults show and edits still save. The
+    // pre-load guard exists to stop an in-flight load overwriting an edit, and
+    // a failed load is not in flight. (Reported by Copilot on KC-PR-#70.)
+    const broken = makeInMemoryLocalStore({})
+    const { store } = renderPage({
+      ...stubbedThunkExtra,
+      localStore: {
+        ...broken,
+        preferences: {
+          ...broken.preferences,
+          get() {
+            throw new Error('storage disabled')
+          },
+        },
+      },
+    })
+
+    await userEvent.click(await screen.findByRole('button', { name: /General/ }))
+    await waitFor(() => {
+      expect(store.getState().settings.load.kind).toBe('failed')
+    })
+
+    const toggle = screen.getByRole('switch', { name: 'Overdue alerts' })
+    expect((toggle as HTMLButtonElement).disabled).toBe(false)
+    // And the declared default is what it shows.
+    expect(toggle.getAttribute('aria-checked')).toBe('true')
+  })
+
   it('writes a changed preference through to the store', async () => {
     const localStore = makeInMemoryLocalStore({})
     const { store } = renderPage({ ...stubbedThunkExtra, localStore })

--- a/packages/app/src/features/settings/pages/__tests__/SettingsHubPage.test.tsx
+++ b/packages/app/src/features/settings/pages/__tests__/SettingsHubPage.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * The settings surface's container, rendered against a real store built with
+ * `makeStore(stubbedThunkExtra)` (`RC-22`, `RC-35`) — never a hand-assembled
+ * second store, never the live services.
+ *
+ * The second block is the issue's *"settings close triggers the push (#31
+ * observable)"* acceptance criterion: the assertion is on the stubbed
+ * `SettingsSyncService` recording a push, which is the only place that fact is
+ * observable from outside the auth slice.
+ */
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+import { StoreProvider } from '../../../../library/StoreProvider'
+import {
+  type ThunkExtra,
+  makeStore,
+  stubbedThunkExtra,
+} from '../../../../library/store'
+import { GoogleCalendarConnections } from '../../../../services/googleCalendar/GoogleCalendarConnection'
+import { makeStubbedGoogleCalendarService } from '../../../../services/googleCalendar/GoogleCalendarService'
+import { makeInMemoryLocalStore } from '../../../../services/localStore/InMemoryLocalStore'
+import { makeRecordingNavigationService } from '../../../../services/navigation/NavigationService'
+import { makeStubbedSettingsSyncService } from '../../../../services/sync/SettingsSyncService'
+import { SettingsHubPage } from '../SettingsHubPage'
+
+afterEach(cleanup)
+
+const renderPage = (extra: ThunkExtra = stubbedThunkExtra) => {
+  const store = makeStore(extra)
+  const view = render(
+    <StoreProvider store={store}>
+      <SettingsHubPage />
+    </StoreProvider>,
+  )
+  return { store, view }
+}
+
+describe('opening the surface', () => {
+  it('lands on the hub with canon three groups', async () => {
+    renderPage()
+
+    expect(await screen.findByTestId('settings-hub')).toBeTruthy()
+    expect(screen.getByText('Preferences')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Integrations/ })).toBeTruthy()
+  })
+
+  it('reads the stored preferences so a pane opens on real values', async () => {
+    const { store } = renderPage({
+      ...stubbedThunkExtra,
+      localStore: makeInMemoryLocalStore({
+        preferences: { 'kro:session.defaultDuration': 45 },
+      }),
+    })
+
+    await waitFor(() => {
+      expect(store.getState().settings.load.kind).toBe('loaded')
+    })
+    expect(store.getState().settings.values['session.defaultDuration']).toBe(45)
+  })
+
+  it('asks the deployment about Google rather than assuming a state', async () => {
+    const calls: string[] = []
+    renderPage({
+      ...stubbedThunkExtra,
+      googleCalendar: makeStubbedGoogleCalendarService({
+        calls,
+        connection: GoogleCalendarConnections.connected(),
+      }),
+    })
+
+    await waitFor(() => {
+      expect(calls).toContain('connection')
+    })
+  })
+
+  it("does NOT pull settings on open — canon rule, made observable", async () => {
+    const settingsSync = makeStubbedSettingsSyncService()
+    renderPage({ ...stubbedThunkExtra, settingsSync })
+
+    await screen.findByTestId('settings-hub')
+
+    expect(settingsSync.pullCount()).toBe(0)
+    expect(settingsSync.pushes()).toHaveLength(0)
+  })
+})
+
+describe('closing the surface pushes the synced preferences', () => {
+  it('sends the cloud-scoped values back when the surface goes away', async () => {
+    const settingsSync = makeStubbedSettingsSyncService()
+    const { view } = renderPage({ ...stubbedThunkExtra, settingsSync })
+
+    await screen.findByTestId('settings-hub')
+    expect(settingsSync.pushes()).toHaveLength(0)
+
+    view.unmount()
+
+    await waitFor(() => {
+      expect(settingsSync.pushes().length).toBeGreaterThan(0)
+    })
+  })
+
+  it('pushes the values the user actually changed', async () => {
+    const settingsSync = makeStubbedSettingsSyncService()
+    const { store, view } = renderPage({
+      ...stubbedThunkExtra,
+      settingsSync,
+      localStore: makeInMemoryLocalStore({
+        preferences: { 'kro:session.defaultDuration': 45 },
+      }),
+    })
+
+    await waitFor(() => {
+      expect(store.getState().settings.load.kind).toBe('loaded')
+    })
+    view.unmount()
+
+    await waitFor(() => {
+      const [first] = settingsSync.pushes()
+      expect(
+        first?.find((entry) => entry.key === 'session.defaultDuration')?.value,
+      ).toBe(45)
+    })
+  })
+
+  it('never pushes a device-local option — the five stay on the device', async () => {
+    const settingsSync = makeStubbedSettingsSyncService()
+    const { view } = renderPage({ ...stubbedThunkExtra, settingsSync })
+
+    await screen.findByTestId('settings-hub')
+    view.unmount()
+
+    await waitFor(() => {
+      expect(settingsSync.pushes().length).toBeGreaterThan(0)
+    })
+    const keys = (settingsSync.pushes()[0] ?? []).map((entry) => entry.key)
+    for (const local of [
+      'general.appearance',
+      'general.haptics',
+      'earn.milestoneHaptics',
+      'session.keepScreenAwake',
+      'session.soundOnEnd',
+    ]) {
+      expect(keys).not.toContain(local)
+    }
+  })
+})
+
+describe('drilling into a pane', () => {
+  it('opens the General pane with every schema row on it', async () => {
+    renderPage()
+
+    await userEvent.click(await screen.findByRole('button', { name: /General/ }))
+
+    expect(screen.getByTestId('preferences-section')).toBeTruthy()
+    expect(screen.getByLabelText('Start')).toBeTruthy()
+    expect(screen.getByRole('switch', { name: 'Overdue alerts' })).toBeTruthy()
+  })
+
+  it('opens the Integrations pane with the honest unconfigured Google row', async () => {
+    renderPage({
+      ...stubbedThunkExtra,
+      googleCalendar: makeStubbedGoogleCalendarService({
+        connection: GoogleCalendarConnections.unconfigured(['GOOGLE_CLIENT_ID']),
+      }),
+    })
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /Integrations/ }),
+    )
+
+    expect(screen.getByTestId('integrations-section')).toBeTruthy()
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByRole('button', {
+            name: 'Connect Google Calendar',
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(true)
+    })
+  })
+
+  it('returns to the hub from a pane', async () => {
+    renderPage()
+
+    await userEvent.click(await screen.findByRole('button', { name: /Earn Preferences/ }))
+    expect(screen.queryByTestId('settings-hub')).toBeNull()
+
+    await userEvent.click(screen.getByTestId('pane-back'))
+    expect(screen.getByTestId('settings-hub')).toBeTruthy()
+  })
+
+  it('writes a changed preference through to the store', async () => {
+    const localStore = makeInMemoryLocalStore({})
+    const { store } = renderPage({ ...stubbedThunkExtra, localStore })
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /Session Preferences/ }),
+    )
+    await waitFor(() => {
+      expect(store.getState().settings.load.kind).toBe('loaded')
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'Increase Session' }))
+
+    await waitFor(() => {
+      expect(localStore.preferences.get('kro:session.defaultDuration')).toBe(25)
+    })
+  })
+})
+
+describe('the desktop frame', () => {
+  it("carries canon minimum sheet size on a pointer-driven surface", async () => {
+    const { store } = renderPage()
+
+    await screen.findByTestId('settings-surface')
+    // The default surface is the SSR one; the shell stamps the real measurement.
+    // Either way the frame comes from the ported table, never from a media query
+    // written in this Page.
+    expect(store.getState().main.surface).toBeTruthy()
+    const panel = screen.getByTestId('settings-surface')
+    expect(['modal', 'sheet']).toContain(panel.getAttribute('data-presentation'))
+  })
+
+  it('tells the shell which destination is mounted, so the URL stays the authority', async () => {
+    const { store } = renderPage()
+
+    await screen.findByTestId('settings-hub')
+
+    expect(store.getState().main.selected.kind).toBe('settings')
+  })
+
+  it('offers Done, which navigates away rather than dismissing nothing', async () => {
+    const navigation = makeRecordingNavigationService()
+    renderPage({ ...stubbedThunkExtra, navigation })
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Done' }))
+
+    // Navigation goes through the injected Service (`RC-17`); the route change
+    // is what re-selects the destination, which is why this asserts on the call
+    // rather than on `main.selected`.
+    await waitFor(() => {
+      expect(navigation.calls).toEqual([{ kind: 'navigate', path: '/my-day' }])
+    })
+  })
+})

--- a/packages/app/src/features/settings/pages/__tests__/settingsFormatting.test.ts
+++ b/packages/app/src/features/settings/pages/__tests__/settingsFormatting.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The pure conversions the preference controls sit on.
+ */
+import { WeekDay } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  ACCENT_SWATCH_COLOR,
+  accentSwatchColor,
+  deviceTimeZone,
+  knownTimeZones,
+  timeInputMinutes,
+  timeInputValue,
+  timeZoneLabel,
+  weekDayLetter,
+  weekDayName,
+  weekDaysBitmaskHas,
+  weekDaysBitmaskToggling,
+} from '../settingsFormatting'
+
+describe('minutes → the time input wire format', () => {
+  it('renders canon 09:00 default with both fields padded', () => {
+    expect(timeInputValue(9 * 60)).toBe('09:00')
+  })
+
+  it('renders a non-round time', () => {
+    expect(timeInputValue(7 * 60 + 30)).toBe('07:30')
+  })
+
+  it('renders midnight as 00:00 rather than 24:00', () => {
+    expect(timeInputValue(0)).toBe('00:00')
+  })
+
+  it('clamps a corrupt out-of-range value to the end of the day, never wrapping', () => {
+    expect(timeInputValue(1500)).toBe('23:59')
+    expect(timeInputValue(-30)).toBe('00:00')
+  })
+})
+
+describe('the time input wire format → minutes', () => {
+  it('reads a padded time', () => {
+    expect(timeInputMinutes('17:00')).toBe(17 * 60)
+  })
+
+  it('reads an unpadded hour, which some browsers emit', () => {
+    expect(timeInputMinutes('7:05')).toBe(7 * 60 + 5)
+  })
+
+  it('answers null for an empty field rather than writing midnight', () => {
+    expect(timeInputMinutes('')).toBeNull()
+  })
+
+  it('answers null for an impossible time rather than clamping it into the store', () => {
+    expect(timeInputMinutes('25:00')).toBeNull()
+    expect(timeInputMinutes('12:75')).toBeNull()
+  })
+})
+
+describe('the weekday chips', () => {
+  it('labels a chip with canon single uppercase letter', () => {
+    expect(weekDayLetter(WeekDay.monday)).toBe('M')
+    expect(weekDayLetter(WeekDay.sunday)).toBe('S')
+  })
+
+  it('speaks the full capitalized name, as canon accessibility label does', () => {
+    expect(weekDayName(WeekDay.wednesday)).toBe('Wednesday')
+  })
+
+  it('adds a day to the mask, and reports it present', () => {
+    const withSaturday = weekDaysBitmaskToggling(0, WeekDay.saturday)
+
+    expect(weekDaysBitmaskHas(withSaturday, WeekDay.saturday)).toBe(true)
+    expect(weekDaysBitmaskHas(withSaturday, WeekDay.monday)).toBe(false)
+  })
+
+  it('removes a day already in the mask', () => {
+    const both = weekDaysBitmaskToggling(
+      weekDaysBitmaskToggling(0, WeekDay.monday),
+      WeekDay.friday,
+    )
+    const withoutMonday = weekDaysBitmaskToggling(both, WeekDay.monday)
+
+    expect(weekDaysBitmaskHas(withoutMonday, WeekDay.monday)).toBe(false)
+    expect(weekDaysBitmaskHas(withoutMonday, WeekDay.friday)).toBe(true)
+  })
+
+  it('produces the same mask whatever order the days were pressed in', () => {
+    const forwards = weekDaysBitmaskToggling(
+      weekDaysBitmaskToggling(0, WeekDay.monday),
+      WeekDay.thursday,
+    )
+    const backwards = weekDaysBitmaskToggling(
+      weekDaysBitmaskToggling(0, WeekDay.thursday),
+      WeekDay.monday,
+    )
+
+    expect(forwards).toBe(backwards)
+  })
+
+  it('reports nothing selected on an empty mask', () => {
+    expect(weekDaysBitmaskHas(0, WeekDay.monday)).toBe(false)
+  })
+})
+
+describe('the accent swatches', () => {
+  it('maps every canon choice to a colour', () => {
+    for (const choice of ['blue', 'purple', 'green', 'orange', 'pink', 'graphite']) {
+      expect(ACCENT_SWATCH_COLOR[choice]).toMatch(/^#[0-9a-f]{6}$/)
+    }
+  })
+
+  it("maps graphite to canon Color(white: 0.4)", () => {
+    expect(accentSwatchColor('graphite')).toBe('#666666')
+  })
+
+  it('falls back to a neutral for an unknown raw value rather than rendering nothing', () => {
+    expect(accentSwatchColor('chartreuse')).toBe('#666666')
+  })
+})
+
+describe('time zones', () => {
+  it('offers a non-empty list', () => {
+    expect(knownTimeZones().length).toBeGreaterThan(0)
+  })
+
+  it('offers IANA identifiers rather than offsets', () => {
+    // `Intl.supportedValuesOf` answers `Etc/UTC` where the fallback answers
+    // `UTC`, so the assertion is on the *shape* both agree on rather than on a
+    // single identifier only one of them has.
+    expect(knownTimeZones().some((zone) => zone.includes('/'))).toBe(true)
+  })
+
+  it('answers a device zone rather than an empty string', () => {
+    expect(deviceTimeZone().length).toBeGreaterThan(0)
+  })
+
+  it("spaces an identifier underscores, as canon Picker does", () => {
+    expect(timeZoneLabel('America/New_York')).toBe('America/New York')
+  })
+})

--- a/packages/app/src/features/settings/pages/__tests__/settingsIcons.test.ts
+++ b/packages/app/src/features/settings/pages/__tests__/settingsIcons.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The Settings lane's glyph rows.
+ *
+ * The first assertion is the one that matters: the lane's rows must be disjoint
+ * from the two shared maps, so "which glyph is that symbol" keeps exactly one
+ * answer. The second walks the whole preference schema and the hub's own rows,
+ * so an option declared with a glyph nothing draws fails here rather than
+ * rendering a question mark for a user.
+ */
+import { allSettingOptions } from '@kro/core'
+import { describe, expect, it } from 'vitest'
+import {
+  ENDEAVOR_SF_SYMBOL_TO_LUCIDE,
+  isMappedSymbol,
+} from '../../../../design/endeavor/endeavorIcons'
+import { SF_SYMBOL_TO_LUCIDE } from '../../../../design/system/icons/icons'
+import { settingsSections } from '../../SettingsSection'
+import {
+  SETTINGS_SF_SYMBOL_TO_LUCIDE,
+  isSettingsSymbolMapped,
+  settingsIcon,
+} from '../settingsIcons'
+
+describe('the lane rows do not shadow the shared maps', () => {
+  it('adds no key the design system already answers for', () => {
+    const shared = new Set(Object.keys(SF_SYMBOL_TO_LUCIDE))
+    const overlap = Object.keys(SETTINGS_SF_SYMBOL_TO_LUCIDE).filter((key) =>
+      shared.has(key),
+    )
+
+    expect(overlap).toEqual([])
+  })
+
+  it('adds no key the Endeavor kit already answers for', () => {
+    const kit = new Set(Object.keys(ENDEAVOR_SF_SYMBOL_TO_LUCIDE))
+    const overlap = Object.keys(SETTINGS_SF_SYMBOL_TO_LUCIDE).filter((key) =>
+      kit.has(key),
+    )
+
+    expect(overlap).toEqual([])
+  })
+
+  it('defers to the shared answer for a symbol both know how to draw', () => {
+    expect(isMappedSymbol('calendar')).toBe(true)
+    expect(settingsIcon('calendar')).toBe(SF_SYMBOL_TO_LUCIDE.calendar)
+  })
+})
+
+describe('every symbol a settings surface holds resolves to a real glyph', () => {
+  it('draws every option declared glyph', () => {
+    const unmapped = allSettingOptions
+      .map((option) => option.glyph)
+      .filter((glyph): glyph is string => glyph !== null)
+      .filter((glyph) => !isSettingsSymbolMapped(glyph))
+
+    expect(unmapped).toEqual([])
+  })
+
+  it('draws every hub row glyph', () => {
+    const unmapped = settingsSections
+      .map((section) => section.glyph)
+      .filter((glyph) => !isSettingsSymbolMapped(glyph))
+
+    expect(unmapped).toEqual([])
+  })
+
+  it('draws the four sync-footer glyphs', () => {
+    for (const glyph of [
+      'checkmark.icloud',
+      'icloud.slash',
+      'arrow.triangle.2.circlepath',
+      'person.crop.circle.badge.questionmark',
+    ]) {
+      expect(isSettingsSymbolMapped(glyph)).toBe(true)
+    }
+  })
+})
+
+describe('an unmapped symbol fails visibly, never silently', () => {
+  it('returns a component rather than undefined', () => {
+    expect(typeof settingsIcon('not.a.real.symbol')).not.toBe('undefined')
+  })
+
+  it('reports the symbol as unmapped', () => {
+    expect(isSettingsSymbolMapped('not.a.real.symbol')).toBe(false)
+  })
+
+  it('reports a mapped lane symbol as mapped', () => {
+    expect(isSettingsSymbolMapped('cup.and.saucer')).toBe(true)
+  })
+})

--- a/packages/app/src/features/settings/pages/settingsFormatting.ts
+++ b/packages/app/src/features/settings/pages/settingsFormatting.ts
@@ -1,0 +1,145 @@
+/**
+ * The three pure conversions the preference controls need, and canon's accent
+ * palette.
+ *
+ * All four are here rather than inline in the Fragment so they are testable
+ * without a renderer, and so the Fragment stays layout.
+ */
+import { type WeekDay, weekDays, weekDaysBitmask, weekDaysFromBitmask } from '@kro/core'
+
+// ---------------------------------------------------------------------------
+// Time of day ⇄ the `<input type="time">` wire format
+// ---------------------------------------------------------------------------
+
+const MINUTES_PER_HOUR = 60
+const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR
+
+const pad = (value: number): string => String(value).padStart(2, '0')
+
+/**
+ * Minutes from midnight → `HH:MM`, the only value an `<input type="time">`
+ * accepts.
+ *
+ * Out-of-range input clamps rather than wrapping: a stored `1500` is corrupt,
+ * and `01:00` (the wrap) would look like a deliberate setting while `23:59`
+ * reads as the end of the day it actually is.
+ */
+export const timeInputValue = (minutesFromMidnight: number): string => {
+  const clamped = Math.min(
+    Math.max(Math.round(minutesFromMidnight), 0),
+    MINUTES_PER_DAY - 1,
+  )
+  return `${pad(Math.floor(clamped / MINUTES_PER_HOUR))}:${pad(clamped % MINUTES_PER_HOUR)}`
+}
+
+/**
+ * `HH:MM` → minutes from midnight, or `null` when the field is empty or
+ * malformed. `null` means "do not write", never "midnight": a browser hands
+ * back `''` while the user is mid-edit, and writing `0` there would silently
+ * move their working day to midnight.
+ */
+export const timeInputMinutes = (value: string): number | null => {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value)
+  if (match === null) return null
+  const hours = Number(match[1])
+  const minutes = Number(match[2])
+  if (hours > 23 || minutes > 59) return null
+  return hours * MINUTES_PER_HOUR + minutes
+}
+
+/** The clock time a stored value reads as, for a row's summary line. */
+export const timeOfDayLabel = (minutesFromMidnight: number): string =>
+  timeInputValue(minutesFromMidnight)
+
+// ---------------------------------------------------------------------------
+// Working days
+// ---------------------------------------------------------------------------
+
+/** Canon's single-letter chip label — `day.rawValue.prefix(1).uppercased()`. */
+export const weekDayLetter = (day: WeekDay): string =>
+  day.charAt(0).toUpperCase()
+
+/** Canon's accessible label — `day.rawValue.capitalized`. */
+export const weekDayName = (day: WeekDay): string =>
+  day.charAt(0).toUpperCase() + day.slice(1)
+
+/** The bitmask with `day` toggled — canon's `insert`/`remove` on the `Set`. */
+export const weekDaysBitmaskToggling = (mask: number, day: WeekDay): number => {
+  const selected = new Set(weekDaysFromBitmask(mask))
+  if (selected.has(day)) selected.delete(day)
+  else selected.add(day)
+  // Rebuilt in canon's `allCases` order so the mask never depends on click
+  // order, which is what makes two devices agree on the same stored number.
+  return weekDaysBitmask(weekDays.filter((candidate) => selected.has(candidate)))
+}
+
+/** Whether the mask contains `day`. */
+export const weekDaysBitmaskHas = (mask: number, day: WeekDay): boolean =>
+  weekDaysFromBitmask(mask).includes(day)
+
+// ---------------------------------------------------------------------------
+// Accent swatches — canon `extension AccentChoice { var color: Color }`
+// ---------------------------------------------------------------------------
+
+/**
+ * The concrete colour each accent choice draws as.
+ *
+ * Canon puts this mapping in the **UI** layer for the same reason it is here
+ * and not in `@kro/core`: the domain stores a choice, not a colour. The values
+ * are the CSS equivalents of the SwiftUI system colours canon names, so the two
+ * apps' swatch rows read as the same palette.
+ */
+export const ACCENT_SWATCH_COLOR: Readonly<Record<string, string>> = {
+  blue: '#0a84ff',
+  purple: '#af52de',
+  green: '#34c759',
+  orange: '#ff9f0a',
+  pink: '#ff375f',
+  // Canon: `Color(white: 0.4)`.
+  graphite: '#666666',
+}
+
+/** The swatch colour for a raw accent value, or a neutral for an unknown one. */
+export const accentSwatchColor = (raw: string): string =>
+  ACCENT_SWATCH_COLOR[raw] ?? '#666666'
+
+// ---------------------------------------------------------------------------
+// Time zones
+// ---------------------------------------------------------------------------
+
+/**
+ * Every zone this browser knows, or a short documented fallback.
+ *
+ * Canon reads `TimeZone.knownTimeZoneIdentifiers`. `Intl.supportedValuesOf` is
+ * the web's equivalent and is present in every browser this app targets, but it
+ * is absent under some test runtimes — so the fallback exists to keep a suite
+ * deterministic, not to be shipped. It is deliberately tiny and obviously
+ * partial: a short list reads as a fallback, where a plausible-looking long one
+ * would read as the real answer.
+ */
+export const knownTimeZones = (): readonly string[] => {
+  const supported = (
+    Intl as unknown as { supportedValuesOf?: (key: string) => string[] }
+  ).supportedValuesOf
+  if (typeof supported === 'function') {
+    try {
+      return supported.call(Intl, 'timeZone')
+    } catch {
+      // Fall through to the documented fallback below.
+    }
+  }
+  return ['UTC', 'America/Bogota', 'America/New_York', 'Europe/Madrid', 'Asia/Tokyo']
+}
+
+/** The device's own zone — canon's *"defaults to the device's current zone"*. */
+export const deviceTimeZone = (): string => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  } catch {
+    return 'UTC'
+  }
+}
+
+/** Canon's `id.replacingOccurrences(of: "_", with: " ")`. */
+export const timeZoneLabel = (identifier: string): string =>
+  identifier.split('_').join(' ')

--- a/packages/app/src/features/settings/pages/settingsIcons.ts
+++ b/packages/app/src/features/settings/pages/settingsIcons.ts
@@ -1,0 +1,129 @@
+/**
+ * The Settings vocabulary's SF Symbol → lucide rows.
+ *
+ * The design system owns the shared mapping (`design/system/icons/icons.ts`)
+ * and the Endeavor kit adds its own rows on top of it
+ * (`design/endeavor/endeavorIcons.ts`). Between them they answer for the
+ * glyphs those surfaces draw — and for almost none of the ~30 symbols the
+ * preference schema declares (`sunrise`, `cup.and.saucer`, `paintpalette`,
+ * `speaker.wave.2`, …), because no shipped surface had drawn them yet.
+ *
+ * So this is the same pattern the Endeavor kit already established: a lane's
+ * own rows, resolved *after* the shared maps so a symbol both know stays one
+ * answer. `settingsIcons.test.ts` asserts the rows are disjoint from the
+ * shared maps, which is what keeps that true.
+ *
+ * **Upstream candidate.** These rows belong in
+ * `design/system/icons/icons.ts` once a second surface needs them — that file
+ * is outside this issue's lane, and forking the map for one lane is the
+ * smaller, reversible mistake. Named in the PR body.
+ */
+import {
+  Bell,
+  CalendarRange,
+  CircleHelp,
+  CirclePause,
+  Cloud,
+  CloudOff,
+  Coffee,
+  Contrast,
+  CreditCard,
+  Eye,
+  Flame,
+  Globe,
+  Hand,
+  House,
+  KeyRound,
+  Layers,
+  LogOut,
+  type LucideIcon,
+  Mail,
+  RotateCw,
+  Sigma,
+  SlidersHorizontal,
+  Sparkles,
+  SunMedium,
+  Sunrise,
+  Sunset,
+  Timer,
+  Trophy,
+  UserRound,
+  Volume2,
+} from 'lucide-react'
+import {
+  iconForBindingSymbol,
+  isMappedSymbol,
+} from '../../../design/endeavor/endeavorIcons'
+
+/** SF Symbol name → lucide component, for the symbols Settings draws. */
+export const SETTINGS_SF_SYMBOL_TO_LUCIDE = {
+  // Schema glyphs — `SettingOptions.ts`
+  globe: Globe,
+  sunrise: Sunrise,
+  sunset: Sunset,
+  'bell.badge': Bell,
+  flame: Flame,
+  'circle.lefthalf.filled': Contrast,
+  'calendar.day.timeline.left': CalendarRange,
+  house: House,
+  'hand.tap': Hand,
+  'arrow.up.and.down': SlidersHorizontal,
+  'arrow.up.arrow.down': SlidersHorizontal,
+  'rectangle.3.group': Layers,
+  function: Sigma,
+  trophy: Trophy,
+  'party.popper': Sparkles,
+  'cup.and.saucer': Coffee,
+  stopwatch: Timer,
+  'pause.circle': CirclePause,
+  'arrow.triangle.2.circlepath': RotateCw,
+  'sun.max': SunMedium,
+  'speaker.wave.2': Volume2,
+  // The Do visibility filter's glyph. It is a non-preference option and no pane
+  // renders it, but the map answers for every declared glyph so a future
+  // surface cannot meet a question mark.
+  eye: Eye,
+  // Hub rows — `SettingsFeature.Section.systemImage`
+  'slider.horizontal.3': SlidersHorizontal,
+  'star.circle': Trophy,
+  'square.stack.3d.up': Layers,
+  creditcard: CreditCard,
+  // Integrations and the sync footer
+  'icloud.fill': Cloud,
+  'icloud.slash': CloudOff,
+  'checkmark.icloud': Cloud,
+  'person.crop.circle.badge.questionmark': UserRound,
+  // Sign-in methods — the Profile pane's "Method" and "Connected" rows.
+  // `apple.logo` has no lucide counterpart and lucide's `Apple` is a fruit, so
+  // the row draws a neutral key rather than a wrong mark; the *buttons* on the
+  // auth surface carry the real brand artwork (`ProviderMarks`).
+  'apple.logo': KeyRound,
+  'envelope.fill': Mail,
+  'f.circle.fill': KeyRound,
+  'rectangle.portrait.and.arrow.right': LogOut,
+} as const satisfies Record<string, LucideIcon>
+
+export type SettingsSymbolName = keyof typeof SETTINGS_SF_SYMBOL_TO_LUCIDE
+
+/**
+ * The glyph for any SF Symbol name a settings surface holds.
+ *
+ * Order matters: the shared maps win, so a symbol both know keeps one answer.
+ * An unmapped name draws the help glyph rather than returning `undefined`,
+ * which React renders as a crash — the same visible failure
+ * `iconForBindingSymbol` chose, for the same reason.
+ */
+export function settingsIcon(name: string): LucideIcon {
+  if (isMappedSymbol(name)) return iconForBindingSymbol(name)
+  return (
+    (SETTINGS_SF_SYMBOL_TO_LUCIDE as Record<string, LucideIcon>)[name] ??
+    CircleHelp
+  )
+}
+
+/** Whether `name` draws a real glyph rather than the help fallback. */
+export function isSettingsSymbolMapped(name: string): boolean {
+  return isMappedSymbol(name) || name in SETTINGS_SF_SYMBOL_TO_LUCIDE
+}
+
+export type { LucideIcon }

--- a/packages/app/src/features/triage/__tests__/TriageSelectors.test.ts
+++ b/packages/app/src/features/triage/__tests__/TriageSelectors.test.ts
@@ -57,6 +57,7 @@ import {
 import { triageSessionSeed, triageEndeavorFixtures } from '../TriageMocks'
 import { initialTriageState } from '../TriageFeature'
 import { initialMainState } from '../../main/MainFeature'
+import { initialSettingsState } from '../../settings/SettingsState'
 
 /** Selectors run against a hand-built root state, never a live store. */
 const rootWith = (slice: TriageState): RootState => ({
@@ -73,6 +74,7 @@ const rootWith = (slice: TriageState): RootState => ({
   earn: initialEarnState,
   platform: initialPlatformState,
   session: initialSessionState,
+  settings: initialSettingsState,
   auth: initialAuthState,
   main: initialMainState,
 })

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -66,3 +66,41 @@ export {
   selectIsGreetingLoading,
 } from './features/greeting/GreetingSelectors'
 export { type GreetingViewModel, useGreeting } from './features/greeting/useGreeting'
+
+/**
+ * Auth + Settings UI (KC-IS-#32) — the Settings hub and its panes, the profile
+ * popover, and the auth surface.
+ *
+ * Appended as its own block rather than folded above, for the same
+ * anti-contention reason `features/main`'s block gives: a parallel child adds
+ * its own block below instead of contending for a line in an existing one.
+ *
+ * Only `SettingsHubPage` is reachable from `apps/web` (the `/adjust` route
+ * mounts it); everything else is exported because a story, a test or the shell
+ * composes it. The auth *slice* stays KC-IS-#31's and is not re-exported here.
+ */
+export {
+  type AccountPane,
+  type AccountSectionFragmentProps,
+  type IntegrationsSectionFragmentProps,
+  type PreferencesSectionFragmentProps,
+  type ProfilePopoverFragmentProps,
+  type SettingsHubFragmentProps,
+  AccountSectionFragment,
+  IntegrationsSectionFragment,
+  PreferencesSectionFragment,
+  ProfileControlPage,
+  ProfilePopoverFragment,
+  SettingsHubFragment,
+  SettingsHubPage,
+  SettingsSectionId,
+  settingsSections,
+} from './features/settings'
+export {
+  type AuthSurfaceFragmentProps,
+  type AuthSurfacePageProps,
+  type LocalDataDialogFragmentProps,
+  AuthSurfaceFragment,
+  AuthSurfacePage,
+  LocalDataDialogFragment,
+} from './features/auth/pages'

--- a/packages/app/src/library/store.ts
+++ b/packages/app/src/library/store.ts
@@ -32,6 +32,7 @@ import { mainSlice } from '../features/main/MainFeature'
 import { planSlice } from '../features/plan/PlanFeature'
 import { platformSlice } from '../features/platform/PlatformFeature'
 import { sessionSlice } from '../features/session/SessionFeature'
+import { settingsSlice } from '../features/settings/SettingsFeature'
 import { triageSlice } from '../features/triage/TriageFeature'
 import {
   type AuthService,
@@ -274,6 +275,7 @@ export const makeStore = (extra: ThunkExtra = liveThunkExtra) =>
       session: sessionSlice.reducer,
       auth: authSlice.reducer,
       main: mainSlice.reducer,
+      settings: settingsSlice.reducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({


### PR DESCRIPTION
> 🟥 **Ichigo · Substitute** — the local plane, entire · *local, on your creds · I open PRs for **you** to merge (I never merge `main`, never review my own work)*
> acting as **Shinigami** (product code) · handbook `v0.5` · authored locally (Claude Code session, on behalf of @zheref) — no CI run

Closes #32 · Part of #1

# What this changes for you

`/adjust` stops being a placeholder. It is the Settings hub: your profile at the
top, the five preference sections, Integrations and Subscription under them, and
a small footer telling you where your settings stand with the cloud.

Open **General** and every option Kro stores is on screen — your working hours,
your timezone, notification times, theme and accent, week start, landing
section, haptics — with the same controls and the same words the Mac app uses.
Set an end time that is not after the start and the section says so, in place,
while both times stay exactly as you typed them. **Session**, **Plan**, **Do**
and **Earn** work the same way.

The profile control in the toolbar is now yours: signed out it invites you in,
signed in it shows your initials, your name and your email, and offers Sign Out.
Tapping the invitation opens the sign-in surface — email and password with a
sign-in ⇄ create toggle, and *Sign in with Apple* and *Sign in with Google*
drawn to each provider's own branding. On a build with no Kro Cloud project it
says so calmly and tells you the app still works on this device, rather than
failing with something you cannot act on.

**Integrations** tells the truth about what this deployment can do. Google
Calendar offers Connect where connecting can work, Reconnect where a grant has
lapsed, and an explanation where the deployment has no Google client at all.
Apple Calendar and Apple Reminders stay listed — the Mac app lists them too and
its Connect buttons do nothing — but here they say why instead of looking
pressable.

And when you sign in on a device that already has work on it, Kro asks what to
do with it: sign it all to your account, clear it and start over, or cancel.

---

## Where the rows come from

Every preference row is **derived from the schema** KC-IS-#11 ported
(`settingOptionsByGroup`), never from a list typed out a second time. An option
cannot be declared and then silently not offered:
`SettingsElements.test.ts` asserts, per section, that the rendered key set is
exactly the declared key set — as a comparison against `@kro/core`, not against
an expectation typed here.

What is *not* derived is the copy. A row's label, its section header, its footer
and an `int` option's stepper range are canon's own strings and numbers,
transcribed per key: deriving a label from `do.nowThresholdHours` gives "Now
Threshold Hours" where canon says `“Now” window`. An option the copy table does
not name still renders, under a spaced-out fallback label and in a trailing
"Other" subgroup — a schema addition must show up as an unpolished row, never as
a missing one.

## How to verify

```bash
git fetch origin && git switch ichigo/32-auth-settings-ui
make setup
make lint && make typecheck && make test && make build
```

Then run the app and drive the surfaces:

```bash
cd apps/web && pnpm exec next start -p 3457
```

1. **The hub.** Open <http://localhost:3457/adjust>. Three groups: the profile
   row, *Preferences* (General · Plan · Do · Earn · Session), and the unlabelled
   account group (Integrations · Subscription).
2. **Every schema option, once.** Open **General**. Count the rows: 12, one per
   option `generalOptions` declares. Repeat for Session (7), Plan (6), Do (4),
   Earn (5). `pnpm --filter @kro/app exec vitest run src/features/settings/__tests__/SettingsElements.test.ts`
   asserts the same thing against the schema.
3. **The working-hours warning.** In General set **Start** to `18:00`. The
   inline warning appears under the card and **both** times stay as entered —
   canon persists them and warns; it does not refuse the write.
4. **The close push.** Press **Done** (or leave `/adjust` any other way). That
   fires KC-IS-#31's `settingsClosed` trigger. Press browser Back: the footer now
   reads *"Sign in to sync across devices"*, because the push reported that this
   build has no Kro Cloud project. Opening Settings does **not** pull — canon is
   emphatic about that, and
   `SettingsHubPage.test.tsx` asserts `pullCount() === 0` on open and a recorded
   push on unmount.
5. **Integrations, honestly.** Open **Integrations** with no `GOOGLE_CLIENT_ID`
   set. Google Calendar's Connect is disabled and the row says *"no Google client
   is configured"* — not "you have not connected". Set the Google env and it
   becomes a working Connect that navigates to `/api/google/connect`.
6. **The auth surface.** Tap the profile row (or the toolbar profile control →
   *Sign In to Kro*). Toggle sign-in ⇄ create: the name field appears and the
   email you typed survives the toggle. With no Supabase project every control is
   inert and the surface says the app still works locally.
7. **The profile popover.** Tap the toolbar profile control. Desktop gets a 300px
   popover; a narrow window gets a sheet, from the same ported decision table the
   rest of the shell reads.
8. **The three-way dialog.**
   `pnpm --filter @kro/app exec vitest run src/features/settings/pages/__tests__/ProfileControlPage.test.tsx`
   drives a real sign-in over a store seeded with two anonymous rows and asserts
   each arm: *Sign All* adopts them, *Clear Everything* deletes them, *Cancel*
   leaves both unowned.

## Definition of Done

- [x] `make lint && make typecheck && make test && make build` green locally.
      Lint reports the same **9 pre-existing warnings** in `(legacy)` and
      `components/` that `main` reports; no new one.
- [x] Per-artifact minimums (`spec/08-acceptance.md`): ≥3 tests per Shifter,
      Selector, reducer arm and Producer; ≥3 stories **and** ≥3 render tests per
      Page and Fragment, all consuming `SettingsMocks` / `authUserMocks`.
      **473 new tests**; the package suite is 258 files / 5 744 tests green.
- [x] ≥80 % line coverage on every touched file. Two exemptions, both `RC-57`
      passive shells: `apps/web/src/app/(shell)/adjust/AdjustPageClient.tsx` and
      the two retired `(legacy)` redirect pages — each has a spec anyway.
- [x] Tests use `stubbedThunkExtra` / a `stubbed…Service`. No live network, no
      mocked `fetch`, no inline `State`.
- [x] No new `any`, no `@ts-ignore`. No suppression added.
- [x] Conventional Commit ≤72; `Closes #32`; no LLM trailer.
- [x] `# What this changes for you` + `## How to verify` (`CON-17`).
- [x] Nothing committed with `--no-verify`.
- [ ] **Feature spec + mermaid diagram (`UZF-21`, `UZF-23`).** `docs/Features/`
      does not exist in this repo yet and no merged child has created it; the
      product spec for Preferences is canon's
      (`zheref/KroApple@main:docs/Features/Preferences.md`), which this port
      follows and does not change. Creating this repo's `docs/Features/` tree is
      a repo-wide decision that belongs with whoever establishes it, not to one
      feature child — **named here as an open item rather than ticked**.
- [x] **Feature flag (`UZF-22`).** No new flag: this surface is canon's standard
      Settings surface, which canon states is "not behind a dedicated flag". The
      one gate it honours is the existing `googleCalendar` flag, which decides
      whether the Integrations pane lists the Google row at all.

## Canon

Ported from `zheref/KroApple@55a188e` (`origin/main` at authoring time; the epic
pins `2c1ee45`). Read: `KroUI/Settings/SettingsHub/SettingsHubView.swift`, the
five `…PreferencesView.swift`, `IntegrationsView.swift`, `ProfileView.swift`,
`SubscriptionView.swift`, `KroUI/Auth/AuthView.swift`,
`KroUI/Main/ProfilePopoverView.swift`, `Kro/Application/Settings/**` and
`docs/Features/Preferences.md`.

**The surfaces this issue ports did not move between the epic's pin and the
tip** — the diff `2c1ee45…55a188e` touches `Kro/Application/Main/**`,
`KroCore/Model/Sidebar*` and the Do screen (all #13's lane), plus the Appearance
pane noted below. Nothing under `KroUI/Settings/**`, `KroUI/Auth/**` or
`ProfilePopoverView.swift` changed.

### Divergences from canon, and why

1. **No Appearance section.** Canon at the tip has a sixth preferences section,
   listed only while the `appearanceThemes` flag is enabled. That flag is not in
   this repo's registry — `@kro/core`'s `FeatureFlags` has 28 entries and no
   `appearanceThemes` — so porting the section would mean **inventing a flag**.
   Canon's own General pane still renders the Theme and Accent rows while the
   flag is off, and that flag-off layout is the shipping one this port
   reproduces.
2. **"Not used yet" badges — an addition beyond canon.** KC-IS-#11 moved canon's
   prose annotation ("declared, not yet consumed") into the schema, and this
   surface says it out loud on the row. Canon does not: a KroApple user meets a
   control that quietly changes nothing. The issue requires those options to be
   **visible**; showing them *and* saying which are inert is the honest reading,
   and it is one derived field, not a per-row decision. **Flagged as a product
   call for you** — deleting the badge is a one-line change if you disagree.
3. **Apple Calendar / Apple Reminders subtitles.** Canon says *"EventKit on this
   device."* — true of a Mac, false of every browser. The rows stay (canon ships
   them with `.disabled(true)` Connect buttons, and hiding them would make the
   web's list a different list) but the sentence becomes one the web can defend.
4. **Google has four states, not two.** Canon's `connected: Bool` cannot tell
   "this build has no Google client" from "you have not connected" — on iOS the
   client is in the bundle, so the distinction does not arise. KC-IS-#33's
   `GoogleCalendarConnection` has both, and collapsing them would put a Connect
   button on a deployment where connecting cannot work.
5. **Apple sign-in goes through the OAuth redirect.** Canon splits it in two
   (`beginAppleSignIn` mints a nonce pair, `signInWithApple` exchanges the id
   token Apple's *native* control returns). The web has no such control, so both
   provider buttons take `startOAuthRedirectThunk` — which KC-IS-#31 built for
   exactly this and whose own header calls it "Google, **and Apple with no id
   token**". The nonce is not minted at all, so no stale nonce can sit in state
   waiting to be replayed.
6. **Profile pane: no Edit Profile, no Request Data Deletion.** Canon offers
   both. KC-IS-#31 ships neither a profile update nor a deletion request, so
   porting the buttons would mean inventing the flows behind them.
7. **Subscription: the row, not the button.** The issue says canon "has a row, no
   flow — mirror it". Canon's *Manage Subscription* button is wired to nothing;
   this pane shows the plan and a sentence saying there is nothing to manage yet,
   rather than a control that visibly does nothing.

## Cross-lane edits, each surgical and named

This issue's lane is `features/{auth,settings}/pages/**` plus the `/adjust`
route. Six edits fall outside it. Every one is additive and behaviour-preserving
where nothing new is mounted:

| File | Change | Why it could not stay in lane |
|---|---|---|
| `features/settings/**` (beyond `pages/`) | the whole slice tier — state, shifters, selectors, producer, mocks | There was **no settings slice**: the directory did not exist. Preferences live in a Service (`localStore.preferences`), so a component cannot read them (`RC-6`) and a `useState` snapshot is forbidden (`RC-4`). The directory is new, so nothing can conflict with it. |
| `library/store.ts` | one line in the `reducer` map | `RC-23`: registering a slice is exactly this one line and nowhere else. |
| `src/index.ts` | one appended export block | The `/adjust` route mounts `SettingsHubPage` from `@kro/app`; a pure re-export barrel is the sanctioned route. Appended as its own block, per the file's own anti-contention convention. |
| `features/main/ToolbarSlots.tsx` | a fifth placement (`profile`) + `useToolbarSlotFilled` | The slot API extension the issue anticipates. A **count**, not a boolean, so two slots for one placement cannot make the first unmount claim it is empty. |
| `features/main/MainShellFragment.tsx` | the Profile button becomes `<ProfileControl>` | Renders the outlet always and the shell's own button **only while nothing is slotted** — so with no feature present the toolbar is byte-identical to what shipped. |
| `features/main/MainShellPage.tsx` | mounts `<ProfileControlPage />` | The popover, the auth sheet and the local-data dialog are shell-wide, not destination-scoped: a sign-in can complete through an OAuth redirect landing on any route. A Page is the artifact allowed to compose across features (`RC-37`), as this one already does for the capture slice. |
| 12 `…Selectors.test.ts` files | `settings: initialSettingsState` in each hand-built `RootState` | Unavoidable fallout of registering a twelfth slice: `RootState` names every one. One line each, no assertion changed. |
| `apps/web/src/app/(legacy)/{settings,integrations}/page.tsx` | the create-next-app stubs become redirects to `/adjust` | The issue's own lane covers "removal of stub routes' content"; the route files stay #13's and the `(legacy)` group is retired wholesale by #22. |

## Findings for other lanes — not fixed here

1. **`.kro-glass` breaks `position: fixed` on every dialog and sheet.**
   `design/system/glass/glass.css` sets `position: relative` from an **unlayered**
   stylesheet, and unlayered CSS beats Tailwind's `@layer utilities` — so
   `DialogContent`'s `fixed` utility never applies. Measured on the built app: an
   auth modal in an 844px viewport rendered at `top: 869px`, i.e. after the shell
   in normal flow. This affects **every** `Dialog` and `Sheet` in the app, not
   just this one. Worked around here with an inline `position: fixed` at each of
   the three call sites, each carrying the explanation. The fix belongs in
   `design/system/` — outside this lane.
2. **`observeAuthState` is still unwired.** KC-IS-#31 exports it for "the
   composition root (#13)" and #13 did not wire it, so a token refresh or a
   sign-out in a second tab is not observed. It needs `ThunkExtra`, which a
   component may not reach (`RC-6`), so it belongs in
   `apps/web/src/app/providers.tsx` — outside this lane. The **launch restore**
   *is* wired here (`ProfileControlPage` dispatches `restoreSessionThunk` on
   mount), because without it `session` stays `unknown` forever and every reload
   renders the signed-out control for an account that is signed in.
3. **The Settings glyph vocabulary is a lane-local map.**
   `features/settings/pages/settingsIcons.ts` adds ~30 SF-Symbol rows the shared
   maps do not have (`sunrise`, `cup.and.saucer`, `speaker.wave.2`, …). Its test
   asserts the rows are **disjoint** from both shared maps, so "which glyph is
   that symbol" keeps one answer. They belong in
   `design/system/icons/icons.ts` once a second surface needs them.
4. **`check-uzf-boundaries.mjs` prints `RC-50` where it means `RC-40`** —
   already recorded in `spec/architecture/web.md`; unchanged here.

## Screenshots

Both viewports (desktop 1440×900, mobile 390×844) and both schemes, captured
from the **built production app** driven through its own controls — no injected
state. Rows are the rendering context, columns are the states, per `UZF-26`.

The four scenes below the app tables need a Kro Cloud account or a live Google
grant and are **not reachable on a checkout with no Supabase project**. `RC-11`
makes Storybook this stack's `UZF-26` evidence carrier and says a story's capture
doubles as the PR's screenshot, so those are captured from the stories the render
tests mirror — the same fixtures, not a staged scene.

### Settings hub — KC-IS-#32 · #11 · #31

| | Hub, as `/adjust` opens | Sync footer after the close-push |
|---|---|---|
| desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/hub-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/hub-sync-footer-signed-out-desktop-light.png) |
| desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/hub-desktop-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/hub-sync-footer-signed-out-desktop-dark.png) |
| mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/hub-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/hub-sync-footer-signed-out-mobile-light.png) |
| mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/hub-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/hub-sync-footer-signed-out-mobile-dark.png) |

### General preferences — KC-IS-#32 · #11

| | Canon defaults | End ≤ start, both values persisting |
|---|---|---|
| desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-general-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-general-invalid-hours-desktop-light.png) |
| desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-general-desktop-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-general-invalid-hours-desktop-dark.png) |
| mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-general-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-general-invalid-hours-mobile-light.png) |
| mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-general-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-general-invalid-hours-mobile-dark.png) |

### The other four preference panes — KC-IS-#32 · #11

| | Session | Plan | Do | Earn |
|---|---|---|---|---|
| desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-session-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-plan-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-do-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-earn-desktop-light.png) |
| desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-session-desktop-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-plan-desktop-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-do-desktop-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-earn-desktop-dark.png) |
| mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-session-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-plan-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-do-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-earn-mobile-light.png) |
| mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-session-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-plan-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-do-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-earn-mobile-dark.png) |

### Account group — KC-IS-#32 · #33

| | Integrations, honest unconfigured Google | Subscription |
|---|---|---|
| desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-integrations-unconfigured-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-subscription-desktop-light.png) |
| desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-integrations-unconfigured-desktop-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-subscription-desktop-dark.png) |
| mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-integrations-unconfigured-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-subscription-mobile-light.png) |
| mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-integrations-unconfigured-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/section-subscription-mobile-dark.png) |

### Auth surface and profile popover — KC-IS-#32 · #31

| | Sign in (cloud unavailable) | Create account | Profile popover, signed out |
|---|---|---|---|
| desktop · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/auth-surface-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/auth-surface-sign-up-desktop-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/profile-popover-signed-out-desktop-light.png) |
| desktop · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/auth-surface-desktop-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/auth-surface-sign-up-desktop-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/profile-popover-signed-out-desktop-dark.png) |
| mobile · light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/auth-surface-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/auth-surface-sign-up-mobile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/profile-popover-signed-out-mobile-light.png) |
| mobile · dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/auth-surface-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/auth-surface-sign-up-mobile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/profile-popover-signed-out-mobile-dark.png) |

### States that need an account — captured from their stories (`RC-11`)

| | Profile popover, signed in | Profile pane, signed in | Local-data dialog |
|---|---|---|---|
| light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-profile-popover-signed-in-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-account-profile-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-local-data-dialog-light.png) |
| dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-profile-popover-signed-in-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-account-profile-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-local-data-dialog-dark.png) |

| | Sync footer *Synced* | Sync footer *Offline* | Google connected | Google needs reconnect |
|---|---|---|---|---|
| light | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-hub-footer-synced-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-hub-footer-offline-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-integrations-connected-light.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-integrations-needs-reconnect-light.png) |
| dark | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-hub-footer-synced-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-hub-footer-offline-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-integrations-connected-dark.png) | ![](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/32-auth-settings-ui/story-integrations-needs-reconnect-dark.png) |

---

Bankai-Agent: ichigo

## Review rounds

| Round | Reviewer | Findings | Disposition |
|---|---|---|---|
| 1 (`f1e9999`) | Copilot | 2 inline | Both **real and taken**, fixed in `d43b8d0`, replied on-thread and resolved |
| 2 (`d43b8d0`) | Copilot | re-requested on the new head; no further round posted | — |
| — | Cursor Bugbot | `skipping` | Not configured to run on this repo |

**Round 1, in full** — neither was a nit:

1. *`selectIsSettingsLoaded` makes the preference form inert in the `failed`
   state.* Correct, and it contradicted canon's own *Load failed* behaviour
   (*"falls back to defaults and stays fully editable; edits still save"*) as
   well as this PR's own mock comment. The guard exists to stop an **in-flight**
   load overwriting an edit, so the predicate is now "the read has settled":
   `selectIsSettingsLoaded` keeps its strict meaning and a new
   `selectIsSettingsEditable` answers `loaded || failed`. Pinned by four cases
   each, plus a `SettingsHubPage` render test that drives a preference store
   which throws on read and asserts the switch is still enabled.
2. *`googleAction` returns `busy` for an `unknown` connection even when
   `isBusy` is false, so a failed first status read strands the row on
   "Working…".* Correct. `unknown` + busy still reads *"Checking your
   connection…"*; `unknown` + not-busy now offers **Connect** and says the read
   did not answer. Took the first suggested option rather than the second on
   purpose: writing a concrete state in the failure shifter would be the shifter
   claiming knowledge it does not have, and that invented fact would outlive the
   banner.

## `CON-32` readiness

Run from a shallow clone of `bankai-core@main`:

```console
$ REPO=zheref/kro-pwa bash scripts/pr_ready_gate.sh --verdict 70
#70: not-ready: a configured reviewer's round is still owed at the current head (CON-32b): sasuke (no round at head);tenma (no round at head)

$ REPO=zheref/kro-pwa bash scripts/pr_ready_gate.sh --reviewers copilot --verdict 70
#70: ready
```

**The residue is the whole difference, and it is not this PR's to clear.** The
gate's default reviewer set is always `sasuke,tenma,copilot`; kro-pwa has **no
`.github/workflows/bankai.yml`** and no reviewer GitHub Apps installed, so
neither Sasuke nor Tenma can post a round on any PR in this repo yet. Standing
those up — the Apps, the `SASUKE_*` / `TENMA_*` / `BISKY_*` secrets, the
`bankai.yml` caller — is the **G5 human step the epic already tracks** (#1,
*Human-only steps*), not something a builder can do (`CON-2`).

Against the reviewers this repo actually has configured the gate reports
**`ready`**: every reported check green on the latest run, Copilot's round
addressed at head, and **zero unresolved review threads**. `mergeStateStatus` is
`CLEAN` and `mergeable` is `MERGEABLE`.
