### PR TITLE
fix(capture): let a Task or Reminder submit without a date

### DIFF
--- a/docs/Features/Inbox.md
+++ b/docs/Features/Inbox.md
@@ -1,0 +1,232 @@
+# Inbox
+
+> The cross-platform behaviour is canon in `zheref/KroApple`'s own
+> `docs/Features/Inbox.md`. This file is Kro Web's copy of that spec plus the
+> **Web notes** section at the end, which is the only part that is
+> web-specific. Where the two disagree, canon is right and this file is the
+> bug.
+
+## Purpose
+
+The Inbox is a transient, recency-organized list of endeavors that the user
+has just captured. Its job is to let the user *act on* fresh items quickly —
+by triaging them into the Eisenhower matrix, scheduling them for today,
+starting a session, or dismissing them — before they drift into the
+longer-term backlog.
+
+**The Inbox handles non-event endeavors only.** Calendar events bypass the
+Inbox entirely: when the user captures an event, the app routes them straight
+to the Plan tab and scrolls the day view to the event's time slot. See *User
+flows* below.
+
+## Feature flag
+
+- Name: none (Inbox is always available for non-event captures)
+- Default state: on
+- Rollout / sunset notes: Inbox is a permanent surface. Specific buttons it
+  shows ([Triage](./Triage.md), Add for Today) have their own per-feature
+  gates.
+
+## Entry points
+
+- Appears automatically as a sheet (or, on desktop widths, a glass popover —
+  see *Web notes*) shortly after the user captures a new non-event endeavor
+  through the input prompt.
+- Manually openable from the top-bar Inbox affordance.
+
+## Core concepts
+
+- **Endeavor** — a single user-captured intent (task, reminder, habit).
+  Events are NOT inboxable.
+- **Just Created** — the single non-event endeavor the user added in the last
+  action; surfaced as its own row at the top of the sheet on the *first*
+  presentation. On any subsequent open of the Inbox sheet, that endeavor moves
+  into **Pending Triage** (the "Just Created" slot only fires once per
+  capture).
+- **Pending Triage** — every *unscheduled* non-event endeavor, with **no age
+  bound** on either end. The Inbox is the catch-all for any endeavor that has
+  never been triaged: brand-new captures (under 24 hours old) and
+  long-neglected ones (weeks or months old) both appear here. An endeavor is
+  "unscheduled" when it has neither a scheduled time (start) nor a due date.
+- **Triage** — the act of deciding *where* an endeavor belongs (urgency /
+  importance). See [Triage](./Triage.md).
+- **Add for Today** — the act of scheduling an endeavor to a specific time on
+  the current day.
+
+## User flows
+
+### 1. Capture an endeavor — kind decides routing
+
+1. User confirms a new endeavor via the input prompt.
+2. Kind branches:
+   - **Event**: the input prompt enforces start + end at the Add button — the
+     button is disabled until both times are picked. The app then switches to
+     the **Plan** tab (after a brief delay so the input prompt finishes
+     dismissing first) and opens the day in **list mode** — the chronological
+     day list anchored at the event's row, highlighted with the "just
+     created" accent. The Inbox **does not** open. This is the *only* path
+     that auto-navigates a captured endeavor away from the Inbox.
+   - **Task / Reminder / Habit**: the Inbox sheet opens after a brief delay
+     (so the prompt has time to dismiss) with the new endeavor in the **Just
+     Created** section and any other unscheduled items below it. Non-event
+     captures never auto-navigate to the Plan tab — even when they would
+     apply to today; the user reaches Plan only by explicitly using *Add for
+     Today* on a row.
+3. **A Task or Reminder can be captured with no date at all** — the date
+   chip's Clear affordance (see *Web notes*) lets the user submit one with
+   neither a start nor a due date, which is exactly what makes it eligible
+   for Pending Triage the moment the Just Created slot drains. This is the
+   product-level statement of the fix tracked as `KC-IS-#75`.
+4. The user reviews / triages / schedules from there.
+
+### 2. Triage an inbox row
+
+See [Triage](./Triage.md) for the full flow.
+
+### 3. Add an inbox row to Today
+
+1. User taps the **Add for Today** button on a row.
+2. A small popover appears anchored to the button, showing a time picker
+   pre-filled with the next 15-minute slot after the current moment.
+3. User adjusts the time and confirms, or cancels to back out.
+4. On confirm:
+   - The Inbox sheet dismisses.
+   - The endeavor's due time is updated to the picked moment.
+   - The app switches to the Plan tab.
+   - A toast appears confirming the scheduling and offering **Undo**
+     (auto-dismisses after about 8 seconds).
+5. If the user taps **Undo** within the toast's lifetime, the endeavor's
+   previous schedule is restored and the toast clears.
+
+### 4. Quick actions via row swipes
+
+- **Leading swipe** exposes **Start** (begin a focus session for the
+  endeavor) and **Edit** (open the endeavor for editing).
+- **Trailing swipe** exposes **Delete** (destructive) and **Archive**.
+
+### 5. Empty state
+
+When there is nothing to show, the sheet presents an empty-state illustration
+and copy. No action affordances are present in that state.
+
+## States
+
+- **Loading** — the sheet uses the latest in-memory snapshot of endeavors, so
+  there is no explicit loading state. New non-event captures are reflected
+  immediately.
+- **Populated** — at least one of *Just Created* or *Pending Triage* has
+  rows (events are never counted).
+- **Empty** — no rows in any section.
+- **Triage pushed** — the Triage screen is mounted on top of the inbox list.
+  The list is preserved underneath and re-appears when Triage closes.
+- **Scheduling popover open** — the time-picker popover is anchored to a
+  specific row's *Add for Today* button. Only one popover can be open at a
+  time.
+
+## Interactions with other features
+
+- **[Triage](./Triage.md)** — the only entry point, and the surface Triage
+  lives inside. On confirmation the Inbox re-reads its rows, which is what
+  makes the triaged row disappear from Pending Triage.
+- **Plan** — non-event endeavors hand off to Plan via *Add for Today* (with
+  toast + Undo). **Events bypass the Inbox altogether** and hand off to Plan
+  with a scroll target on the event's day + time.
+
+## Out of scope
+
+- Long-term backlog management.
+- Bulk actions across multiple rows. All actions are row-scoped.
+- Recurring endeavors — they appear like any other row but the Inbox does not
+  expose their recurrence rules.
+- **Calendar events.** They are explicitly excluded from every section and
+  never auto-open the Inbox; this is invariant.
+
+## Open questions
+
+- Should the Pending Triage section grow to include items older than 7 days
+  when the Inbox is empty otherwise? (Owner: PM. Inherited from canon,
+  2026-05-19.)
+
+## Diagrams
+
+### Capture routing (events vs. non-events)
+
+```mermaid
+flowchart TD
+    capture[User confirms new endeavor] --> kind{Kind?}
+    kind -->|event| validate{Has start + end?}
+    validate -->|no| drop[Result rejected — Add stays disabled]
+    validate -->|yes| planRoute[Switch to Plan tab]
+    planRoute --> planDay[Set day = event date]
+    planDay --> planScroll[Set scroll target = event start]
+    planScroll --> planDone[User lands on event slot]
+    kind -->|task / reminder / habit| dateChoice{Date chip left set, or cleared?}
+    dateChoice -->|left set| inboxDelayDated[Brief delay to let prompt dismiss]
+    dateChoice -->|cleared| inboxDelayDateless[Brief delay — endeavor carries no due date]
+    inboxDelayDated --> inboxSheet[Inbox sheet opens]
+    inboxDelayDateless --> inboxSheet
+    inboxSheet --> justCreated[Endeavor sits in the Just Created slot]
+    justCreated --> reopen[Inbox reopened later]
+    reopen --> pendingCheck{Unscheduled — no start, no due?}
+    pendingCheck -->|yes| pendingTriage[Appears in Pending Triage]
+    pendingCheck -->|no| gone[Not shown — it was scheduled or completed]
+```
+
+### Inbox interactions
+
+```mermaid
+flowchart TD
+    sheet[Inbox sheet open] --> populated{Any unscheduled\nnon-event endeavors?}
+    populated -- no --> empty[Empty state]
+    populated -- yes --> rows[Rows grouped by recency\nevents + scheduled items excluded]
+    empty --> dismissEmpty[User dismisses]
+    rows --> chooseRow[User selects a row action\nonly unscheduled items here]
+    chooseRow --> triage[Triage tapped]
+    chooseRow --> aft[Add for Today tapped]
+    chooseRow --> swipeStart[Swipe · Start session]
+    chooseRow --> swipeEdit[Swipe · Edit]
+    chooseRow --> swipeDelete[Swipe · Delete]
+    chooseRow --> swipeArchive[Swipe · Archive]
+    triage --> push[Push Triage onto inbox nav stack]
+    push --> triageConfirm[User confirms in Triage]
+    triageConfirm --> applied[Parent applies decision]
+    applied --> pop[Triage pops, Inbox list returns]
+    aft --> popover[Time picker popover]
+    popover --> confirm[User confirms time]
+    popover --> cancel[User cancels]
+    cancel --> rows
+    confirm --> dismiss2[Inbox sheet dismisses]
+    dismiss2 --> planTab[App switches to Plan tab]
+    planTab --> toast[Bottom toast w/ Undo]
+    toast --> undo{Undo tapped\nwithin ~8s?}
+    undo -- yes --> restore[Previous schedule restored]
+    undo -- no/timeout --> done[Scheduling committed]
+```
+
+## Web notes
+
+Everything above is the shared spec. These are the decisions that exist only
+because this is a browser.
+
+- **Presentation.** The Inbox — and the capture prompt that feeds it — is a
+  bottom sheet with a custom detent on a phone-width viewport and a glass
+  popover anchored to the FAB's own corner on desktop, per `KC-IS-#24`'s web
+  idiom for the pair.
+- **The date chip's Clear affordance is a web-only addition, not a canon
+  port (`KC-IS-#75`).** Canon's `EndeavorInputPrompt` date chip is always
+  `isSet: true` and offers no way to unset it — only its time chips (start
+  and, for an event, end) carry a Clear button. That leaves canon's own
+  Pending Triage definition — *"every unscheduled non-event endeavor"* —
+  unreachable through its own capture prompt for anything but a Habit, which
+  never shows a date chip at all. This repo closes that gap by extending the
+  same Clear-button idiom canon already uses for time to the date chip too,
+  for Task and Reminder (never for Event, which has no way to represent a
+  missing start). Upstream candidate for KroApple; recorded here rather than
+  filed there, since this repo owns no authority over KroApple's canon.
+- **The disabled Add control names what blocks it** in text, next to the
+  button and referenced by it, because a disabled control leaves the
+  reachable action surface entirely on the web. Canon has no equivalent — a
+  disabled control there carries no explanation.
+- **Dates and times use the browser's own date/time controls** rather than a
+  wheel picker, reachable by keyboard and by screen reader without anything
+  being built.

--- a/packages/app/src/features/capture/CaptureFeature.ts
+++ b/packages/app/src/features/capture/CaptureFeature.ts
@@ -55,6 +55,7 @@ import {
   withAddForTodayTimeAdjusted,
   withCaptureCommitted,
   withContextLoaded,
+  withDateCleared,
   withDatePicked,
   withDestinationSelected,
   withException,
@@ -251,6 +252,17 @@ export const captureSlice = createSlice({
 
     userDidPickDate(state, action: PayloadAction<{ date: Date }>) {
       Object.assign(state, withDatePicked(state, action.payload.date))
+    },
+
+    /**
+     * User intent: the date chip's Clear button (`KC-IS-#75`).
+     *
+     * The affordance canon's own date chip never offers — see `CaptureDraft`'s
+     * `hasDate` doc in `CaptureRules.ts`. It is what lets a Task or Reminder
+     * submit dateless, so it reaches Pending Triage.
+     */
+    userDidClearDate(state) {
+      Object.assign(state, withDateCleared(state))
     },
 
     /**
@@ -548,6 +560,7 @@ export const {
   userDidAdjustAddForTodayTime,
   userDidBeginTimeEdit,
   userDidCancelAddForToday,
+  userDidClearDate,
   userDidDiscardCapture,
   userDidDismissInbox,
   userDidEditTitle,

--- a/packages/app/src/features/capture/CaptureMocks.ts
+++ b/packages/app/src/features/capture/CaptureMocks.ts
@@ -43,6 +43,7 @@ import {
   withAddForTodayRequested,
   withCaptureCommitted,
   withContextLoaded,
+  withDateCleared,
   withException,
   withFetchStarted,
   withPromptOpened,
@@ -229,10 +230,25 @@ export const captureDraftFixtures = {
     title: 'Write the retro',
     hasTime: true,
   })),
+  /**
+   * Titled task, date cleared — `KC-IS-#75`: still valid (only events require
+   * a date), and it is what submits a Task that lands in Pending Triage.
+   */
+  titledTaskNoDate: draftOf(CaptureKind.task, (draft) => ({
+    ...draft,
+    title: 'Sort the garage',
+    hasDate: false,
+  })),
   /** Titled reminder — valid without a time. */
   titledReminder: draftOf(CaptureKind.reminder, (draft) => ({
     ...draft,
     title: 'Bins out',
+  })),
+  /** Titled reminder, date cleared — the same dateless path, for a Reminder. */
+  titledReminderNoDate: draftOf(CaptureKind.reminder, (draft) => ({
+    ...draft,
+    title: 'Ping the landlord',
+    hasDate: false,
   })),
   /** Titled habit — valid, and its date is dropped on submission. */
   titledHabit: draftOf(CaptureKind.habit, (draft) => ({
@@ -363,6 +379,22 @@ export const captureStateMocks = {
       initialStart: null,
     }),
     'Book the flights',
+  ),
+
+  /**
+   * The prompt open on Task, titled, date cleared — `KC-IS-#75`: still valid
+   * (only events require a date), and this IS the dateless-capture affordance
+   * the date chip's Clear button unlocks.
+   */
+  promptTaskDateCleared: withDateCleared(
+    withTitleEdited(
+      withPromptOpened(loadedPool, {
+        kind: CaptureKind.task,
+        now: CAPTURE_MOCK_NOW,
+        initialStart: null,
+      }),
+      'Sort the garage',
+    ),
   ),
 
   /** The prompt open on Event with a title but no times — Add still disabled. */

--- a/packages/app/src/features/capture/CaptureRules.ts
+++ b/packages/app/src/features/capture/CaptureRules.ts
@@ -499,8 +499,28 @@ export const nextFreeSlotToday = (
 export interface CaptureDraft {
   readonly title: string
   readonly kind: CaptureKind
-  /** Due / start **day**. Time-of-day here is never read. */
+  /**
+   * Due / start **day**. Time-of-day here is never read.
+   *
+   * Always a real candidate instant, exactly like `time`/`endTime` — so the
+   * date panel has something to open on even while `hasDate` is `false`.
+   */
   readonly date: Date
+  /**
+   * Whether the user has committed to `date`, mirroring `hasTime`.
+   *
+   * **KC-IS-#75.** Canon's `EndeavorInputPrompt` draft has no equivalent
+   * flag — its date chip is always `isSet: true` and offers no clear
+   * affordance — so a Task built from it can never reach Pending Triage
+   * (`start === null && due === null`), even though canon's own Inbox spec
+   * defines Pending Triage as "every unscheduled non-event endeavor". This
+   * flag is what makes that state reachable: `false` for a Task or Reminder
+   * means the capture submits with no due date. An Event forces this back to
+   * `true` the moment its kind is selected (`withKindSelected`) and its own
+   * Clear affordance is never offered — `Endeavor.event(...)` has no way to
+   * represent an event without a start.
+   */
+  readonly hasDate: boolean
   readonly hasTime: boolean
   readonly time: Date
   readonly hasEndTime: boolean
@@ -539,6 +559,10 @@ export const makeCaptureDraft = (params: {
     title: '',
     kind: params.kind,
     date,
+    // Matches canon's own `isSet: true` seed — a fresh capture still opens
+    // dated by default. `hasDate` only ever turns false through an explicit
+    // Clear (`withDateCleared`).
+    hasDate: true,
     hasTime: initialStart !== null,
     time: base,
     hasEndTime: initialStart !== null,
@@ -658,9 +682,14 @@ export interface CaptureResult {
  * `commitIfValid()` — the result, or `null` when the draft may not be
  * submitted.
  *
- * The three per-kind projections are canon's, verbatim: habits drop the date,
- * only tasks and habits carry rewards, and only an event with a committed end
- * carries `endTime`.
+ * The per-kind projections are canon's, verbatim, plus one this repo adds:
+ * habits drop the date, only tasks and habits carry rewards, and only an
+ * event with a committed end carries `endTime`. **`date` also drops to `null`
+ * whenever `hasDate` is `false`** (`KC-IS-#75`) — canon's own draft has no
+ * such flag and always emits `draft.dueDate`, which is exactly why a Task
+ * built through its prompt can never reach Pending Triage. `hasDate` stays
+ * pinned `true` for an event (`withKindSelected`, `withDateCleared`), so this
+ * branch never drops an event's date.
  */
 export const captureResultFromDraft = (
   draft: CaptureDraft,
@@ -670,7 +699,12 @@ export const captureResultFromDraft = (
   return {
     title: trimmedCaptureTitle(draft),
     kind: draft.kind,
-    date: draft.kind === CaptureKind.habit ? null : draft.date,
+    date:
+      draft.kind === CaptureKind.habit
+        ? null
+        : draft.hasDate
+          ? draft.date
+          : null,
     time: draft.hasTime ? draft.time : null,
     endTime: isEvent && draft.hasEndTime ? draft.endTime : null,
     destination: draft.destination,

--- a/packages/app/src/features/capture/CaptureShifters.ts
+++ b/packages/app/src/features/capture/CaptureShifters.ts
@@ -25,7 +25,7 @@ import {
   ADD_FOR_TODAY_UNDO_WINDOW_MS,
   type CaptureDestination,
   type CaptureDraft,
-  type CaptureKind,
+  CaptureKind,
   type CaptureRecurrence,
   type CaptureSchedulingSnapshot,
   captureIntentFor,
@@ -170,6 +170,11 @@ export function withTitleEdited(
  * *"close any open editors when switching kinds"* — the draft's committed
  * values are kept, so a user who typed a time and then switched from Task to
  * Event still has it.
+ *
+ * **`hasDate` is forced back to `true` when the new kind is an Event**
+ * (`KC-IS-#75`) — an event has no way to represent a missing start, and the
+ * Clear-date affordance is only ever offered on Task/Reminder, so this is the
+ * one seam a dateless draft could otherwise carry into an Event.
  */
 export function withKindSelected(
   state: CaptureState,
@@ -180,16 +185,39 @@ export function withKindSelected(
   return {
     ...state,
     prompt: {
-      draft: { ...prompt.draft, kind },
+      draft: {
+        ...prompt.draft,
+        kind,
+        hasDate: kind === CaptureKind.event ? true : prompt.draft.hasDate,
+      },
       startEdit: null,
       endEdit: null,
     },
   }
 }
 
-/** One concern: the date chip picked a day. */
+/** One concern: the date chip picked a day. Picking one always commits it. */
 export function withDatePicked(state: CaptureState, date: Date): CaptureState {
-  return withDraft(state, (draft) => ({ ...draft, date }))
+  return withDraft(state, (draft) => ({ ...draft, date, hasDate: true }))
+}
+
+/**
+ * One concern: the date chip's Clear button (`KC-IS-#75`).
+ *
+ * The one affordance canon's own date chip never offers — see `CaptureDraft`'s
+ * `hasDate` doc. A no-op for an Event (dates are mandatory; the button is
+ * never rendered for one, but the invariant is enforced here too, not only in
+ * the view) and for an already-dateless draft.
+ */
+export function withDateCleared(state: CaptureState): CaptureState {
+  const prompt = state.prompt
+  if (prompt === null) return state
+  if (prompt.draft.kind === CaptureKind.event) return state
+  if (!prompt.draft.hasDate) return state
+  return {
+    ...state,
+    prompt: { ...prompt, draft: { ...prompt.draft, hasDate: false } },
+  }
 }
 
 /**

--- a/packages/app/src/features/capture/__tests__/CaptureFeature.test.ts
+++ b/packages/app/src/features/capture/__tests__/CaptureFeature.test.ts
@@ -21,6 +21,7 @@ import {
   userDidAdjustAddForTodayTime,
   userDidBeginTimeEdit,
   userDidCancelAddForToday,
+  userDidClearDate,
   userDidDiscardCapture,
   userDidDismissInbox,
   userDidEditTitle,
@@ -200,6 +201,26 @@ describe('userDidPickDate', () => {
     expect(
       reduce(loaded, userDidPickDate({ date: captureMockAt(18, 0, 0) })),
     ).toEqual(loaded)
+  })
+})
+
+describe('userDidClearDate', () => {
+  it('unsets the date on a Task — the KC-IS-#75 dateless-capture affordance', () => {
+    expect(reduce(openPrompt, userDidClearDate()).prompt?.draft.hasDate).toBe(
+      false,
+    )
+  })
+
+  it('leaves an Event dated — it has no way to represent one missing', () => {
+    const event = reduce(
+      openPrompt,
+      userDidSelectKind({ kind: CaptureKind.event }),
+    )
+    expect(reduce(event, userDidClearDate()).prompt?.draft.hasDate).toBe(true)
+  })
+
+  it('is harmless when no prompt is open', () => {
+    expect(reduce(loaded, userDidClearDate())).toEqual(loaded)
   })
 })
 
@@ -663,6 +684,23 @@ describe('submitting a capture', () => {
     const slice = store.getState().capture
     expect(slice.endeavors.map((value) => value.id)).toContain('new-task')
     expect(slice.prompt).toBeNull()
+  })
+
+  it('the KC-IS-#75 regression, through the real thunk: a dateless Task submits with no due date', async () => {
+    const store = await loadedStore()
+    await store.dispatch(
+      submitCaptureThunk({
+        draft: captureDraftFixtures.titledTaskNoDate,
+        id: 'dateless-task',
+        now: CAPTURE_MOCK_NOW,
+      }),
+    )
+
+    const endeavor = store
+      .getState()
+      .capture.endeavors.find((value) => value.id === 'dateless-task')
+    expect(endeavor?.due).toBeNull()
+    expect(endeavor?.start).toBeNull()
   })
 
   it('sends a task to the Inbox and an event to Plan', async () => {

--- a/packages/app/src/features/capture/__tests__/CaptureMocks.test.ts
+++ b/packages/app/src/features/capture/__tests__/CaptureMocks.test.ts
@@ -9,8 +9,9 @@ import {
   captureStateMocks,
 } from '../CaptureMocks'
 import {
-  captureBlocker,
   canSubmitCapture,
+  captureBlocker,
+  captureResultFromDraft,
   nearestQuarterHourSlot,
   nextQuarterHourSlot,
 } from '../CaptureRules'
@@ -88,6 +89,19 @@ describe('the draft fixtures', () => {
 
   it('include the one event shape that may be submitted', () => {
     expect(canSubmitCapture(captureDraftFixtures.completeEvent)).toBe(true)
+  })
+
+  it('include a dateless Task and Reminder — the KC-IS-#75 fix — both still submittable', () => {
+    expect(canSubmitCapture(captureDraftFixtures.titledTaskNoDate)).toBe(true)
+    expect(canSubmitCapture(captureDraftFixtures.titledReminderNoDate)).toBe(
+      true,
+    )
+    expect(
+      captureResultFromDraft(captureDraftFixtures.titledTaskNoDate)?.date,
+    ).toBeNull()
+    expect(
+      captureResultFromDraft(captureDraftFixtures.titledReminderNoDate)?.date,
+    ).toBeNull()
   })
 })
 

--- a/packages/app/src/features/capture/__tests__/CaptureRules.test.ts
+++ b/packages/app/src/features/capture/__tests__/CaptureRules.test.ts
@@ -175,8 +175,22 @@ describe('what blocks the Add button', () => {
       reason: null,
     },
     {
+      scenario:
+        'a titled Task with its date cleared needs no date either (KC-IS-#75)',
+      draft: captureDraftFixtures.titledTaskNoDate,
+      blocker: null,
+      reason: null,
+    },
+    {
       scenario: 'a titled Reminder needs no time either',
       draft: captureDraftFixtures.titledReminder,
+      blocker: null,
+      reason: null,
+    },
+    {
+      scenario:
+        'a titled Reminder with its date cleared is just as valid (KC-IS-#75)',
+      draft: captureDraftFixtures.titledReminderNoDate,
       blocker: null,
       reason: null,
     },
@@ -237,6 +251,9 @@ describe('the draft the prompt opens with', () => {
 
     expect(draft.hasTime).toBe(false)
     expect(draft.hasEndTime).toBe(false)
+    // A fresh draft still opens dated, matching canon's own seed — the
+    // dateless path (`KC-IS-#75`) is reached only through an explicit Clear.
+    expect(draft.hasDate).toBe(true)
     expect(draft.time).toEqual(captureMockAt(17, 10, 0))
     expect(draft.date).toEqual(captureMockAt(17, 0, 0))
   })
@@ -417,6 +434,23 @@ describe('what a confirmed prompt emits', () => {
     ).toBeNull()
   })
 
+  it('drops a Task’s date once the date chip is cleared — the KC-IS-#75 fix', () => {
+    expect(
+      captureResultFromDraft(captureDraftFixtures.titledTaskNoDate)?.date,
+    ).toBeNull()
+    // A cleared date still submits with its title and every other field —
+    // clearing the date is not "as if habit": rewards survive.
+    expect(
+      captureResultFromDraft(captureDraftFixtures.titledTaskNoDate)?.rewards,
+    ).toBe(10)
+  })
+
+  it('drops a Reminder’s date the same way — Pending Triage has no kind exception', () => {
+    expect(
+      captureResultFromDraft(captureDraftFixtures.titledReminderNoDate)?.date,
+    ).toBeNull()
+  })
+
   it('refuses an event result that is missing a boundary at the domain edge', () => {
     const result = resultOf(captureDraftFixtures.completeEvent)
     expect(isCaptureResultValidForCreation(result)).toBe(true)
@@ -483,6 +517,24 @@ describe('building the endeavor a capture stores', () => {
       destination: CaptureDestination.kroCloud,
     })
     expect(event.hostedBy).toEqual([EndeavorHost.supabase])
+  })
+
+  it('gives a dateless Task no due date at all — the KC-IS-#75 regression', () => {
+    const task = build(captureDraftFixtures.titledTaskNoDate)
+    expect(task.due).toBeNull()
+    expect(task.start).toBeNull()
+  })
+
+  it('the KC-IS-#75 regression, end to end: capture a dateless Task → it appears in Pending Triage', () => {
+    const task = build(captureDraftFixtures.titledTaskNoDate)
+    const rows = pendingTriageEndeavors([task], null)
+    expect(rows.map((row) => row.id)).toContain(task.id)
+  })
+
+  it('the same regression for a Reminder — Pending Triage is kind-agnostic', () => {
+    const reminder = build(captureDraftFixtures.titledReminderNoDate)
+    const rows = pendingTriageEndeavors([reminder], null)
+    expect(rows.map((row) => row.id)).toContain(reminder.id)
   })
 })
 

--- a/packages/app/src/features/capture/__tests__/CaptureSelectors.test.ts
+++ b/packages/app/src/features/capture/__tests__/CaptureSelectors.test.ts
@@ -15,10 +15,15 @@ import { CaptureExceptions } from '../CaptureException'
 import type { CaptureState } from '../CaptureFeature'
 import {
   CAPTURE_MOCK_NOW,
+  captureDraftFixtures,
   captureMockAt,
   captureStateMocks,
 } from '../CaptureMocks'
-import { CaptureDestination } from '../CaptureRules'
+import {
+  CaptureDestination,
+  captureResultFromDraft,
+  endeavorFromCaptureResult,
+} from '../CaptureRules'
 import {
   selectAddForToday,
   selectAddForTodayPrefill,
@@ -44,8 +49,10 @@ import {
   selectUndoSnapshot,
 } from '../CaptureSelectors'
 import {
+  withCaptureCommitted,
   withDestinationSelected,
   withException,
+  withInboxOpened,
   withTriageRequested,
 } from '../CaptureShifters'
 import { initialMainState } from '../../main/MainFeature'
@@ -371,6 +378,28 @@ describe('selectPendingTriageEndeavors', () => {
     for (const row of selectPendingTriageEndeavors(loaded)) {
       expect(vistaStatuses?.has(row.status)).toBe(true)
     }
+  })
+
+  it('surfaces a captured dateless Task — the KC-IS-#75 regression, end to end through this selector', () => {
+    const result = captureResultFromDraft(captureDraftFixtures.titledTaskNoDate)
+    if (result === null) throw new Error('expected a valid capture result')
+    const endeavor = endeavorFromCaptureResult(result, {
+      id: 'dateless-task',
+      now: CAPTURE_MOCK_NOW,
+    })
+
+    const committed = withCaptureCommitted(captureStateMocks.loadedPool, {
+      endeavor,
+      destination: CaptureDestination.local,
+      now: CAPTURE_MOCK_NOW,
+    })
+    // Reopening the Inbox drains the Just Created slot into Pending Triage
+    // (`withInboxOpened`) — the same second-open the user performs in the app.
+    const reopened = withInboxOpened(committed)
+
+    expect(
+      selectPendingTriageEndeavors(rootWith(reopened)).map((row) => row.id),
+    ).toContain('dateless-task')
   })
 })
 

--- a/packages/app/src/features/capture/__tests__/CaptureShifters.test.ts
+++ b/packages/app/src/features/capture/__tests__/CaptureShifters.test.ts
@@ -21,6 +21,7 @@ import {
   withAddForTodayTimeAdjusted,
   withCaptureCommitted,
   withContextLoaded,
+  withDateCleared,
   withDatePicked,
   withDestinationSelected,
   withException,
@@ -223,6 +224,20 @@ describe('withKindSelected', () => {
   it('is a no-op after the prompt has been dismissed', () => {
     expect(withKindSelected(loaded, CaptureKind.event)).toBe(loaded)
   })
+
+  it('forces the date back on when the new kind is an Event (KC-IS-#75)', () => {
+    const dateless = withDateCleared(openPrompt)
+    expect(dateless.prompt?.draft.hasDate).toBe(false)
+
+    const switched = withKindSelected(dateless, CaptureKind.event)
+    expect(switched.prompt?.draft.hasDate).toBe(true)
+  })
+
+  it('leaves a Task’s cleared date cleared when switching to Reminder', () => {
+    const dateless = withDateCleared(openPrompt)
+    const switched = withKindSelected(dateless, CaptureKind.reminder)
+    expect(switched.prompt?.draft.hasDate).toBe(false)
+  })
 })
 
 describe('withDatePicked', () => {
@@ -239,8 +254,40 @@ describe('withDatePicked', () => {
     ).toBe(false)
   })
 
+  it('re-commits the date, undoing a prior Clear', () => {
+    const dateless = withDateCleared(openPrompt)
+    expect(dateless.prompt?.draft.hasDate).toBe(false)
+
+    const picked = withDatePicked(dateless, captureMockAt(18, 0, 0))
+    expect(picked.prompt?.draft.hasDate).toBe(true)
+  })
+
   it('is a no-op after the prompt has been dismissed', () => {
     expect(withDatePicked(loaded, captureMockAt(18, 0, 0))).toBe(loaded)
+  })
+})
+
+describe('withDateCleared', () => {
+  it('unsets the date on a Task, the KC-IS-#75 affordance', () => {
+    const cleared = withDateCleared(openPrompt)
+    expect(cleared.prompt?.draft.hasDate).toBe(false)
+    // The candidate day itself is untouched — only the commit flag flips, so
+    // re-opening the picker still has something sensible to show.
+    expect(cleared.prompt?.draft.date).toEqual(openPrompt.prompt?.draft.date)
+  })
+
+  it('refuses to clear an Event’s date — it has no way to represent one missing', () => {
+    const event = withKindSelected(openPrompt, CaptureKind.event)
+    expect(withDateCleared(event)).toBe(event)
+  })
+
+  it('is a no-op on an already-dateless draft', () => {
+    const cleared = withDateCleared(openPrompt)
+    expect(withDateCleared(cleared)).toBe(cleared)
+  })
+
+  it('is a no-op after the prompt has been dismissed', () => {
+    expect(withDateCleared(loaded)).toBe(loaded)
   })
 })
 

--- a/packages/app/src/features/capture/pages/CapturePromptFragment.stories.tsx
+++ b/packages/app/src/features/capture/pages/CapturePromptFragment.stories.tsx
@@ -53,6 +53,7 @@ const prompt = (
     onEditTitle={noop}
     onSelectKind={noop}
     onPickDate={noop}
+    onClearDate={noop}
     onBeginTimeEdit={noop}
     onPickTime={noop}
     onEndTimeEdit={noop}
@@ -144,6 +145,19 @@ export const HabitHasNoDate = {
   render: () => (
     <ThemeScope theme="light">
       {prompt(captureDraftFixtures.titledHabit, 'sheet')}
+    </ThemeScope>
+  ),
+}
+
+/**
+ * A Task with its date cleared — the `KC-IS-#75` fix. The chip reads "No
+ * date" and its Clear button is gone; Add stays enabled, so this is exactly
+ * what submits a Task into Pending Triage.
+ */
+export const SheetTaskDateCleared = {
+  render: () => (
+    <ThemeScope theme="light">
+      {prompt(captureDraftFixtures.titledTaskNoDate, 'sheet')}
     </ThemeScope>
   ),
 }

--- a/packages/app/src/features/capture/pages/CapturePromptFragment.tsx
+++ b/packages/app/src/features/capture/pages/CapturePromptFragment.tsx
@@ -121,6 +121,8 @@ export interface CapturePromptFragmentProps {
   readonly onEditTitle: (title: string) => void
   readonly onSelectKind: (kind: CaptureKind) => void
   readonly onPickDate: (date: Date) => void
+  /** The date chip's Clear button — never offered for an Event (`KC-IS-#75`). */
+  readonly onClearDate: () => void
   readonly onBeginTimeEdit: (field: CaptureTimeField) => void
   readonly onPickTime: (field: CaptureTimeField, time: Date) => void
   readonly onEndTimeEdit: (
@@ -213,6 +215,7 @@ function PromptForm({
   onEditTitle,
   onSelectKind,
   onPickDate,
+  onClearDate,
   onBeginTimeEdit,
   onPickTime,
   onEndTimeEdit,
@@ -324,14 +327,32 @@ function PromptForm({
           ) : null}
 
           {isHabit ? null : (
-            <PromptChip
-              glyph={<CalendarGlyph size={12} aria-hidden />}
-              label={formatCaptureDate(draft.date, now, locale)}
-              isSet
-              isExpanded={panel === 'date'}
-              accessibilityLabel={`Date: ${formatCaptureDate(draft.date, now, locale)}`}
-              onSelect={() => togglePanel('date')}
-            />
+            <>
+              <PromptChip
+                glyph={<CalendarGlyph size={12} aria-hidden />}
+                label={
+                  draft.hasDate
+                    ? formatCaptureDate(draft.date, now, locale)
+                    : 'No date'
+                }
+                isSet={draft.hasDate}
+                isExpanded={panel === 'date'}
+                accessibilityLabel={
+                  draft.hasDate
+                    ? `Date: ${formatCaptureDate(draft.date, now, locale)}`
+                    : 'Date: No date'
+                }
+                onSelect={() => togglePanel('date')}
+              />
+              {/*
+                Never offered for an Event — canon's `Endeavor.event(...)` has
+                no way to represent one without a start, and `withDateCleared`
+                enforces the same invariant at the state layer (`KC-IS-#75`).
+              */}
+              {!isEvent && draft.hasDate ? (
+                <ClearButton label="Clear date" onSelect={onClearDate} />
+              ) : null}
+            </>
           )}
 
           <PromptChip

--- a/packages/app/src/features/capture/pages/CapturePromptPage.tsx
+++ b/packages/app/src/features/capture/pages/CapturePromptPage.tsx
@@ -24,6 +24,7 @@ import type {
 } from '../CaptureFeature'
 import {
   userDidBeginTimeEdit,
+  userDidClearDate,
   userDidDiscardCapture,
   userDidEditTitle,
   userDidEndTimeEdit,
@@ -132,6 +133,7 @@ export function CapturePromptPage() {
         dispatch(userDidSelectKind({ kind }))
       }
       onPickDate={(date: Date) => dispatch(userDidPickDate({ date }))}
+      onClearDate={() => dispatch(userDidClearDate())}
       onBeginTimeEdit={(field: CaptureTimeField) =>
         dispatch(userDidBeginTimeEdit({ field }))
       }

--- a/packages/app/src/features/capture/pages/__tests__/CapturePromptFragment.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/CapturePromptFragment.test.tsx
@@ -63,6 +63,7 @@ const renderPrompt = (
       onEditTitle={noop}
       onSelectKind={noop}
       onPickDate={noop}
+      onClearDate={noop}
       onBeginTimeEdit={noop}
       onPickTime={noop}
       onEndTimeEdit={noop}
@@ -170,6 +171,26 @@ describe('the chip strip follows the kind', () => {
 
     expect(screen.getByRole('button', { name: 'Date: Today' })).toBeTruthy()
   })
+
+  it('offers a Clear button on a dated Task, the KC-IS-#75 affordance', () => {
+    renderPrompt(captureDraftFixtures.titledTask)
+
+    expect(screen.getByRole('button', { name: 'Clear date' })).toBeTruthy()
+  })
+
+  it('reads "No date" once the date is cleared, and drops the Clear button', () => {
+    renderPrompt(captureDraftFixtures.titledTaskNoDate)
+
+    expect(screen.getByRole('button', { name: 'Date: No date' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Clear date' })).toBeNull()
+  })
+
+  it('never offers a date Clear button on an Event — it has no way to be dateless', () => {
+    renderPrompt(captureDraftFixtures.completeEvent)
+
+    expect(screen.getByRole('button', { name: /^Date:/ })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Clear date' })).toBeNull()
+  })
 })
 
 describe('the two presentations', () => {
@@ -230,6 +251,15 @@ describe('intent leaves through callbacks only (RC-15)', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Time' }))
 
     expect(onBeginTimeEdit).toHaveBeenCalledWith('start')
+  })
+
+  it('raises onClearDate from the date chip’s Clear button, never a local flag', async () => {
+    const onClearDate = vi.fn()
+    renderPrompt(captureDraftFixtures.titledTask, { onClearDate })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear date' }))
+
+    expect(onClearDate).toHaveBeenCalledTimes(1)
   })
 
   it('offers Discard, Clear and Done while an edit is in flight', async () => {

--- a/packages/app/src/features/capture/pages/__tests__/CapturePromptPage.test.tsx
+++ b/packages/app/src/features/capture/pages/__tests__/CapturePromptPage.test.tsx
@@ -177,6 +177,26 @@ describe('every edit goes through the slice, never through local state', () => {
     )
   })
 
+  it('the KC-IS-#75 regression, through the mounted Page: clearing the date captures a dateless Task', async () => {
+    const store = makeCaptureStore({ endeavors: [] })
+    mount(store)
+    open(store)
+    await screen.findByTestId('capture-title')
+
+    await userEvent.type(screen.getByTestId('capture-title'), 'Sort the garage')
+    await userEvent.click(screen.getByRole('button', { name: 'Clear date' }))
+    expect(screen.getByRole('button', { name: 'Date: No date' })).toBeTruthy()
+
+    await userEvent.click(screen.getByTestId('capture-add'))
+
+    await waitFor(() => {
+      expect(store.getState().capture.endeavors).toHaveLength(1)
+    })
+    const captured = store.getState().capture.endeavors[0]
+    expect(captured?.due).toBeNull()
+    expect(captured?.start).toBeNull()
+  })
+
   it('captures once for one intent, however fast Add is pressed twice', async () => {
     const store = makeCaptureStore({ endeavors: [] })
     mount(store)


### PR DESCRIPTION
> **Ichigo — Shinigami** · lets a captured Task or Reminder submit without a date, so it can reach Pending Triage
> local, on your creds · handbook `v0.11.2`

# What this changes for you

Today, capturing a Task or Reminder through the quick-add prompt **always** stamps it with a due date — even though the date chip looks the same as the time chips, which *do* let you clear them. That silently makes "capture something now, come back and triage it later" impossible: Pending Triage only ever shows unscheduled work (no start, no due date), and nothing you capture through the UI could ever be unscheduled unless it was a Habit.

This adds a **Clear** button to the date chip for Task and Reminder (never for Event, which has no way to represent a missing start) — the same idiom the time chips already use. Clear it, the chip reads "No date," and Add stays enabled. Submit it, and the endeavor lands with no due date at all — which is exactly what makes it show up in **Pending Triage** the next time the Inbox opens.

| | Before | After |
|---|---|---|
| Task/Reminder date chip | Always "set," no way to clear it | Clear button, same as the time chips |
| A captured Task with no due date | Unreachable through the UI | One tap: type a title, tap Clear on the date chip, tap Add |
| Pending Triage | Only ever showed Habits (and legacy/imported rows) | Now reachable for a freshly captured Task or Reminder too |

Nothing changes for a capture you don't touch the date chip on — every existing capture still defaults to a dated Task, exactly as today.

## Canon divergence, named up front

I re-fetched `zheref/KroApple@main` and read `Kro/Components/EndeavorInputPrompt.swift` end to end before building this. **Canon's own date chip has no clear affordance either** — it is hard-coded `isSet: true`, and only the time chips (`hasTime`/`hasEndTime`) carry a Clear button. So the premise in KC-IS-#75 ("check canon's EndeavorInputPrompt for its idiom") doesn't hold today: there is no canon idiom to port for the *date* chip specifically — only for *time*, which I did port faithfully (same `ClearButton`, same placement, same "no button until something is set" gating).

This means canon's own capture prompt has the identical gap — a Task built through *its* prompt can never reach Pending Triage either, despite canon's own `InboxSelectors.swift` defining Pending Triage as "every unscheduled non-event endeavor, regardless of age." I did not file this upstream (KroApple isn't mine to file against from here), but I recorded it plainly in `docs/Features/Inbox.md`'s Web notes as a deliberate, reasoned addition rather than a straight port — the fix extends canon's own time-chip Clear idiom to the date chip, since that's the closest real precedent in the same file.

## Scope decision: Reminder, not just Task

KC-IS-#75's title and regression criterion name a Task specifically, but the underlying mechanism (`hasDate` on the shared `CaptureDraft`, the Clear button on the shared date chip) is kind-agnostic by construction — Task and Reminder go through the identical draft, the identical `captureBlocker`, and the identical `endeavorFromCaptureResult` path. Canon's own Pending Triage definition includes Reminder too ("every unscheduled non-event endeavor"). Special-casing the Clear button to Task-only would have meant an inconsistent UI (visible for Task, permanently absent for Reminder) implementing an artificially incomplete fix, so I extended it to both. Event stays excluded at both the Shifter level (`withDateCleared` no-ops on an Event kind) and the UI level (the Clear button is never rendered for one) — `Endeavor.event(...)` has no way to represent a missing start.

## Feature flag (UZF-22)

None needed. This is a bug fix restoring behavior canon's own Inbox spec already promises ("every unscheduled non-event endeavor"); it introduces no new user-visible surface beyond a Clear button that mirrors an existing one, so it doesn't meet UZF-22's "new user-visible behavior" bar for a flag.

## An unrelated defect I found while shooting screenshots — filed separately, not fixed here

While driving the real app to capture evidence, I found that on the **mobile-width** `EndeavorRow` preset (`comfortable`, used by the Inbox), a captured endeavor's **title text renders at 0 width and is invisible** — confirmed via `getBoundingClientRect()`, confirmed in both headless and headed Chromium, confirmed stable across a 5-second wait (not a font/animation race), and **reproduces with a completely vanilla, unmodified capture** — nothing to do with this PR's change. Desktop width does not reproduce it. Filed as [KC-IS-#81](https://github.com/zheref/kro-pwa/issues/81) with full repro steps and the flex-layout diagnosis; **not fixed in this PR** (wrong file lane — it's `packages/app/src/design/endeavor/`, not `capture/`). It's why the mobile Pending-Triage screenshots below show the row's chrome (icon, reward badge, Triage/Add-for-Today buttons) but not its title text; the desktop screenshots of the same state are unaffected and show the title clearly.

## How to verify

### Scenario 1 — a titled Task with its date cleared can be submitted (KC-IS-#75's regression)
**Setup:** `make build`, then `apps/web && pnpm exec next start -p 3114` (or `make dev`).
**Steps:**
1. Go to `/tasks`, tap the quick-add FAB (bottom-right disc).
2. Leave **Task** selected. Type a title, e.g. "Sort the garage."
3. Tap the date chip's **Clear** button (the small × next to it).
4. Confirm the chip now reads "No date," Add stays enabled (not greyed out).
5. Tap **Add**.
**Expected:** the capture succeeds (the Inbox sheet opens with the row in Just Created); no error toast.

### Scenario 2 — the dateless Task reaches Pending Triage
**Setup:** continuing from Scenario 1.
**Steps:**
1. Close the Inbox sheet (Escape, or the Done button).
2. Reopen it (mobile: the Inbox icon in the top-right toolbar; desktop: the "Jot Down" row in the sidebar).
**Expected:** the row that was in "Just Created" now sits under **Pending Triage** — the "come back later and triage it" flow the issue names is now reachable.

### Scenario 3 — an Event's date can never be cleared
**Steps:** open the capture prompt, switch to **Event**.
**Expected:** the date chip's Clear button never appears next to it (only "Clear end time" does, and only once an end time is set) — consistent with canon, which requires an event to always carry a start.

### Scenario 4 — regression proxy (automated)
`pnpm --filter @kro/app vitest run src/features/capture` — 535 tests, all green, including:
- `CaptureRules.test.ts` → *"the KC-IS-#75 regression, end to end: capture a dateless Task → it appears in Pending Triage"*
- `CaptureFeature.test.ts` → *"the KC-IS-#75 regression, through the real thunk: a dateless Task submits with no due date"*
- `CapturePromptPage.test.tsx` → *"the KC-IS-#75 regression, through the mounted Page: clearing the date captures a dateless Task"*
- `CaptureSelectors.test.ts` → *"surfaces a captured dateless Task ... end to end through this selector"*

## Screenshots

Real renders, captured against the production build (`next start`) with Playwright driving the actual capture flow — never staged. Mock/local data only (no real user data). One table per screen, changed states as columns, per `UZF-26`'s presentation contract.

### Capture Prompt — the KC-IS-#75 affordance

| Light · Mobile (390×844) | Dark · Mobile (390×844) | Light · Desktop (1440×900) | Dark · Desktop (1440×900) |
|---|---|---|---|
| ![prompt mobile light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/75-dateless-capture/prompt-dateless-mobile-light.png) | ![prompt mobile dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/75-dateless-capture/prompt-dateless-mobile-dark.png) | ![prompt desktop light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/75-dateless-capture/prompt-dateless-desktop-light.png) | ![prompt desktop dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/75-dateless-capture/prompt-dateless-desktop-dark.png) |

### Inbox — Pending Triage, holding the dateless Task

| Light · Mobile (390×844)¹ | Dark · Mobile (390×844)¹ | Light · Desktop (1440×900) | Dark · Desktop (1440×900) |
|---|---|---|---|
| ![inbox mobile light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/75-dateless-capture/inbox-pending-triage-mobile-light.png) | ![inbox mobile dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/75-dateless-capture/inbox-pending-triage-mobile-dark.png) | ![inbox desktop light](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/75-dateless-capture/inbox-pending-triage-desktop-light.png) | ![inbox desktop dark](https://raw.githubusercontent.com/zheref/kro-assets/main/kro-pwa/75-dateless-capture/inbox-pending-triage-desktop-dark.png) |

¹ The mobile pair shows the row's chrome (icon, `10` reward badge, Triage / Add for Today) but not its title text — that's [KC-IS-#81](https://github.com/zheref/kro-pwa/issues/81), the unrelated pre-existing defect above, not a fresh regression from this change. The desktop pair (same underlying state, unaffected preset) shows "Sort the garage" under Pending Triage clearly.

**Publishing note (Ichigo local session):** I don't push to `kro-assets` myself — these are the future SHA-pinned URLs the mirror step will resolve once published. PNGs are parked at `/private/tmp/claude-501/-Users-zheref-Code-WebStorm-kro-pwa/7ac2edf1-9c3d-4eec-b3be-1b5082c06836/scratchpad/kc75-shots/` (8 files, matching the names above) for the orchestrator to mirror.

## Definition of Done

- [x] `make lint && make typecheck && make test && make build` green locally.
- [x] Per-artifact minimums: ≥3 scenario tests on every touched reducer arm (`userDidClearDate`, `withKindSelected`'s new branch), Shifter (`withDateCleared`, updated `withDatePicked`), Selector coverage (`selectPendingTriageEndeavors` end-to-end), Producer (`submitCaptureThunk` regression test); stories mirror the new render-test states (`SheetTaskDateCleared` added alongside the "No date"/Clear-button render tests).
- [x] ≥80% line coverage on every touched file (`CaptureFeature.ts` 90.31%, `CaptureRules.ts` 93.21%, `CaptureShifters.ts` 98.47%, `CaptureProducer.ts` 94.3%, `CapturePromptFragment.tsx` 96.55%, `CapturePromptPage.tsx` 94.36% — all measured, none estimated).
- [x] Tests use `captureDraftFixtures`/`captureStateMocks`/`stubbedThunkExtra` throughout — no live network, no inline `State`.
- [x] No new `any`, no `@ts-ignore`/`@ts-expect-error`.
- [x] Conventional Commit; `Closes #75`.
- [x] `docs/Features/Inbox.md` created (this repo had none yet for the Capture/Inbox behavior this issue touches) — canon port plus Web notes documenting the divergence.
- [x] `## How to verify` above, four scenarios.

Closes #75

Bankai-Agent: ichigo
<!-- bankai agent=ichigo session=f8ddef42 handbook=v0.11.2 trigger=local -->
